### PR TITLE
fix: unpin transformers by explicitly setting float32 dtype in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pyarrow",
     "simple-parsing",
     "torch",
-    "transformers<4.56.0" # 4.56.0 increases fp error from operation order
+    "transformers"
 ]
 version = "0.6.0"
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def model():
     torch.cuda.manual_seed(42)
 
     config = AutoConfig.from_pretrained("trl-internal-testing/tiny-Phi3ForCausalLM")
-    return AutoModelForCausalLM.from_config(config)
+    return AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
 
 
 @pytest.fixture

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -17,7 +17,7 @@ def test_large_gradients_build(tmp_path: Path, dataset):
     config = AutoConfig.from_pretrained(
         "EleutherAI/pythia-1.4b", trust_remote_code=True
     )
-    model = AutoModelForCausalLM.from_config(config)
+    model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
     collector = GradientCollector(
         model=model.base_model, data=dataset, cfg=IndexConfig(run_path=str(tmp_path))
     )

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -20,7 +20,8 @@ def test_GPTNeoX():
     print(temp_dir)
 
     config = AutoConfig.from_pretrained("trl-internal-testing/tiny-GPTNeoXForCausalLM")
-    model = AutoModelForCausalLM.from_config(config)
+    # Explicitly use float32 so the test isn't sensitive to the config's torch_dtype
+    model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
 
     tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]], device=model.device)
     inputs = dict(

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -33,7 +33,7 @@ def test_large_gradients_query(tmp_path: Path, dataset):
     config = AutoConfig.from_pretrained(
         "EleutherAI/pythia-1.4b", trust_remote_code=True
     )
-    model = AutoModelForCausalLM.from_config(config)
+    model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
 
     collector = GradientCollector(
         model.base_model, data=dataset, cfg=IndexConfig(run_path=str(tmp_path))

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -23,7 +23,7 @@ class TestGradientCollectorCallback:
     def model(self):
         """Create a small test model."""
         config = AutoConfig.from_pretrained("trl-internal-testing/tiny-Phi3ForCausalLM")
-        return AutoModelForCausalLM.from_config(config)
+        return AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
 
     @pytest.fixture
     def dataset(self):


### PR DESCRIPTION
Transformers 4.56+ changed from_config() to honor the config's torch_dtype field, causing test models (tiny-GPTNeoX, tiny-Phi3) to be created in float16 instead of float32. This caused gradient comparison tests to fail from reduced precision, not from any actual change in gradient collection logic.