### PR TITLE
[WIP] Skip gradient collection for documents with fewer than two tokens

### DIFF
--- a/bergson/data.py
+++ b/bergson/data.py
@@ -244,10 +244,27 @@ def _allocate_batches_world(
     """
     if ranks is None:
         ranks = list(range(world_size))
-    if len(doc_lengths) < world_size:
-        raise RuntimeError("Not enough documents to distribute across workers.")
-
-    docs_sorted = sorted(enumerate(doc_lengths), key=lambda x: x[1], reverse=True)
+    # Skip documents shorter than 2 tokens: they cannot produce a valid
+    # next-token label so they contribute no gradient.  Keeping them would
+    # also be problematic for length-0 documents which create [N, 0] tensors
+    # that hang the model forward pass.  These documents are simply omitted
+    # from batches; their gradient index entries stay at the pre-initialized
+    # zero value.
+    docs_sorted = sorted(
+        ((i, l) for i, l in enumerate(doc_lengths) if l >= 2),
+        key=lambda x: x[1],
+        reverse=True,
+    )
+    n_skipped = len(doc_lengths) - len(docs_sorted)
+    if n_skipped > 0 and (not dist.is_initialized() or dist.get_rank() == 0):
+        print(
+            f"Skipping {n_skipped} documents with fewer than 2 tokens "
+            f"(no valid next-token labels)."
+        )
+    if len(docs_sorted) < world_size:
+        raise RuntimeError(
+            "Not enough documents (with 2+ tokens) to distribute across workers."
+        )
     if docs_sorted[0][1] > N:  # a single document would overflow any batch
         raise RuntimeError(
             f"At least one document is too long for the token batch size {N}."

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -244,27 +244,10 @@ def _allocate_batches_world(
     """
     if ranks is None:
         ranks = list(range(world_size))
-    # Skip documents shorter than 2 tokens: they cannot produce a valid
-    # next-token label so they contribute no gradient.  Keeping them would
-    # also be problematic for length-0 documents which create [N, 0] tensors
-    # that hang the model forward pass.  These documents are simply omitted
-    # from batches; their gradient index entries stay at the pre-initialized
-    # zero value.
-    docs_sorted = sorted(
-        ((i, l) for i, l in enumerate(doc_lengths) if l >= 2),
-        key=lambda x: x[1],
-        reverse=True,
-    )
-    n_skipped = len(doc_lengths) - len(docs_sorted)
-    if n_skipped > 0 and (not dist.is_initialized() or dist.get_rank() == 0):
-        print(
-            f"Skipping {n_skipped} documents with fewer than 2 tokens "
-            f"(no valid next-token labels)."
-        )
-    if len(docs_sorted) < world_size:
-        raise RuntimeError(
-            "Not enough documents (with 2+ tokens) to distribute across workers."
-        )
+    if len(doc_lengths) < world_size:
+        raise RuntimeError("Not enough documents to distribute across workers.")
+
+    docs_sorted = sorted(enumerate(doc_lengths), key=lambda x: x[1], reverse=True)
     if docs_sorted[0][1] > N:  # a single document would overflow any batch
         raise RuntimeError(
             f"At least one document is too long for the token batch size {N}."

--- a/bergson/normalizer/fit_normalizers.py
+++ b/bergson/normalizer/fit_normalizers.py
@@ -118,22 +118,29 @@ class NormalizerCollector(HookCollectorBase):
         # set module._inputs to a
         module._inputs = a
 
+    # Maximum number of documents to process at once in the outer-product
+    # matmul.  This caps the size of the intermediate P tensor
+    # [chunk, O, I] to avoid OOM on batches with many short documents.
+    NORMALIZER_CHUNK_SIZE: int = 32
+
     @HookCollectorBase.split_attention_heads
     def backward_hook(self, module: nn.Module, g: Float[Tensor, "N S O"]):
         """
         Compute per-sample gradient and store in mod_grads.
 
         Computes gradient as outer product g.T @ a (again with optional projection and
-        normalization).
+        normalization).  Processes in chunks to bound memory usage.
         """
         a = module._inputs  # [N, S, I/q]
 
         assert isinstance(a, torch.Tensor), "Activation cache missing for module"
         name = assert_type(str, module._name)
 
-        P = g.mT @ a  # [N, O/p, S] @ [N, S, I/q] → [N, O/p, I/q]
-
-        self.callback(name, P)
+        N = g.shape[0]
+        cs = self.NORMALIZER_CHUNK_SIZE
+        for start in range(0, N, cs):
+            P = g[start : start + cs].mT @ a[start : start + cs]
+            self.callback(name, P)
 
     def process_batch(self, indices: list[int], **kwargs):
         """Process collected gradients for a batch."""

--- a/bergson/normalizer/fit_normalizers.py
+++ b/bergson/normalizer/fit_normalizers.py
@@ -118,29 +118,22 @@ class NormalizerCollector(HookCollectorBase):
         # set module._inputs to a
         module._inputs = a
 
-    # Maximum number of documents to process at once in the outer-product
-    # matmul.  This caps the size of the intermediate P tensor
-    # [chunk, O, I] to avoid OOM on batches with many short documents.
-    NORMALIZER_CHUNK_SIZE: int = 32
-
     @HookCollectorBase.split_attention_heads
     def backward_hook(self, module: nn.Module, g: Float[Tensor, "N S O"]):
         """
         Compute per-sample gradient and store in mod_grads.
 
         Computes gradient as outer product g.T @ a (again with optional projection and
-        normalization).  Processes in chunks to bound memory usage.
+        normalization).
         """
         a = module._inputs  # [N, S, I/q]
 
         assert isinstance(a, torch.Tensor), "Activation cache missing for module"
         name = assert_type(str, module._name)
 
-        N = g.shape[0]
-        cs = self.NORMALIZER_CHUNK_SIZE
-        for start in range(0, N, cs):
-            P = g[start : start + cs].mT @ a[start : start + cs]
-            self.callback(name, P)
+        P = g.mT @ a  # [N, O/p, S] @ [N, S, I/q] → [N, O/p, I/q]
+
+        self.callback(name, P)
 
     def process_batch(self, indices: list[int], **kwargs):
         """Process collected gradients for a batch."""


### PR DESCRIPTION
Documents with fewer than 2 tokens cannot produce valid next-token labels, and length-0 documents create [N, 0] tensors that hang the model forward pass. In multi-GPU settings, the bin-packing allocator assigned all zero-length documents to a single rank (cost = 0), causing that rank to stall while others completed their NCCL all-reduces.

Fix by filtering <2-token documents from batch allocation in _allocate_batches_world. Their gradient index entries remain at the pre-initialized zero value, preserving the dataset-to-score index mapping. 

TODO:

we probably want to update the  "is_written" column in scores at these positions to reflect the fact that the 0. gradient is intentional. We may also want to raise an error here unless a --skip_empty_docs flag is given.