### PR TITLE
Reduce default token batch size

### DIFF
--- a/bergson/config.py
+++ b/bergson/config.py
@@ -89,7 +89,7 @@ class IndexConfig:
     projection_type: Literal["normal", "rademacher"] = "rademacher"
     """Type of random projections to use for the gradients."""
 
-    token_batch_size: int = 8192
+    token_batch_size: int = 2048
     """Batch size in tokens for building the index."""
 
     processor_path: str = ""


### PR DESCRIPTION
I'd like to reduce this because it's higher than the seq len of the pythia models that I often use for testing and with validate_batch_size now checking whether this length is exceeded, the runs throw without token_batch_size being defined. We could also remove model the max seq len based validation? Interested in any thoughts