### PR TITLE
Add FAISS

### DIFF
--- a/bergson/__init__.py
+++ b/bergson/__init__.py
@@ -1,4 +1,4 @@
-from .attributor import Attributor
+from .attributor import Attributor, FaissConfig
 from .data import IndexConfig, load_gradients
 from .gradients import (
     GradientCollector,
@@ -11,6 +11,7 @@ __all__ = [
     "fit_normalizers",
     "load_gradients",
     "Attributor",
+    "FaissConfig",
     "GradientCollector",
     "GradientProcessor",
     "IndexConfig",

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -279,7 +279,6 @@ def load_gradients(root_dir: str) -> Union[np.memmap, NDArray]:
     """Map the structured gradients stored in `root_dir` into memory."""
 
     def load_shard(shard_dir: str) -> np.memmap:
-        print("shard dir", shard_dir)
         with open(os.path.join(shard_dir, "info.json")) as f:
             info = json.load(f)
 

--- a/examples/query_index.py
+++ b/examples/query_index.py
@@ -16,7 +16,7 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model, device_map={"": "cuda:0"})
 
-    attr = Attributor(args.index, device="cuda:0")
+    attr = Attributor(args.index, device="cuda")  # device="cuda:0"
 
     # Query loop
     while True:

--- a/examples/query_index.py
+++ b/examples/query_index.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 
+from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from bergson import Attributor
@@ -9,15 +10,15 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("index", type=str)
     parser.add_argument("--model", type=str, default="HuggingFaceTB/SmolLM2-135M")
-    # parser.add_argument("--dataset", type=str, default="EleutherAI/SmolLM2-135M-10B")
-    # parser.add_argument("--text_field", type=str, default="text")
+    parser.add_argument("--dataset", type=str, default="EleutherAI/SmolLM2-135M-10B")
+    parser.add_argument("--text_field", type=str, default="text")
     args = parser.parse_args()
 
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model, device_map={"": "cuda:0"})
-    # dataset = load_dataset(args.dataset, split="train")
+    dataset = load_dataset(args.dataset, split="train")
 
-    attr = Attributor(args.index, device="cuda")
+    attr = Attributor(args.index, device="cuda:0")
 
     # Query loop
     while True:
@@ -42,8 +43,8 @@ def main():
                 print("Found invalid result, skipping")
                 continue
 
-            # text = dataset[idx.item()][args.text_field]
-            # print(text[:5000])
+            text = dataset[idx.item()][args.text_field]
+            print(text[:5000])
 
             print(f"{i + 1}: (distance: {d.item():.4f})")
 

--- a/examples/query_index.py
+++ b/examples/query_index.py
@@ -8,13 +8,14 @@ from bergson import Attributor
 def main():
     parser = ArgumentParser()
     parser.add_argument("index", type=str)
-    parser.add_argument(
-        "--model", type=str, default="HuggingFaceTB/SmolLM2-1.7B-Instruct"
-    )
+    parser.add_argument("--model", type=str, default="HuggingFaceTB/SmolLM2-135M")
+    # parser.add_argument("--dataset", type=str, default="EleutherAI/SmolLM2-135M-10B")
+    # parser.add_argument("--text_field", type=str, default="text")
     args = parser.parse_args()
 
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model, device_map={"": "cuda:0"})
+    # dataset = load_dataset(args.dataset, split="train")
 
     attr = Attributor(args.index, device="cuda")
 
@@ -37,12 +38,13 @@ def main():
         for i, (d, idx) in enumerate(
             zip(result.scores.squeeze(), result.indices.squeeze())
         ):
-            if idx == -1:
+            if idx.item() == -1:
                 print("Found invalid result, skipping")
                 continue
 
-            # tokens = dataset[idx.item()]["input_ids"]
-            # string = tokenizer.decode(tokens, skip_special_tokens=True)
+            # text = dataset[idx.item()][args.text_field]
+            # print(text[:5000])
+
             print(f"{i + 1}: (distance: {d.item():.4f})")
 
 

--- a/examples/query_index.py
+++ b/examples/query_index.py
@@ -16,7 +16,7 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model, device_map={"": "cuda:0"})
 
-    attr = Attributor(args.index, device="cuda")  # device="cuda:0"
+    attr = Attributor(args.index, device="cuda")
 
     # Query loop
     while True:

--- a/examples/query_index.py
+++ b/examples/query_index.py
@@ -8,7 +8,9 @@ from bergson import Attributor
 def main():
     parser = ArgumentParser()
     parser.add_argument("index", type=str)
-    parser.add_argument("--model", type=str, default="HuggingFaceTB/SmolLM2-1.7B-Instruct")
+    parser.add_argument(
+        "--model", type=str, default="HuggingFaceTB/SmolLM2-1.7B-Instruct"
+    )
     args = parser.parse_args()
 
     tokenizer = AutoTokenizer.from_pretrained(args.model)
@@ -32,7 +34,13 @@ def main():
 
         # Print the results
         print(f"Top 5 results for '{query}':")
-        for i, (d, idx) in enumerate(zip(result.scores.squeeze(), result.indices.squeeze())):
+        for i, (d, idx) in enumerate(
+            zip(result.scores.squeeze(), result.indices.squeeze())
+        ):
+            if idx == -1:
+                print("Found invalid result, skipping")
+                continue
+
             # tokens = dataset[idx.item()]["input_ids"]
             # string = tokenizer.decode(tokens, skip_special_tokens=True)
             print(f"{i + 1}: (distance: {d.item():.4f})")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
 example = [
     "trl",
 ]
+faiss = [
+    "faiss-gpu-cu12",
+]
 
 [project.scripts]
 bergson = "bergson.__main__:main"


### PR DESCRIPTION
We can't write to a memmap larger than the CommitLimit on CoreWeave nodes (without adding swap), but once an equivalent number of rows have been written to across multiple memmaps we can load and concatenate them up to the RAM limit. 

Therefore at least initially we will support loading indices from multiple memmaps and then concatenating them in memory (works for ~1M rows). The larger indices (10M rows+) can be loaded from disk into a compressed-format GPU FAISS index in batches using the gradients_loader.

```
❯ grep ^Commit /proc/meminfo
CommitLimit:    395.637292 GB
Committed_AS:   26.360692 GB

❯ free -h
               total        used        free      shared  buff/cache   available
Mem:           754Gi       103Gi       406Gi       9.5Gi       243Gi       6
```