### PR TITLE
Allow pre-commit-ci bot in Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_bots: 'claude'
+          allowed_bots: 'claude,pre-commit-ci'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--max-turns 20'


### PR DESCRIPTION
## Summary
- Adds `pre-commit-ci` to the `allowed_bots` list in the Claude Code review workflow
- Fixes the workflow failing when pre-commit-ci[bot] pushes automated linting/formatting commits

## Test plan
- [ ] Verify the Claude Code review workflow no longer errors on pre-commit-ci pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)