### PR TITLE
clear hook lists so that they don't grow after each step

### DIFF
--- a/bergson/gradients.py
+++ b/bergson/gradients.py
@@ -155,9 +155,9 @@ class AdamNormalizer(Normalizer):
         and the factored second moments.
         """
         # We assume avg_sq is a square matrix of shape [O, I]
-        assert (
-            self.avg_sq.ndim == 2
-        ), f"Expected 2D tensor for avg_sq, got {self.avg_sq.ndim}D"
+        assert self.avg_sq.ndim == 2, (
+            f"Expected 2D tensor for avg_sq, got {self.avg_sq.ndim}D"
+        )
 
         # Compute row and column means
         return AdafactorNormalizer(
@@ -573,5 +573,7 @@ class GradientCollector(ContextDecorator):
             h.remove()
         for h in self._bwd_hooks:
             h.remove()
+        self._fwd_hooks.clear()
+        self._bwd_hooks.clear()
 
         return False


### PR DESCRIPTION
This PR fixes #42 
Specifically the isue was that GradientCollector was accumulating the hooks in its self._fwd_hooks and self._bwd_hooks and it took increasingly longer as we were calling .remove() on more and more entries (apparently .remove() is torch internal functionality of torch.utils.RemovableHandle and does not do affect the list itself).

TODO:
I get different results when running with and without the modification, but seems like a floating point error issue