### PR TITLE
hessians: fix support for --filter_modules

### DIFF
--- a/bergson/collection.py
+++ b/bergson/collection.py
@@ -33,6 +33,7 @@ def collect_gradients(
         scorer=scorer,
         reduce_cfg=reduce_cfg,
         attention_cfgs=attention_cfgs or {},
+        filter_modules=cfg.filter_modules,
     )
 
     validate_batch_size(model, cfg.token_batch_size, collector)

--- a/bergson/collector/dist_preconditioners_gradient_collector.py
+++ b/bergson/collector/dist_preconditioners_gradient_collector.py
@@ -54,32 +54,6 @@ class GradientCollectorWithDistributedPreconditioners(HookCollectorBase):
     scorer: Scorer | None = None
     """Optional scorer for computing scores instead of building an index."""
 
-    def __init__(self, *args, **kwargs):
-        self.data = assert_type(Dataset, kwargs["data"])
-        self.cfg = assert_type(IndexConfig, kwargs["cfg"])
-
-        self.reduce_cfg = kwargs.get("reduce_cfg", None)
-        self.builder = kwargs.get("builder", None)
-        self.scorer = kwargs.get("scorer", None)
-        self.mod_grads = {}
-
-        # Extract parent class arguments
-        parent_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if k
-            in {
-                "model",
-                "filter_modules",
-                "target_modules",
-                "processor",
-                "attention_cfgs",
-            }
-        }
-        parent_kwargs["filter_modules"] = self.cfg.filter_modules
-
-        super().__init__(*args, **parent_kwargs)
-
     def setup(self) -> None:
         """
         Initialize collector state.

--- a/bergson/collector/gradient_collectors.py
+++ b/bergson/collector/gradient_collectors.py
@@ -52,32 +52,6 @@ class GradientCollector(HookCollectorBase):
     scorer: Scorer | None = None
     """Optional scorer for computing scores instead of building an index."""
 
-    def __init__(self, *args, **kwargs):
-        self.data = assert_type(Dataset, kwargs["data"])
-        self.cfg = assert_type(IndexConfig, kwargs["cfg"])
-
-        self.reduce_cfg = kwargs.get("reduce_cfg", None)
-        self.builder = kwargs.get("builder", None)
-        self.scorer = kwargs.get("scorer", None)
-        self.mod_grads = {}
-
-        # Extract parent class arguments
-        parent_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if k
-            in {
-                "model",
-                "filter_modules",
-                "target_modules",
-                "processor",
-                "attention_cfgs",
-            }
-        }
-        parent_kwargs["filter_modules"] = self.cfg.filter_modules
-
-        super().__init__(*args, **parent_kwargs)
-
     def setup(self) -> None:
         """
         Initialize collector state.

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -215,6 +215,7 @@ def collect_hessians(
         "target_modules": target_modules,
         "attention_cfgs": attention_cfgs or {},
         "path": str(index_cfg.partial_run_path),
+        "filter_modules": index_cfg.filter_modules,
     }
     desc = f"Approximating Hessians with {hessian_cfg.method}"
     if ev_correction:

--- a/bergson/normalizer/fit_normalizers.py
+++ b/bergson/normalizer/fit_normalizers.py
@@ -45,35 +45,6 @@ class NormalizerCollector(HookCollectorBase):
     mod_grads: dict = field(default_factory=dict)
     """Temporary storage for gradients during a batch, keyed by module name."""
 
-    def __init__(self, *args, **kwargs):
-        self.data = assert_type(Dataset, kwargs["data"])
-        self.cfg = assert_type(IndexConfig, kwargs["cfg"])
-        self.normalizers = {}
-        self.mod_grads = {}
-
-        self.callback = (
-            self.adafactor_update
-            if self.cfg.normalizer == "adafactor"
-            else self.adam_update
-        )
-
-        # Extract parent class arguments
-        parent_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if k
-            in {
-                "model",
-                "filter_modules",
-                "target_modules",
-                "processor",
-                "attention_cfgs",
-            }
-        }
-        parent_kwargs["filter_modules"] = self.cfg.filter_modules
-
-        super().__init__(*args, **parent_kwargs)
-
     def adafactor_update(self, name: str, g: torch.Tensor):
         # We follow the tensor2tensor implementation of Adafactor, which
         # takes the mean rather than summing over the rows and columns.
@@ -114,6 +85,11 @@ class NormalizerCollector(HookCollectorBase):
 
         Sets up a Builder for gradient storage if not using a Scorer.
         """
+        self.callback = (
+            self.adafactor_update
+            if self.cfg.normalizer == "adafactor"
+            else self.adam_update
+        )
         assert isinstance(
             self.model.device, torch.device
         ), "Model device is not set correctly"
@@ -250,6 +226,7 @@ def fit_normalizers(
         data=data,
         cfg=cfg,
         target_modules=target_modules,
+        filter_modules=cfg.filter_modules,
     )
     computer = CollectorComputer(
         model=model,


### PR DESCRIPTION
Also clean up unnecessary init logic in the other collectors by passing filter_modules explicitly when calling the collector in bergson/collection.py