### PR TITLE
Reshape to square

### DIFF
--- a/bergson/build.py
+++ b/bergson/build.py
@@ -130,6 +130,7 @@ def worker(rank: int, world_size: int, cfg: IndexConfig, ds: Dataset):
             normalizers,
             fisher_fourth_root=cfg.fisher_fourth_root,
             projection_dim=cfg.projection_dim or None,
+            reshape_to_square=cfg.reshape_to_square,
         )
         if rank == 0:
             processor.save(cfg.run_path)

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -82,7 +82,9 @@ def worker(rank: int, world_size: int, cfg: IndexConfig, ds: Dataset):
         target_modules = None
     else:
         if rank == 0:
-            print("PEFT model detected.")
+            print("PEFT model detected. Using Adam and reshape_to_square = True")
+            cfg.normalizer = "adam"
+            cfg.reshape_to_square = True
 
         target_modules = set()
 

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -52,6 +52,9 @@ class IndexConfig:
     projection_dim: int = 16
     """Dimension of the random projection for the index, or 0 to disable it."""
 
+    reshape_to_square: bool = False
+    """Whether to reshape the gradients to a square matrix."""
+
     token_batch_size: int = 8192
     """Batch size in tokens for building the index."""
 

--- a/bergson/math.py
+++ b/bergson/math.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 from torch import Tensor
 
@@ -69,3 +71,32 @@ def trace(matrices: Tensor) -> Tensor:
     """Version of `torch.trace` that works for batches of matrices."""
     diag = torch.linalg.diagonal(matrices)
     return diag.sum(dim=-1, keepdim=True).unsqueeze(-1)
+
+
+def reshape_to_nearest_square(a: torch.Tensor) -> torch.Tensor:
+    """
+    Reshape a 2-D (or any-D) tensor into the *most square* 2-D shape
+    that preserves the total number of elements.
+
+    Returns
+    -------
+    out   : reshaped tensor (view when possible)
+    shape : tuple (rows, cols) that was chosen
+    """
+    n = math.prod(a.shape[-2:])
+    if n == 0:
+        raise ValueError("empty tensor")
+
+    # search divisors closest to sqrt(n)
+    root = math.isqrt(n)
+    cols, rows = None, None
+    for d in range(root, 0, -1):
+        if n % d == 0:
+            rows = d
+            cols = n // d
+            break
+
+    if rows is None or cols is None:
+        raise ValueError("could not find a valid shape for the tensor")
+
+    return a.reshape(*a.shape[:-2], rows, cols)


### PR DESCRIPTION
Allows for reshaping gradients to an approximately square matrix to make our random projection scheme more effective. This is important for PEFT in particular, where naively projecting on the left and right will lead to rank deficiency.

Importantly, `reshape_to_square` only works with the Adam normalizer in this PR, since it makes the Adafactor trick in `GradientCollector` impossible.