### PR TITLE
fix: convert PyArrow Column to list before allocate_batches everywhere

### DIFF
--- a/benchmarks/benchmark_bergson.py
+++ b/benchmarks/benchmark_bergson.py
@@ -275,7 +275,7 @@ class Run:
 
         ds = assert_type(Dataset, setup_data_pipeline(index_cfg))
         batches = allocate_batches(
-            ds["length"], optimal_token_batch_size  # type: ignore
+            ds["length"][:], optimal_token_batch_size  # type: ignore
         )
 
         # In-memory query + score phase
@@ -287,7 +287,7 @@ class Run:
                 cfg=index_cfg,
             )
             query_batches = allocate_batches(
-                eval_ds["length"], optimal_token_batch_size
+                eval_ds["length"][:], optimal_token_batch_size
             )
             query_computer = CollectorComputer(
                 model=model,

--- a/benchmarks/benchmark_factors.py
+++ b/benchmarks/benchmark_factors.py
@@ -177,7 +177,7 @@ def _run_bergson_normalizer(
     index_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
 
     model, _ = setup_model_and_peft(index_cfg, device_map_auto=True)
-    batches = allocate_batches(ds["length"], run_cfg.token_batch_size)
+    batches = allocate_batches(ds["length"][:], run_cfg.token_batch_size)
 
     collector = NormalizerCollector(
         model=model.base_model,  # type: ignore
@@ -243,7 +243,7 @@ def _run_bergson_preconditioner(
     index_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
 
     model, _ = setup_model_and_peft(index_cfg, device_map_auto=True)
-    batches = allocate_batches(ds["length"], run_cfg.token_batch_size)
+    batches = allocate_batches(ds["length"][:], run_cfg.token_batch_size)
 
     collector = GradientCollector(
         model=model.base_model,  # type: ignore
@@ -313,7 +313,7 @@ def _run_bergson_kfac(
 
     # ekfac requires single-device (matching hessian_worker pattern)
     model, target_modules = setup_model_and_peft(index_cfg, device_map_auto=False)
-    batches = allocate_batches(ds["length"], run_cfg.token_batch_size)
+    batches = allocate_batches(ds["length"][:], run_cfg.token_batch_size)
 
     collector = CovarianceCollector(
         model=model.base_model,  # type: ignore

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -78,7 +78,7 @@ def build_worker(
     }
 
     if isinstance(ds, Dataset):
-        batches = allocate_batches(ds["length"], cfg.token_batch_size)
+        batches = allocate_batches(ds["length"][:], cfg.token_batch_size)
         kwargs["batches"] = batches
         collect_gradients(**kwargs)
     else:

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -542,6 +542,8 @@ def _allocate_batches_world(
     """
     if ranks is None:
         ranks = list(range(world_size))
+    if not isinstance(doc_lengths, list):
+        doc_lengths = list(doc_lengths)
     if len(doc_lengths) < world_size:
         raise RuntimeError("Not enough documents to distribute across workers.")
 

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -542,8 +542,6 @@ def _allocate_batches_world(
     """
     if ranks is None:
         ranks = list(range(world_size))
-    if not isinstance(doc_lengths, list):
-        doc_lengths = list(doc_lengths)
     if len(doc_lengths) < world_size:
         raise RuntimeError("Not enough documents to distribute across workers.")
 

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -160,7 +160,7 @@ def hessian_worker(
         "attention_cfgs": attention_cfgs,
     }
 
-    batches = allocate_batches(ds["length"], index_cfg.token_batch_size)
+    batches = allocate_batches(ds["length"][:], index_cfg.token_batch_size)
     kwargs["batches"] = batches
     collect_hessians(**kwargs)
 

--- a/bergson/reduce.py
+++ b/bergson/reduce.py
@@ -81,7 +81,7 @@ def reduce_worker(
     }
 
     if isinstance(ds, Dataset):
-        batches = allocate_batches(ds["length"], index_cfg.token_batch_size)
+        batches = allocate_batches(ds["length"][:], index_cfg.token_batch_size)
         kwargs["batches"] = batches
         collect_gradients(**kwargs)
     else:

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -277,7 +277,9 @@ def score_worker(
     score_device = torch.device(f"cuda:{rank}")
 
     if isinstance(ds, Dataset):
-        kwargs["batches"] = allocate_batches(ds["length"], index_cfg.token_batch_size)
+        kwargs["batches"] = allocate_batches(
+            ds["length"][:], index_cfg.token_batch_size
+        )
         kwargs["scorer"] = create_scorer(
             index_cfg.partial_run_path,
             ds,

--- a/bergson/score/score_writer.py
+++ b/bergson/score/score_writer.py
@@ -254,17 +254,13 @@ class MemmapSequenceScoreWriter(ScoreWriter):
         if rank == 0 and not scores_file_path.exists():
             print(f"Creating new scores file: {scores_file_path}")
 
+            # w+ mode creates a zero-filled file; written flags are already False.
             self.scores = np.memmap(
                 str(scores_file_path),
                 dtype=np.dtype(struct_dtype),  # type: ignore
                 mode="w+",
                 shape=(num_items,),
             )
-
-            for name in names:
-                if "written" in name:
-                    self.scores[name][:] = False
-            self.flush()
 
             # Persist metadata for future runs
             with (path / "info.json").open("w") as f:

--- a/bergson/score/score_writer.py
+++ b/bergson/score/score_writer.py
@@ -254,7 +254,7 @@ class MemmapSequenceScoreWriter(ScoreWriter):
         if rank == 0 and not scores_file_path.exists():
             print(f"Creating new scores file: {scores_file_path}")
 
-            # w+ mode creates a zero-filled file; written flags are already False.
+            # w+ mode creates a zero-filled file.
             self.scores = np.memmap(
                 str(scores_file_path),
                 dtype=np.dtype(struct_dtype),  # type: ignore

--- a/examples/token_attribution.py
+++ b/examples/token_attribution.py
@@ -65,7 +65,7 @@ def main():
     train_ds = setup_data_pipeline(index_cfg)
     assert isinstance(train_ds, Dataset)
     train_batches = allocate_batches(
-        train_ds["length"],
+        train_ds["length"][:],
         index_cfg.token_batch_size,
     )
     print(
@@ -88,7 +88,7 @@ def main():
     query_ds = setup_data_pipeline(query_cfg)
     assert isinstance(query_ds, Dataset)
     query_batches = allocate_batches(
-        query_ds["length"],
+        query_ds["length"][:],
         query_cfg.token_batch_size,
     )
     print(f"Query set: {len(query_ds)} examples, " f"{sum(query_ds['length'])} tokens")

--- a/tests/ekfac_tests/compute_ekfac_ground_truth.py
+++ b/tests/ekfac_tests/compute_ekfac_ground_truth.py
@@ -301,7 +301,7 @@ def tokenize_and_allocate_step(
     data = ds
 
     batches_world = _allocate_batches_world(
-        doc_lengths=list(ds["length"]), N=cfg.token_batch_size, world_size=workers
+        doc_lengths=ds["length"][:], N=cfg.token_batch_size, world_size=workers
     )
 
     return data, batches_world, tokenizer

--- a/tests/ekfac_tests/compute_ekfac_ground_truth.py
+++ b/tests/ekfac_tests/compute_ekfac_ground_truth.py
@@ -301,7 +301,7 @@ def tokenize_and_allocate_step(
     data = ds
 
     batches_world = _allocate_batches_world(
-        doc_lengths=ds["length"], N=cfg.token_batch_size, world_size=workers
+        doc_lengths=list(ds["length"]), N=cfg.token_batch_size, world_size=workers
     )
 
     return data, batches_world, tokenizer

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -95,7 +95,7 @@ def test_in_memory_reduce(tmp_path: Path):
     ds = setup_data_pipeline(index_cfg)
     model, target_modules = setup_model_and_peft(index_cfg)
     processor = create_processor(model, ds, index_cfg, target_modules)
-    batches = allocate_batches(ds["length"], index_cfg.token_batch_size)
+    batches = allocate_batches(ds["length"][:], index_cfg.token_batch_size)
 
     collector = InMemoryCollector(
         model=model.base_model,  # type: ignore

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -50,7 +50,7 @@ def run_pipeline(tmp_path, model_name, token_batch_size, doc_tokens, truncation)
         data=DataConfig(dataset=documents_file, truncation=truncation),
     )
     ds = setup_data_pipeline(cfg)
-    batches = allocate_batches(ds["length"], token_batch_size)
+    batches = allocate_batches(ds["length"][:], token_batch_size)
     model = AutoModelForCausalLM.from_pretrained(model_name)
     collect_gradients(
         model=model,


### PR DESCRIPTION
HuggingFace Dataset column access (ds["length"]) returns a PyArrow Column, not a Python list. Iterating over it element-by-element (via sorted(), random indexing) is ~1000x slower than on a native list. 