### PR TITLE
Fix maximum value check for token_batch_size to allow larger values

### DIFF
--- a/bergson/collection.py
+++ b/bergson/collection.py
@@ -6,7 +6,6 @@ from bergson.collector.gradient_collectors import GradientCollector
 from bergson.config import AttentionConfig, IndexConfig, ReduceConfig
 from bergson.gradients import GradientProcessor
 from bergson.score.scorer import Scorer
-from bergson.utils.utils import validate_batch_size
 
 
 def collect_gradients(
@@ -34,8 +33,6 @@ def collect_gradients(
         reduce_cfg=reduce_cfg,
         attention_cfgs=attention_cfgs or {},
     )
-
-    validate_batch_size(model, cfg.token_batch_size, collector)
 
     computer = CollectorComputer(
         model=model,  # type: ignore

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -511,13 +511,21 @@ def pad_and_tensor(
     return padded_tokens, padded_labels, valid_masks
 
 
-def tokenize(batch: dict, *, args: DataConfig, tokenizer):
+def tokenize(
+    batch: dict,
+    *,
+    args: DataConfig,
+    tokenizer,
+    max_length: int | None = None,
+):
     """Tokenize a batch of data with `tokenizer` according to `args`."""
-    kwargs = dict(
+    kwargs: dict[str, Any] = dict(
         return_attention_mask=False,
         return_length=True,
         truncation=args.truncation,
     )
+    if args.truncation and max_length is not None:
+        kwargs["max_length"] = max_length
     if args.completion_column:
         # We're dealing with a prompt-completion dataset
         convos = [

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -23,7 +23,6 @@ from bergson.hessians.tkfac import TraceCovarianceCollector
 from bergson.utils.utils import (
     convert_precision_to_torch,
     setup_reproducibility,
-    validate_batch_size,
 )
 from bergson.utils.worker_utils import (
     setup_data_pipeline,
@@ -223,8 +222,6 @@ def collect_hessians(
     else:
         collector_args["dtype"] = hessian_dtype
         collector = HESSIAN_APPROXIMATIONS[hessian_cfg.method](**collector_args)
-
-    validate_batch_size(model, index_cfg.token_batch_size, collector)
 
     computer = CollectorComputer(
         model=model,  # type: ignore

--- a/bergson/utils/utils.py
+++ b/bergson/utils/utils.py
@@ -1,16 +1,12 @@
 import os
 import random
-from typing import TYPE_CHECKING, Any, Literal, Type, TypeVar, cast
+from typing import Any, Literal, Type, TypeVar, cast
 
 import numpy as np
 import torch
 from ml_dtypes import bfloat16
 from torch import Tensor, nn
 from transformers import PreTrainedModel
-
-if TYPE_CHECKING:
-    from bergson.collector.collector import HookCollectorBase
-
 
 T = TypeVar("T")
 
@@ -86,39 +82,6 @@ def simple_parse_args_string(args_string: str) -> dict[str, Any]:
         for kv in [arg.split("=") for arg in arg_list]
     }
     return args_dict
-
-
-def validate_batch_size(
-    model: PreTrainedModel,
-    token_batch_size: int | None,
-    collector: "HookCollectorBase",
-):
-    """Validate that the specified token batch size fits on device."""
-    if token_batch_size is None:
-        return
-
-    # Check that token_batch_size doesn't exceed model's max sequence length
-    max_seq_len = getattr(model.config, "max_position_embeddings", None)
-    if max_seq_len is not None and token_batch_size > max_seq_len:
-        raise ValueError(
-            f"Token batch size {token_batch_size} exceeds model's max sequence length "
-            f"({max_seq_len}). Use --token_batch_size {max_seq_len} or smaller."
-        )
-
-    random_tokens = torch.randint(
-        0, 10, (1, token_batch_size), device=model.device, dtype=torch.long
-    )
-    try:
-        with collector:
-            loss = model(random_tokens).logits[0, 0, 0].float()
-            loss.backward()
-            model.zero_grad()
-    except Exception as e:
-        if "CUDA out of memory" in str(e):
-            raise ValueError(
-                f"Token batch size {token_batch_size} is too large for the device. "
-                f"Try reducing the batch size or use --fsdp to shard the model."
-            ) from e
 
 
 DTYPE_BY_PRIORITY = {

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import cast
 
@@ -11,6 +12,7 @@ from datasets import (
 from peft import PeftConfig, PeftModel, get_peft_model_state_dict
 from torch.distributed.fsdp import fully_shard
 from transformers import (
+    AutoConfig,
     AutoModelForCausalLM,
     AutoTokenizer,
     BitsAndBytesConfig,
@@ -248,10 +250,28 @@ def setup_data_pipeline(cfg: IndexConfig) -> Dataset | IterableDataset:
         cfg.data.dataset, cfg.data.split, cfg.data.subset, cfg.data.data_args
     )
 
-    # In many cases the token_batch_size may be smaller than the max length allowed by
-    # the model. If cfg.data.truncation is True, we use the tokenizer to truncate
     tokenizer = AutoTokenizer.from_pretrained(cfg.tokenizer or cfg.model)
-    tokenizer.model_max_length = min(tokenizer.model_max_length, cfg.token_batch_size)
+
+    default_model_max_len = getattr(tokenizer, "model_max_length", None)
+    if (
+        default_model_max_len is not None
+        and cfg.token_batch_size > default_model_max_len
+    ):
+        raise ValueError(
+            f"Token batch size {cfg.token_batch_size} exceeds model_max_length "
+            f"({default_model_max_len}). "
+            f"Use --token_batch_size {default_model_max_len} or smaller."
+        )
+
+    max_pos_emb = getattr(
+        AutoConfig.from_pretrained(cfg.model, revision=cfg.revision),
+        "max_position_embeddings",
+        None,
+    )
+    if max_pos_emb is not None:
+        max_length = min(max_pos_emb, cfg.token_batch_size)
+    else:
+        max_length = cfg.token_batch_size
 
     remove_columns = ds.column_names if cfg.drop_columns else None
 
@@ -259,8 +279,23 @@ def setup_data_pipeline(cfg: IndexConfig) -> Dataset | IterableDataset:
         ds = ds.map(
             tokenize,
             batched=True,
-            fn_kwargs=dict(args=cfg.data, tokenizer=tokenizer),
+            fn_kwargs=dict(args=cfg.data, tokenizer=tokenizer, max_length=max_length),
         )
+
+    if not cfg.data.truncation and isinstance(ds, Dataset):
+        max_doc_len = max(ds["length"])
+        if max_pos_emb is not None and max_doc_len > max_pos_emb:
+            warnings.warn(
+                f"Dataset contains a document longer than max_position_embeddings "
+                f"({max_doc_len} > {max_pos_emb}). "
+                f"Consider using --truncation."
+            )
+        elif max_doc_len > cfg.token_batch_size:
+            warnings.warn(
+                f"Dataset contains a document longer than token_batch_size "
+                f"({max_doc_len} > {cfg.token_batch_size}). "
+                f"Consider increasing --token_batch_size or using --truncation."
+            )
 
     if cfg.data.reward_column:
         assert isinstance(ds, Dataset), "Dataset required for advantage estimation"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -115,7 +115,7 @@ def test_conv1d_build(tmp_path: Path, dataset):
         # This build hangs in pytest with preconditioners enabled.
         # It works when run directly so it may be a pytest issue.
         skip_preconditioners=True,
-        # GPT-2 max_position_embeddings is 1024
+        # GPT-2 model_max_length is 1024
         token_batch_size=1024,
     )
 

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,0 +1,165 @@
+"""Tests for truncation and max_length handling."""
+
+import json
+
+import pytest
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+from bergson import GradientProcessor, collect_gradients
+from bergson.config import DataConfig, IndexConfig
+from bergson.data import allocate_batches
+from bergson.utils.worker_utils import setup_data_pipeline
+
+# GPT-2: model_max_length=max_position_embeddings
+# Pythia-14m: model_max_length=very large
+GPT2 = "openai-community/gpt2"
+PYTHIA = "EleutherAI/pythia-14m"
+
+
+def get_max_position_embeddings(model_name):
+    """The maximum supported context length."""
+    return AutoConfig.from_pretrained(model_name).max_position_embeddings
+
+
+GPT2_MAX_POS_EMB = get_max_position_embeddings(GPT2)
+PYTHIA_MAX_POS_EMB = get_max_position_embeddings(PYTHIA)
+
+
+def create_documents_file(tmp_path, model, doc_tokens):
+    """Create a JSON file with documents of exactly `doc_tokens` tokens."""
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    # Generate exact token count by decoding repeated token IDs
+    token_id = tokenizer.encode("hello")[0]
+    tokens = [token_id] * doc_tokens
+    text = tokenizer.decode(tokens)
+    assert len(tokenizer.encode(text)) == doc_tokens
+    data = [{"text": text}]
+    path = tmp_path / "docs.json"
+    path.write_text("\n".join(json.dumps(d) for d in data))
+    return str(path)
+
+
+def run_pipeline(tmp_path, model_name, token_batch_size, doc_tokens, truncation):
+    documents_file = create_documents_file(tmp_path, model_name, doc_tokens)
+    cfg = IndexConfig(
+        run_path=str(tmp_path / "run"),
+        model=model_name,
+        token_batch_size=token_batch_size,
+        skip_preconditioners=True,
+        data=DataConfig(dataset=documents_file, truncation=truncation),
+    )
+    ds = setup_data_pipeline(cfg)
+    batches = allocate_batches(ds["length"], token_batch_size)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    collect_gradients(
+        model=model,
+        data=ds,
+        processor=GradientProcessor(projection_dim=16),
+        cfg=cfg,
+        batches=batches,
+    )
+    return ds
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("truncation", [True, False])
+@pytest.mark.parametrize(
+    "model,token_batch_size",
+    [
+        # token_batch_size < max_position_embeddings
+        (GPT2, GPT2_MAX_POS_EMB // 2),
+        (PYTHIA, PYTHIA_MAX_POS_EMB // 2),
+        # token_batch_size = max_position_embeddings
+        (GPT2, GPT2_MAX_POS_EMB),
+        (PYTHIA, PYTHIA_MAX_POS_EMB),
+        # token_batch_size > max_position_embeddings
+        (PYTHIA, PYTHIA_MAX_POS_EMB * 2),
+    ],
+)
+def test_short_documents(tmp_path, model, token_batch_size, truncation):
+    """Short documents (fit within token_batch_size and max_position_embeddings)
+    work regardless of truncation setting.
+    """
+    max_position_embeddings = get_max_position_embeddings(model)
+    doc_tokens = min(token_batch_size, max_position_embeddings) // 2
+    ds = run_pipeline(tmp_path, model, token_batch_size, doc_tokens, truncation)
+    assert max(ds["length"]) == doc_tokens
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize(
+    "model,token_batch_size",
+    [
+        # token_batch_size < max_position_embeddings: truncates to token_batch_size
+        (GPT2, GPT2_MAX_POS_EMB // 2),
+        (PYTHIA, PYTHIA_MAX_POS_EMB // 2),
+        # token_batch_size = max_position_embeddings: truncates to both
+        (GPT2, GPT2_MAX_POS_EMB),
+        (PYTHIA, PYTHIA_MAX_POS_EMB),
+        # token_batch_size > max_position_embeddings:
+        # truncates to max_position_embeddings
+        # (for GPT2, see `test_token_batch_size_exceeds_model_max_length`)
+        (PYTHIA, PYTHIA_MAX_POS_EMB * 2),
+    ],
+)
+def test_long_documents_truncated(tmp_path, model, token_batch_size):
+    """Long documents get truncated to
+    min(token_batch_size, max_position_embeddings).
+    """
+    doc_tokens = token_batch_size * 2
+    max_position_embeddings = get_max_position_embeddings(model)
+    expected_length = min(token_batch_size, max_position_embeddings)
+    assert doc_tokens > expected_length
+    ds = run_pipeline(tmp_path, model, token_batch_size, doc_tokens, truncation=True)
+    assert max(ds["length"]) == expected_length
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize(
+    "model,token_batch_size",
+    [
+        # token_batch_size < max_position_embeddings
+        (GPT2, GPT2_MAX_POS_EMB // 2),
+        (PYTHIA, PYTHIA_MAX_POS_EMB // 2),
+        # token_batch_size = max_position_embeddings
+        (GPT2, GPT2_MAX_POS_EMB),
+        (PYTHIA, PYTHIA_MAX_POS_EMB),
+        # token_batch_size > max_position_embeddings
+        # (for GPT2, see `test_token_batch_size_exceeds_model_max_length`)
+        (PYTHIA, PYTHIA_MAX_POS_EMB * 2),
+    ],
+)
+def test_long_documents_fail_without_truncation(tmp_path, model, token_batch_size):
+    """Without truncation, we fail when a document exceeds token_batch_size."""
+    doc_tokens = token_batch_size + 1
+    with pytest.warns(UserWarning, match="max_position_embeddings|token_batch_size"):
+        with pytest.raises(RuntimeError, match="too long"):
+            run_pipeline(
+                tmp_path, model, token_batch_size, doc_tokens, truncation=False
+            )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_long_documents_warn_without_truncation(tmp_path):
+    """Without truncation, we warn when a document exceeds max_position_embeddings
+    but not token_batch_size.
+    """
+    # Only possible when token_batch_size > max_position_embeddings (requires PYTHIA)
+    token_batch_size = PYTHIA_MAX_POS_EMB * 3
+    doc_tokens = (
+        PYTHIA_MAX_POS_EMB * 2
+    )  # max_position_embeddings < doc_tokens < token_batch_size
+    with pytest.warns(UserWarning, match="max_position_embeddings"):
+        run_pipeline(tmp_path, PYTHIA, token_batch_size, doc_tokens, truncation=False)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_token_batch_size_exceeds_model_max_length(tmp_path):
+    """token_batch_size > model_max_length raises an error
+    (GPT2 has model_max_length=max_position_embeddings).
+    """
+    token_batch_size = GPT2_MAX_POS_EMB * 2
+    doc_tokens = GPT2_MAX_POS_EMB // 2
+    with pytest.raises(ValueError, match="model_max_length"):
+        run_pipeline(tmp_path, GPT2, token_batch_size, doc_tokens, truncation=True)


### PR DESCRIPTION
Previously, token_batch_size was limited by max_position_embeddings, but this is the maximum length of one sequence, and a batch can contain multiple sequences. As far as I can tell, the real limit is the default value of model_max_length in the tokenizer (some models have model_max_length == max_position_embeddings which causes this confusion).

We also make the truncation logic more explicit by passing a max_length parameter instead of mutating model_max_len.