### PR TITLE
Remove columns only after advantage calculation

### DIFF
--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -192,7 +192,7 @@ def setup_data_pipeline(cfg: IndexConfig) -> Dataset | IterableDataset:
     ds = ds.map(
         tokenize,
         batched=True,
-        fn_kwargs=dict(args=cfg.data, tokenizer=tokenizer),     
+        fn_kwargs=dict(args=cfg.data, tokenizer=tokenizer),
     )
     if cfg.data.reward_column:
         assert isinstance(ds, Dataset), "Dataset required for advantage estimation"


### PR DESCRIPTION
This fixes the fact that the columns are droped before advantage is computed