### PR TITLE
[WIP] Add mixed precision gradient collection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Don't save data to a directory that is not in the gitignore - especially the dat
 
 Don't remove large datasets from the HF cache without asking.
 
+When a bug is reported, start by writing a test that reproduces the bug. Then fix the bug and prove it with a passing test.
+
 ### Tests
 
 Mark tests requiring GPUs with `@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")`.

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -11,7 +11,7 @@ from .config import (
     PreprocessConfig,
     QueryConfig,
     ScoreConfig,
-    TrackstarConfig,
+    TrackStarConfig,
 )
 from .double_backward import DoubleBackwardConfig, double_backward
 from .hessians.hessian_approximations import approximate_hessians
@@ -120,7 +120,7 @@ class Hessian:
 
 
 @dataclass
-class Trackstar:
+class TrackStar:
     """Run preconditioners, build, and score as a single pipeline."""
 
     index_cfg: IndexConfig
@@ -129,13 +129,13 @@ class Trackstar:
 
     preprocess_cfg: PreprocessConfig
 
-    trackstar_cfg: TrackstarConfig
+    trackstar_cfg: TrackStarConfig
 
     def execute(self):
         if self.index_cfg.normalizer != "adafactor":
             print(
                 "Warning: not using Adafactor normalizer. Pass --normalizer adafactor "
-                "to match the Trackstar paper."
+                "to match the TrackStar paper."
             )
 
         trackstar(
@@ -160,7 +160,7 @@ class Main:
     """Routes to the subcommands."""
 
     command: Union[
-        Build, Query, Preconditioners, Reduce, Score, Hessian, Trackstar, Magic
+        Build, Query, Preconditioners, Reduce, Score, Hessian, TrackStar, Magic
     ]
 
     def execute(self):

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -1,7 +1,9 @@
+import copy
 from dataclasses import dataclass
 from typing import Optional, Union
 
 from simple_parsing import ArgumentParser, ConflictResolution
+from datasets import get_dataset_config_names
 
 from .build import build
 from .config import (
@@ -19,7 +21,7 @@ from .query.query_index import query
 from .score.score import score_dataset
 from .trackstar import trackstar
 from .utils.worker_utils import validate_run_path
-
+from .utils.utils import simple_parse_args_string
 
 @dataclass
 class Build:
@@ -34,9 +36,40 @@ class Build:
         if self.index_cfg.skip_index and self.index_cfg.skip_preconditioners:
             raise ValueError("Either skip_index or skip_preconditioners must be False")
 
-        validate_run_path(self.index_cfg)
+        if self.index_cfg.build_subsets:
+            self._build_all_subsets()
+        else:
+            validate_run_path(self.index_cfg)
+            build(self.index_cfg, self.preprocess_cfg)
 
-        build(self.index_cfg, self.preprocess_cfg)
+    def _build_all_subsets(self):
+        """Build a separate index per dataset subset."""
+        configs = get_dataset_config_names(
+            self.index_cfg.data.dataset, 
+            **simple_parse_args_string(self.index_cfg.data.data_args) # type: ignore
+        )
+
+        # Filter out the implicit "default" config that single-config datasets use
+        configs = [c for c in configs if c != "default"]
+        subsets = sorted(configs)
+
+        assert subsets, (
+            f"No subsets found for dataset '{self.index_cfg.data.dataset}'. "
+            "Remove --build_subsets or specify a --subset manually."
+        )
+
+        print(f"Building {len(subsets)} subset indices: {subsets}")
+        for subset_name in subsets:
+            sub_cfg = copy.deepcopy(self.index_cfg)
+            sub_cfg.data.subset = subset_name
+            sub_cfg.run_path = f"{self.index_cfg.run_path}/{subset_name}"
+            sub_cfg.build_subsets = False
+
+            print(f"Building subset: {subset_name}")
+            print(f"Run path: {sub_cfg.run_path}")
+
+            validate_run_path(sub_cfg)
+            build(sub_cfg, self.preprocess_cfg)
 
 
 @dataclass

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -66,8 +66,8 @@ def build_worker(
             world_size=world_size,
         )
 
-    model, target_modules = setup_model_and_peft(index_cfg)
-    processor = create_processor(model, ds, index_cfg, target_modules)
+    model, target_modules, adam_buffer = setup_model_and_peft(index_cfg)
+    processor = create_processor(model, ds, index_cfg, target_modules, adam_buffer)
 
     maybe_auto_batch_size(index_cfg, model, ds, processor, target_modules, rank)
 

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -38,6 +38,11 @@ from bergson.utils.logger import get_logger
 from bergson.utils.peft import set_peft_enabled
 from bergson.utils.utils import assert_type
 
+# Ensure bf16 matmuls use fp32 accumulation across tiles. Without this, cross-tile
+# reductions may use fp16 accumulators, losing precision when summing outer products
+# across long sequences.
+torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+
 
 @dataclass
 class HookCollectorBase(ContextDecorator, ABC):
@@ -753,37 +758,49 @@ def fwd_bwd_factory(cfg: IndexConfig) -> Callable:
         Returns a tensor of shape [batch_size] with one loss value per sample.
     """
 
+    _AUTOCAST_DTYPES = {"bf16": torch.bfloat16, "fp16": torch.float16}
+    autocast_dtype = _AUTOCAST_DTYPES.get(cfg.precision)
+
     def fwd_bwd(model, x: Tensor, y: Tensor, batch: dict):
-        logits = model(x).logits[:, :-1]
-        masks = y[:, 1:] != -100
-        denoms = (
-            masks.sum(dim=1, dtype=model.dtype) if cfg.loss_reduction == "mean" else 1.0
+        device_type = "cuda" if x.is_cuda else "cpu"
+        amp = (
+            torch.autocast(device_type, dtype=autocast_dtype)
+            if autocast_dtype
+            else nullcontext()
         )
+        with amp:
+            logits = model(x).logits[:, :-1]
+            masks = y[:, 1:] != -100
+            denoms = (
+                masks.sum(dim=1, dtype=model.dtype)
+                if cfg.loss_reduction == "mean"
+                else 1.0
+            )
 
-        if cfg.loss_fn == "kl":
-            with torch.inference_mode():
-                set_peft_enabled(model, False)
-                ref_lps = torch.log_softmax(model(x).logits[:, :-1], dim=-1)
-                set_peft_enabled(model, True)
+            if cfg.loss_fn == "kl":
+                with torch.inference_mode():
+                    set_peft_enabled(model, False)
+                    ref_lps = torch.log_softmax(model(x).logits[:, :-1], dim=-1)
+                    set_peft_enabled(model, True)
 
-            ft_lps = torch.log_softmax(logits, dim=-1)
+                ft_lps = torch.log_softmax(logits, dim=-1)
 
-            # Compute average KL across all unmasked tokens
-            kls = torch.sum(ft_lps.exp() * (ft_lps - ref_lps), dim=-1)
-            losses = torch.sum(kls * masks, dim=-1) / denoms
-            if "advantage" in batch:
-                losses *= torch.tensor(batch["advantage"], device=losses.device)
+                # Compute average KL across all unmasked tokens
+                kls = torch.sum(ft_lps.exp() * (ft_lps - ref_lps), dim=-1)
+                losses = torch.sum(kls * masks, dim=-1) / denoms
+                if "advantage" in batch:
+                    losses *= torch.tensor(batch["advantage"], device=losses.device)
 
-        else:
-            losses = F.cross_entropy(
-                logits.reshape(-1, logits.size(-1)),
-                y[:, 1:].flatten(),
-                reduction="none",
-                label_smoothing=cfg.label_smoothing,
-            ).reshape_as(y[:, 1:])
-            losses = losses.sum(1) / denoms
-            if "advantage" in batch:
-                losses *= torch.tensor(batch["advantage"], device=losses.device)
+            else:
+                losses = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)),
+                    y[:, 1:].flatten(),
+                    reduction="none",
+                    label_smoothing=cfg.label_smoothing,
+                ).reshape_as(y[:, 1:])
+                losses = losses.sum(1) / denoms
+                if "advantage" in batch:
+                    losses *= torch.tensor(batch["advantage"], device=losses.device)
 
         losses.sum().backward()
         model.zero_grad()
@@ -796,37 +813,47 @@ def fwd_bwd_factory(cfg: IndexConfig) -> Callable:
 def fwd_bwd_hessian_factory(
     index_cfg: IndexConfig, hessian_cfg: HessianConfig
 ) -> Callable:
-    def fwd_bwd_hessian(model, x: Tensor, y: Tensor, batch: dict):
-        logits = model(x).logits[:, :-1]
-        masks = y[:, 1:] != -100
-        denoms = (
-            masks.sum(dim=1, dtype=model.dtype)
-            if index_cfg.loss_reduction == "mean"
-            else 1.0
-        )
-        if hessian_cfg.use_dataset_labels:
-            losses = F.cross_entropy(
-                logits.reshape(-1, logits.size(-1)),
-                y[:, 1:].flatten(),
-                reduction="none",
-            ).reshape_as(y[:, 1:])
-            losses = losses.sum(1) / denoms
-        else:
-            with torch.no_grad():
-                probs = F.softmax(logits, dim=-1)
-                sampled_tokens = torch.multinomial(
-                    probs.reshape(-1, probs.size(-1)),
-                    num_samples=1,
-                    replacement=True,
-                ).reshape_as(y[:, 1:])
-            losses = F.cross_entropy(
-                logits.reshape(-1, logits.size(-1)),
-                sampled_tokens.flatten(),
-                reduction="none",
-            ).reshape_as(y[:, 1:])
-            losses = losses.sum(1) / denoms
+    _AUTOCAST_DTYPES = {"bf16": torch.bfloat16, "fp16": torch.float16}
+    autocast_dtype = _AUTOCAST_DTYPES.get(index_cfg.precision)
 
-        losses.sum().backward()
+    def fwd_bwd_hessian(model, x: Tensor, y: Tensor, batch: dict):
+        device_type = "cuda" if x.is_cuda else "cpu"
+        amp = (
+            torch.autocast(device_type, dtype=autocast_dtype)
+            if autocast_dtype
+            else nullcontext()
+        )
+        with amp:
+            logits = model(x).logits[:, :-1]
+            masks = y[:, 1:] != -100
+            denoms = (
+                masks.sum(dim=1, dtype=model.dtype)
+                if index_cfg.loss_reduction == "mean"
+                else 1.0
+            )
+            if hessian_cfg.use_dataset_labels:
+                losses = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)),
+                    y[:, 1:].flatten(),
+                    reduction="none",
+                ).reshape_as(y[:, 1:])
+                losses = losses.sum(1) / denoms
+            else:
+                with torch.no_grad():
+                    probs = F.softmax(logits, dim=-1)
+                    sampled_tokens = torch.multinomial(
+                        probs.reshape(-1, probs.size(-1)),
+                        num_samples=1,
+                        replacement=True,
+                    ).reshape_as(y[:, 1:])
+                losses = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)),
+                    sampled_tokens.flatten(),
+                    reduction="none",
+                ).reshape_as(y[:, 1:])
+                losses = losses.sum(1) / denoms
+
+            losses.sum().backward()
         model.zero_grad()
 
         return losses

--- a/bergson/collector/gradient_collectors.py
+++ b/bergson/collector/gradient_collectors.py
@@ -96,11 +96,13 @@ class GradientCollector(HookCollectorBase):
         P = self._compute_gradient(module, g)
 
         if not self.cfg.skip_preconditioners:
-            P = P.float()
-            if name in self.processor.preconditioners:
-                self.processor.preconditioners[name].addmm_(P.mT, P)
-            else:
-                self.processor.preconditioners[name] = P.mT @ P
+            # Disable autocast so preconditioner accumulation stays in fp32
+            with torch.autocast(P.device.type, enabled=False):
+                P = P.float()
+                if name in self.processor.preconditioners:
+                    self.processor.preconditioners[name].addmm_(P.mT, P)
+                else:
+                    self.processor.preconditioners[name] = P.mT @ P
 
         if self.save_index and self.preprocess_cfg.aggregation == "none":
             # Asynchronously move the gradient to CPU and convert to the final
@@ -109,6 +111,9 @@ class GradientCollector(HookCollectorBase):
                 device="cpu", dtype=self.save_dtype, non_blocking=True
             )
         else:
+            # TODO we probably only want this for build not score so it
+            # should happen in builder.
+            # Benchmark and add disk save precision flag
             self.mod_grads[name] = P.to(dtype=self.save_dtype)
 
     def process_batch(self, indices: list[int], **kwargs):

--- a/bergson/config.py
+++ b/bergson/config.py
@@ -373,7 +373,7 @@ class FaissConfig:
 
 
 @dataclass
-class TrackstarConfig:
+class TrackStarConfig:
     """Config for the trackstar pipeline query dataset."""
 
     query: DataConfig = field(default_factory=DataConfig)
@@ -386,9 +386,14 @@ class TrackstarConfig:
     index preconditioners intersect at this component. Typical value is
     ~1000 out of ~65K total components."""
 
-    num_stats_sample_preconditioner: bool = True
-    """Whether to use num_stats_sample items or the full dataset to
-    compute preconditioners."""
+    sample_preconditioners: bool = True
+    """Whether to use num_stats_sample items to compute preconditioners.
+    If False, uses the full dataset."""
+
+    stats_token_batch_size: int | None = None
+    """Token batch size for normalizer/preconditioner estimation steps (1-2).
+    These components are always collected in fp32, so use ~2x the VRAM when
+    in half precision. If None, uses the main token_batch_size."""
 
     resume: bool = False
     """Skip pipeline steps whose output directory already exists."""

--- a/bergson/config.py
+++ b/bergson/config.py
@@ -157,6 +157,12 @@ class IndexConfig:
     processor_path: str = ""
     """Path to a precomputed processor."""
 
+    adam_state_path: str = ""
+    """Path to a training checkpoint directory containing an optimizer.pt
+    or to an optimizer state file. Extracts Adam exp_avg_sq second
+    moments and loads them into AdamNormalizer. Mutually exclusive with
+    fitting normalizers via --normalizer."""
+
     normalizer: Literal["adafactor", "adam", "none"] = "none"
     """Type of normalizer to use for the gradients."""
 
@@ -208,6 +214,10 @@ class IndexConfig:
     """If provided, a glob pattern to filter out modules from gradient collection.
     For example, "transformer.h.*.mlp.*" will exclude all MLP layers in a
     standard transformer architecture."""
+
+    build_subsets: bool = False
+    """When enabled, iterate over all subsets of the dataset and build a
+    separate index for each one in a subdirectory of run_path."""
 
     overwrite: bool = False
     """Whether to overwrite any existing index in the run path."""

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -509,9 +509,9 @@ class Scores:
     def __len__(self) -> int:
         return len(self.mmap)
 
-    def __getitem__(self, key: Any) -> Any:
-        items = self.mmap[key]
-        return structured_to_unstructured(items[self._score_fields])
+    def __getitem__(self, key: Any) -> np.ndarray:
+        score_data = structured_to_unstructured(self.mmap[self._score_fields])
+        return score_data[key]
 
     def get(self, key: Any, score_idx: int = 0) -> Any:
         """Get scores for a specific score index."""
@@ -521,6 +521,11 @@ class Scores:
         """Check whether all scores in the structured mmap have
         been written to (i.e. are not still zeros)"""
         return all(np.all(self.mmap[f"written_{i}"]) for i in range(self.num_scores))
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        num_rows = len(self.mmap)
+        return (num_rows, self.num_scores)
 
 
 def load_scores(
@@ -615,17 +620,26 @@ def tokenize(
     labels_list: list[list[int]] = []
 
     for i, convo in enumerate(convos):
-        # Find the spans of the assistant's responses in the tokenized output
-        pos = 0
+        # Find the spans (start, end) of the assistant's responses in the tokens
         spans: list[tuple[int, int]] = []
 
-        for msg in convo:
+        # We use rfind to find the last match in the string so if the answer is
+        # duplicated in the user prompt we don't select that.
+
+        # We work backwards through the messages and restrict the search to not
+        # use previously matching substrings so if two assistant messages
+        # have the same content they won't both match the right-most substring.
+        search_end = len(strings[i])
+
+        for msg in reversed(convo):
             if msg["role"] != "assistant":
                 continue
 
             ans = msg["content"]
-            start = strings[i].rfind(ans, pos)
+            start = strings[i].rfind(ans, 0, search_end)
             if start < 0:
+                print("String under test: ", strings[i])
+                print("Substring search: ", ans)
                 raise RuntimeError(
                     "Failed to find completion in the chat-formatted conversation. "
                     "Make sure the chat template does not alter the completion, e.g. "
@@ -633,18 +647,35 @@ def tokenize(
                 )
 
             # move past this match
-            pos = start + len(ans)
+            end = start + len(ans)
 
-            start_token = encodings.char_to_token(i, start)
-            end_token = encodings.char_to_token(i, pos)
-            spans.append((start_token, end_token))
+            start_token_idx = encodings.char_to_token(i, start)
+            end_token_idx = encodings.char_to_token(i, end)
+            # When end falls on the last char, char_to_token returns None;
+            # look up the token for the previous char and advance by one.
+            if end_token_idx is None and end > 0:
+                prev = encodings.char_to_token(i, end - 1)
+                if prev is not None:
+                    end_token_idx = prev + 1
+            spans.append((start_token_idx, end_token_idx))
+
+            # Update the boundary; the next message must be found before this one
+            search_end = start
+
+        spans = list(reversed(spans))
 
         # Labels are -100 everywhere except where the assistant's response is
         tokens = encodings["input_ids"][i]
         labels = [-100] * len(tokens)
         for start, end in spans:
-            if start is not None and end is not None:
-                labels[start:end] = tokens[start:end]
+            if start is None:
+                # Entire span is beyond the truncation boundary, so we skip.
+                continue
+            if end is None:
+                # Span starts in-bounds but extends past truncation, so we
+                # label up to the end of the truncated sequence
+                end = len(tokens)
+            labels[start:end] = tokens[start:end]
 
         labels_list.append(labels)
 

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -159,12 +159,8 @@ def dist_worker(
             worker(*worker_args)
     finally:
         if dist.is_initialized():
-            try:
-                dist.barrier()
-            except Exception as e:
-                print(f"Barrier failed during cleanup: {e}")
-                pass
-
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
             dist.destroy_process_group()
 
 

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -145,7 +145,7 @@ def hessian_worker(
             world_size=world_size,
         )
 
-    model, target_modules = setup_model_and_peft(index_cfg)
+    model, target_modules, _ = setup_model_and_peft(index_cfg)
 
     attention_cfgs = {
         module: index_cfg.attention for module in index_cfg.split_attention_modules

--- a/bergson/normalizer/fit_normalizers.py
+++ b/bergson/normalizer/fit_normalizers.py
@@ -23,11 +23,12 @@ from bergson.utils.utils import assert_type, get_gradient_dtype
 @dataclass(kw_only=True)
 class NormalizerCollector(HookCollectorBase):
     """
-    Collects per-sample gradients from model layers and writes them to disk.
+    Collects per-sample gradients from model layers and uses them to fit
+    an optimizer-based second moment normalizer.
 
     - For each forward/backward hook, we compute the the gradient or a low-rank
     approximation via random projections, if cfg.projection_dim is set.
-    - Supports normalization via Adam or Adafactor normalizers.
+    - Fit Adam or Adafactor normalizers.
     """
 
     data: Dataset
@@ -142,6 +143,7 @@ class NormalizerCollector(HookCollectorBase):
         a = module._inputs  # [N, S, I]
 
         assert isinstance(a, torch.Tensor), "Activation cache missing for module"
+
         name = assert_type(str, module._name)
 
         P = g.mT @ a  # [N, O, S] @ [N, S, I] → [N, O, I]

--- a/bergson/normalizer/fit_normalizers.py
+++ b/bergson/normalizer/fit_normalizers.py
@@ -58,7 +58,9 @@ class NormalizerCollector(HookCollectorBase):
         bias_sq = None
         if bias_grad is not None:
             # [N, S, O] -> [N, O] -> [O]
-            bias_sq = bias_grad.float().sum(dim=1).square().sum(0)
+            # Sum over sequence dim in compute dtype, then upcast to fp32
+            # to match training (autograd reduces before optimizer upcasts)
+            bias_sq = bias_grad.sum(dim=1).float().square().sum(0)
 
         if (normalizer := self.normalizers.get(name)) is None:
             # initialize accumulators at zero
@@ -89,7 +91,9 @@ class NormalizerCollector(HookCollectorBase):
         # bias_avg_sq = E[bias_grad^2] where bias_grad = g.sum(dim=seq)
         bias_sq = None
         if bias_grad is not None:
-            bias_sq = bias_grad.float().sum(dim=1).square().sum(0)
+            # Sum over sequence dim in compute dtype, then upcast to fp32
+            # to match training (autograd reduces before optimizer upcasts)
+            bias_sq = bias_grad.sum(dim=1).float().square().sum(0)
 
         # initialize accumulators at zero
         if (normalizer := self.normalizers.get(name)) is None:

--- a/bergson/process_preconditioners.py
+++ b/bergson/process_preconditioners.py
@@ -30,7 +30,7 @@ def process_preconditioners(
         print("Computing preconditioner eigen decompositions...")
 
     for name in preconditioners.keys():
-        prec = preconditioners[name].to(dtype=torch.float64, device=device)
+        prec = preconditioners[name].to(dtype=torch.float64)
         eigvals, eigvecs = torch.linalg.eigh(prec)
         preconditioners_eigen[name] = (
             eigvals.to(dtype=dtype).contiguous().cpu(),

--- a/bergson/query/query_index.py
+++ b/bergson/query/query_index.py
@@ -71,12 +71,12 @@ def query(
             model=query_cfg.model,
         )
         tokenizer = AutoTokenizer.from_pretrained(query_cfg.model)
-        model, target_modules = setup_model_and_peft(
+        model, target_modules, _ = setup_model_and_peft(
             query_index_cfg, device_map_auto=query_cfg.device_map_auto
         )
     else:
         tokenizer = AutoTokenizer.from_pretrained(index_cfg.model)
-        model, target_modules = setup_model_and_peft(
+        model, target_modules, _ = setup_model_and_peft(
             index_cfg, device_map_auto=query_cfg.device_map_auto
         )
 

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -265,8 +265,8 @@ def score_worker(
             world_size=world_size,
         )
 
-    model, target_modules = setup_model_and_peft(index_cfg)
-    processor = create_processor(model, ds, index_cfg, target_modules)
+    model, target_modules, adam_buffer = setup_model_and_peft(index_cfg)
+    processor = create_processor(model, ds, index_cfg, target_modules, adam_buffer)
 
     attention_cfgs = {
         module: index_cfg.attention for module in index_cfg.split_attention_modules

--- a/bergson/trackstar.py
+++ b/bergson/trackstar.py
@@ -6,7 +6,7 @@ from .config import (
     IndexConfig,
     PreprocessConfig,
     ScoreConfig,
-    TrackstarConfig,
+    TrackStarConfig,
 )
 from .process_grads import mix_preconditioners
 from .score.score import score_dataset
@@ -48,7 +48,7 @@ def trackstar(
     index_cfg: IndexConfig,
     score_cfg: ScoreConfig,
     preprocess_cfg: PreprocessConfig,
-    trackstar_cfg: TrackstarConfig,
+    trackstar_cfg: TrackStarConfig,
 ):
     """Run the full trackstar pipeline: preconditioners -> mix -> build -> score."""
     run_path = index_cfg.run_path
@@ -57,7 +57,6 @@ def trackstar(
     mixed_preconditioner_path = f"{run_path}/mixed_preconditioner"
     query_path = f"{run_path}/query"
     scores_path = f"{run_path}/scores"
-    resume = trackstar_cfg.resume
 
     # Steps 1-2 only compute preconditioners, so don't preprocess grads.
     precond_preprocess_cfg = PreprocessConfig()
@@ -118,6 +117,9 @@ def trackstar(
         query_index_cfg.data = trackstar_cfg.query
         query_index_cfg.processor_path = query_processsor_path
         query_index_cfg.skip_preconditioners = True
+        # Step 4 applies the mixed preconditioner during gradient collection,
+        # which uses more memory than steps 1-2. Use the smaller batch size.
+        query_index_cfg.token_batch_size = precond_batch_size
         validate(trackstar_cfg.resume, query_index_cfg)
         build(query_index_cfg, preprocess_cfg)
 
@@ -128,6 +130,9 @@ def trackstar(
         score_index_cfg.run_path = scores_path
         score_index_cfg.processor_path = value_processor_path
         score_index_cfg.skip_preconditioners = True
+        # Scoring applies preconditioners during gradient collection, so use
+        # the smaller batch size to avoid OOM.
+        score_index_cfg.token_batch_size = precond_batch_size
         score_cfg.query_path = query_path
         validate(trackstar_cfg.resume, score_index_cfg)
         score_dataset(score_index_cfg, score_cfg, preprocess_cfg)

--- a/bergson/trackstar.py
+++ b/bergson/trackstar.py
@@ -13,7 +13,7 @@ from .score.score import score_dataset
 from .utils.worker_utils import validate_run_path
 
 
-def _limit_split_for_precond(cfg: IndexConfig) -> None:
+def limit_split_for_precond(cfg: IndexConfig) -> None:
     """Limit the data split to stats_sample_size for preconditioner-only steps."""
     # TODO this code is hacky and bad
 
@@ -27,7 +27,14 @@ def _limit_split_for_precond(cfg: IndexConfig) -> None:
             cfg.data.split = f"{base_split}[:{cfg.stats_sample_size}]"
 
 
-def _step_complete(path: str, resume: bool) -> bool:
+def validate(resume, cfg: IndexConfig):
+    """Validate run path, skipping when resume would preserve partial output."""
+    if resume and cfg.partial_run_path.exists():
+        return
+    validate_run_path(cfg)
+
+
+def is_step_complete(path: str, resume: bool) -> bool:
     """Check if a step's output already exists and should be skipped."""
     if not resume:
         return False
@@ -45,9 +52,9 @@ def trackstar(
 ):
     """Run the full trackstar pipeline: preconditioners -> mix -> build -> score."""
     run_path = index_cfg.run_path
-    value_precond_path = f"{run_path}/value_preconditioner"
-    query_precond_path = f"{run_path}/query_preconditioner"
-    mixed_precond_path = f"{run_path}/mixed_preconditioner"
+    value_processor_path = f"{run_path}/value_processor"
+    query_processsor_path = f"{run_path}/query_processor"
+    mixed_preconditioner_path = f"{run_path}/mixed_preconditioner"
     query_path = f"{run_path}/query"
     scores_path = f"{run_path}/scores"
     resume = trackstar_cfg.resume
@@ -55,69 +62,72 @@ def trackstar(
     # Steps 1-2 only compute preconditioners, so don't preprocess grads.
     precond_preprocess_cfg = PreprocessConfig()
 
-    def _validate(cfg: IndexConfig):
-        """Validate run path, skipping when resume would preserve partial output."""
-        if resume and cfg.partial_run_path.exists():
-            return
-        validate_run_path(cfg)
+    # Steps 1-2 upcast activations and gradients to fp32 for normalizer fitting,
+    # so they may need a smaller token batch size than the main collection.
+    precond_batch_size = (
+        trackstar_cfg.stats_token_batch_size or index_cfg.token_batch_size
+    )
 
     # Step 1: Compute normalizers and preconditioners on value dataset
-    print("Step 1/5: Computing normalizers and preconditioners on value dataset...")
-    if not _step_complete(value_precond_path, resume):
-        value_precond_cfg = deepcopy(index_cfg)
-        value_precond_cfg.run_path = value_precond_path
-        value_precond_cfg.skip_index = True
-        value_precond_cfg.skip_preconditioners = False
-        if trackstar_cfg.num_stats_sample_preconditioner:
-            _limit_split_for_precond(value_precond_cfg)
-        _validate(value_precond_cfg)
-        build(value_precond_cfg, precond_preprocess_cfg)
+    print("Step 1/5: Fit normalizers then compute preconditioners on index data...")
+    if not is_step_complete(value_processor_path, trackstar_cfg.resume):
+        value_processor_cfg = deepcopy(index_cfg)
+        value_processor_cfg.run_path = value_processor_path
+        value_processor_cfg.skip_index = True
+        value_processor_cfg.skip_preconditioners = False
+        value_processor_cfg.token_batch_size = precond_batch_size
+        if trackstar_cfg.sample_preconditioners:
+            limit_split_for_precond(value_processor_cfg)
+        validate(trackstar_cfg.resume, value_processor_cfg)
+        build(value_processor_cfg, precond_preprocess_cfg)
 
     # Step 2: Compute normalizers and preconditioners on query dataset
-    print("Step 2/5: Computing normalizers and preconditioners on query dataset...")
-    if not _step_complete(query_precond_path, resume):
-        query_precond_cfg = deepcopy(index_cfg)
-        query_precond_cfg.run_path = query_precond_path
-        query_precond_cfg.data = trackstar_cfg.query
-        query_precond_cfg.skip_index = True
-        query_precond_cfg.skip_preconditioners = False
-        if trackstar_cfg.num_stats_sample_preconditioner:
-            _limit_split_for_precond(query_precond_cfg)
-        _validate(query_precond_cfg)
-        build(query_precond_cfg, precond_preprocess_cfg)
+    print("Step 2/5: Fit normalizers then compute preconditioners on query data...")
+    if not is_step_complete(query_processsor_path, trackstar_cfg.resume):
+        query_processor_cfg = deepcopy(index_cfg)
+        query_processor_cfg.run_path = query_processsor_path
+        query_processor_cfg.data = trackstar_cfg.query
+        query_processor_cfg.skip_index = True
+        query_processor_cfg.skip_preconditioners = False
+        query_processor_cfg.token_batch_size = precond_batch_size
+        if trackstar_cfg.sample_preconditioners:
+            limit_split_for_precond(query_processor_cfg)
+        validate(trackstar_cfg.resume, query_processor_cfg)
+        build(query_processor_cfg, precond_preprocess_cfg)
 
     # Step 3: Mix query and value preconditioners
     print("Step 3/5: Mixing preconditioners...")
-    if not _step_complete(mixed_precond_path, resume):
+    if not is_step_complete(mixed_preconditioner_path, trackstar_cfg.resume):
         mix_preconditioners(
-            query_path=query_precond_path,
-            index_path=value_precond_path,
-            output_path=mixed_precond_path,
+            query_path=query_processsor_path,
+            index_path=value_processor_path,
+            output_path=mixed_preconditioner_path,
             target_downweight_components=trackstar_cfg.target_downweight_components,
         )
+
+    preprocess_cfg.preconditioner_path = mixed_preconditioner_path
 
     # Step 4: Build query gradient index using query-specific normalizer.
     # The mixed preconditioner is set here but only applied during build if the
     # user is aggregating the query dataset (preprocess_cfg.aggregation != "none").
     # Otherwise, preconditioning will be deferred to score time in step 5.
     print("Step 4/5: Building query gradient index...")
-    preprocess_cfg.preconditioner_path = mixed_precond_path
-    if not _step_complete(query_path, resume):
-        query_cfg = deepcopy(index_cfg)
-        query_cfg.run_path = query_path
-        query_cfg.data = trackstar_cfg.query
-        query_cfg.processor_path = query_precond_path
-        query_cfg.skip_preconditioners = True
-        _validate(query_cfg)
-        build(query_cfg, preprocess_cfg)
+    if not is_step_complete(query_path, trackstar_cfg.resume):
+        query_index_cfg = deepcopy(index_cfg)
+        query_index_cfg.run_path = query_path
+        query_index_cfg.data = trackstar_cfg.query
+        query_index_cfg.processor_path = query_processsor_path
+        query_index_cfg.skip_preconditioners = True
+        validate(trackstar_cfg.resume, query_index_cfg)
+        build(query_index_cfg, preprocess_cfg)
 
     # Step 5: Score value dataset against query using mixed preconditioner
     print("Step 5/5: Scoring value dataset...")
-    if not _step_complete(scores_path, resume):
+    if not is_step_complete(scores_path, trackstar_cfg.resume):
         score_index_cfg = deepcopy(index_cfg)
         score_index_cfg.run_path = scores_path
-        score_index_cfg.processor_path = value_precond_path
+        score_index_cfg.processor_path = value_processor_path
         score_index_cfg.skip_preconditioners = True
         score_cfg.query_path = query_path
-        _validate(score_index_cfg)
+        validate(trackstar_cfg.resume, score_index_cfg)
         score_dataset(score_index_cfg, score_cfg, preprocess_cfg)

--- a/bergson/utils/load_adam_state.py
+++ b/bergson/utils/load_adam_state.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import torch
+from transformers import PreTrainedModel
+
+from bergson.gradients import AdamNormalizer
+
+
+def load_from_optimizer(
+    model: PreTrainedModel,
+    adam_state_path: str,
+    include_bias: bool = False,
+    target_modules: set[str] | None = None,
+) -> dict[str, AdamNormalizer]:
+    """Load Adam second moments (exp_avg_sq) from a checkpoint and create
+    AdamNormalizer instances for each target linear layer.
+
+    This function only supports modules with .weight and/or .bias
+    parameters.
+
+    Args:
+        model: The model whose parameter names are used to map optimizer
+            state indices to layer names.
+        adam_state_path: Path to either a checkpoint directory containing
+            ``optimizer.pt`` or directly to an optimizer state file.
+        target_modules: Optional set of module names to include. If ``None``,
+            all linear layers are included.
+
+    Returns:
+        Dictionary mapping layer names to ``AdamNormalizer`` instances.
+    """
+    # Load optimizer state
+    state_path = Path(adam_state_path)
+    if state_path.is_dir():
+        state_path = state_path / "optimizer.pt"
+
+    optimizer_state = torch.load(state_path, map_location="cpu", weights_only=True)
+
+    # The optimizer state is keyed by position in the trainable parameter list.
+    # For LoRA checkpoints, only include LoRA params.
+    # Otherwise include all params.
+    lora_params = [(n, p) for n, p in model.named_parameters() if "lora" in n]
+    if lora_params:
+        params_for_index = lora_params
+    else:
+        params_for_index = list(model.named_parameters())
+
+    target_param_index_to_name: dict[int, str] = {}
+    for idx, (name, param) in enumerate(params_for_index):
+        target_param_index_to_name[idx] = name
+
+        # Safety check
+        if idx in optimizer_state["state"]:
+            opt_shape = optimizer_state["state"][idx]["exp_avg_sq"].shape
+            if opt_shape != param.shape:
+                raise ValueError(
+                    f"Shape mismatch at index {idx}: param '{name}' has shape "
+                    f"{tuple(param.shape)} but optimizer state has {tuple(opt_shape)}. "
+                    f"The parameter ordering may have changed between training "
+                    f"and loading."
+                )
+
+    # Extract second moments per layer
+    normalizers: dict[str, AdamNormalizer] = {}
+    for param_idx, state in optimizer_state["state"].items():
+        param_idx = int(param_idx)
+        if param_idx not in target_param_index_to_name:
+            continue
+
+        param_name = target_param_index_to_name[param_idx]
+
+        if not param_name.endswith(".weight"):
+            continue
+
+        weight_exp_avg_sq = state.get("exp_avg_sq")
+
+        # Skips 1D weights such as LayerNorm
+        if weight_exp_avg_sq is None or weight_exp_avg_sq.ndim != 2:
+            continue
+
+        # Extract layer name
+        layer_name = param_name.removesuffix(".weight")
+        # PEFT models prefix param names with "base_model." but target module
+        # names don't have it — strip so normalizer keys match collector keys.
+        module_name = layer_name.removeprefix("base_model.")
+
+        if target_modules is not None and module_name not in target_modules:
+            continue
+
+        bias_exp_avg_sq = None
+        if include_bias:
+            bias_name = layer_name + ".bias"
+            for idx, name in target_param_index_to_name.items():
+                if name == bias_name:
+                    bias_state = optimizer_state["state"].get(idx)
+                    if bias_state is not None:
+                        bias_exp_avg_sq = bias_state.get("exp_avg_sq")
+                    break
+
+        normalizers[module_name] = AdamNormalizer(
+            weight_avg_sq=weight_exp_avg_sq,
+            bias_avg_sq=bias_exp_avg_sq,
+        )
+
+    assert normalizers, (
+        f"No Adam second moments (exp_avg_sq) found in '{adam_state_path}'. "
+        "Ensure the checkpoint was saved from an Adam-family optimizer."
+    )
+
+    # Move normalizer tensors to the model's device
+    device = next(model.parameters()).device
+    for norm in normalizers.values():
+        norm.weight_avg_sq = norm.weight_avg_sq.to(device)
+        if norm.bias_avg_sq is not None:
+            norm.bias_avg_sq = norm.bias_avg_sq.to(device)
+
+    print(f"Loaded {len(normalizers)} Adam normalizers from '{adam_state_path}'")
+    return normalizers

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -25,6 +25,7 @@ from bergson.data import allocate_batches, load_data_string, tokenize
 from bergson.format import apply_format
 from bergson.gradients import GradientProcessor, Normalizer
 from bergson.normalizer.fit_normalizers import fit_normalizers
+from bergson.utils.load_adam_state import load_from_optimizer
 from bergson.utils.utils import assert_type, get_layer_list
 
 
@@ -85,6 +86,7 @@ def create_processor(
     ds: Dataset | IterableDataset,
     cfg: IndexConfig,
     target_modules: set[str] | None = None,
+    adam_buffer: dict[str, Normalizer] | None = None,
 ) -> GradientProcessor:
     """Handle processor creation and normalizer fitting"""
     local_rank = cfg.distributed.local_rank
@@ -101,7 +103,10 @@ def create_processor(
             skip_preconditioners=cfg.skip_preconditioners,
         )
     else:
-        normalizers = create_normalizers(model, ds, cfg, target_modules)
+        if adam_buffer:
+            normalizers = adam_buffer
+        else:
+            normalizers = create_normalizers(model, ds, cfg, target_modules)
 
         processor = GradientProcessor(
             normalizers,
@@ -119,7 +124,7 @@ def create_processor(
 def setup_model_and_peft(
     cfg: IndexConfig,
     device_map_auto: bool = False,
-) -> tuple[PreTrainedModel, set | None]:
+) -> tuple[PreTrainedModel, set | None, dict | None]:
     """Handle model loading, quantization, FSDP, and PEFT detection"""
     local_rank = cfg.distributed.local_rank
 
@@ -205,6 +210,14 @@ def setup_model_and_peft(
                         f"Adapter parameter '{processed_name}' not found in the model."
                     )
 
+    # Extract Adam state from parameters with requires_grad
+    if cfg.adam_state_path:
+        normalizers = load_from_optimizer(
+            model, cfg.adam_state_path, cfg.include_bias, target_modules
+        )
+    else:
+        normalizers = None
+
     # Configure gradients
     model.requires_grad_(False)
     model.get_input_embeddings().requires_grad_(True)  # type: ignore
@@ -217,7 +230,7 @@ def setup_model_and_peft(
 
     model = cast(PreTrainedModel, model)
 
-    return model, target_modules  # type: ignore
+    return model, target_modules, normalizers  # type: ignore
 
 
 def estimate_advantage(ds: Dataset, cfg: DataConfig):

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -106,7 +106,8 @@ def create_processor(
         if adam_buffer:
             normalizers = adam_buffer
         else:
-            normalizers = create_normalizers(model, ds, cfg, target_modules)
+            # Disable normalizers due to lack of empirical validation
+            normalizers = {}  # create_normalizers(model, ds, cfg, target_modules)
 
         processor = GradientProcessor(
             normalizers,

--- a/examples/filter_data.py
+++ b/examples/filter_data.py
@@ -25,7 +25,7 @@ class FilterConfig:
     """Config for building the index and running the model/dataset pipeline."""
 
     filter: Literal["classification", "attribution", "trackstar", "loss", "random"] = (
-        "attribution"
+        "trackstar"
     )
     """Filter to apply to the training set before finetuning."""
 
@@ -97,6 +97,9 @@ class FilterConfig:
     dry_run: bool = False
     """Whether to run the script in dry run mode."""
 
+    overwrite: bool = False
+    """Overwrite existing trackstar scores."""
+
     revision: str | None = None
     """Revision of the model to use."""
 
@@ -119,6 +122,7 @@ def run_sft(
     eval: Dataset,
     output_dir: str,
     model_name_or_path: str | None = None,
+    run_name: str | None = None,
 ) -> dict:
     """Run SFT. Uses HF Trainer which handles DDP automatically.
     Returns the final eval metrics."""
@@ -172,6 +176,7 @@ def run_sft(
             ddp_find_unused_parameters=False,
             dataset_kwargs={"skip_prepare_dataset": True},
             seed=cfg.seed,
+            run_name=run_name,
         ),
     )
 
@@ -242,7 +247,7 @@ def run_trackstar(
 ) -> None:
     """Run the bergson trackstar pipeline to score the dataset."""
     scores_path = Path(trackstar_path) / "scores"
-    if scores_path.exists():
+    if scores_path.exists() and not args.overwrite:
         print(f"Trackstar scores already exist at {scores_path}, skipping.")
         return
 
@@ -281,6 +286,8 @@ def run_trackstar(
         str(args.projection_dim),
         "--token_batch_size",
         "8192",
+        "--stats_token_batch_size",
+        "4096",
         "--nproc_per_node",
         str(num_gpus),
         "--overwrite",
@@ -549,16 +556,19 @@ def main(
             f"examples/runs/{model_name}_{dataset_name}"
             f"_trackstar{lora_suffix}{proj_suffix}"
         )
-        run_trackstar(args, trackstar_path, model=sft_model_path)
+        run_trackstar(
+            args,
+            trackstar_path,
+            model=sft_model_path,
+            num_gpus=torch.cuda.device_count(),
+        )
 
     # Step 3: Filter the training set
     print("Filtering...")
     if args.num_examples == 0:
         train = orig_train
     elif args.filter == "trackstar":
-        scores_path = Path(
-            f"examples/runs/{model_name}_{dataset_name}_trackstar{lora_suffix}{proj_suffix}/scores"
-        )
+        scores_path = Path(trackstar_path) / "scores"
         scores = load_scores(scores_path)
         # Scores are in original dataset order (before train/test split).
         # Use _orig_idx to map train split positions to original indices.
@@ -647,7 +657,9 @@ def main(
     )
 
     print(f"Training on {len(train)} examples, evaluating on {len(eval_ds)} examples.")
-    metrics = run_sft(args, train, eval_ds, f"examples/runs/{run_name}")
+    metrics = run_sft(
+        args, train, eval_ds, f"examples/runs/{run_name}", run_name=run_name
+    )
 
     print(f"\n{'='*60}")
     print(f"Run: {run_name}")

--- a/examples/filter_data.py
+++ b/examples/filter_data.py
@@ -1,23 +1,30 @@
+"""Launch this script with torchrun."""
+
 import gc
 import json
+import logging
 import os
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 import torch
+import torch.distributed as dist
 from datasets import Dataset, load_dataset
 from peft import LoraConfig, get_peft_model
 from simple_parsing import parse
 from torch import Tensor
+from torch.utils.data import Sampler
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from trl import SFTConfig, SFTTrainer
 
 from bergson.config import DataConfig
 from bergson.data import load_gradient_dataset, load_scores, tokenize
-from bergson.process_grads import get_trackstar_preconditioner, precondition_flat_grads
 from bergson.utils.utils import assert_type
+
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 @dataclass
@@ -29,10 +36,10 @@ class FilterConfig:
     )
     """Filter to apply to the training set before finetuning."""
 
-    model: str = "HuggingFaceTB/SmolLM2-1.7B-Instruct"
+    model: str = "Qwen/Qwen2.5-1.5B"
     """Name of the model to load."""
 
-    dataset: str = "argilla/magpie-ultra-v0.1"
+    dataset: str = "sander-wood/irishman"
     """Dataset identifier to finetune on."""
 
     index_dataset: str = ""
@@ -55,22 +62,22 @@ class FilterConfig:
     name: str | None = None
     """Name of the run, used to save the model and tokenizer."""
 
-    max_samples: int = 25_000
+    max_samples: int = 50_000
     """Maximum number of samples to use from the dataset. 0 for all."""
 
-    num_examples: int = 10_000
+    num_examples: int = 5_000
     """Number of items to select from the training set after filtering."""
 
-    prompt_column: str = ""
+    prompt_column: str = "abc notation"
     """Column in the dataset that contains the prompts."""
 
     completion_column: str = ""
     """Optional column in the dataset that contains the completions."""
 
-    conversation_column: str = "messages"
+    conversation_column: str = ""
     """Optional column in the dataset that contains the conversation."""
 
-    batch_size: int = 512
+    map_batch_size: int = 512
     """Batch size for processing the dataset."""
 
     seed: int = 42
@@ -78,6 +85,11 @@ class FilterConfig:
 
     lowest: bool = False
     """Select the lowest scores."""
+
+    ordered: bool = True
+    """Replay the original full-dataset shuffle order during the filtered
+    retrain. Selected items appear in the same sequence as the original SFT
+    run, with removed items simply skipped."""
 
     sample: bool = False
     """Filter by sampling from the dataset without replacement with
@@ -106,35 +118,89 @@ class FilterConfig:
     query_method: Literal["mean", "nearest"] = "mean"
     """Method to use for computing the query."""
 
-    use_lora: bool = False
+    use_lora: bool = True
     """Use LoRA for finetuning instead of full SFT."""
 
-    lora_rank: int = 16
+    lora_rank: int = 64
     """LoRA rank (only used when use_lora=True)."""
 
     projection_dim: int = 16
     """Projection dimension for gradient index."""
 
+    test_size: float = 0.05
+
+    tag: str = ""
+
+    pdbs: int = 1
+    "Per-device batch size"
+
+    learning_rate: float = 5e-5
+
+    precision: str = "fp32"
+
+    subset: str = "default"
+
+
+def set_seeds(seed: int):
+    """Set all random seeds for reproducibility."""
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+
+class OrderedFilterSampler(Sampler[int]):
+    """Replays the full-dataset shuffle, yielding only selected items.
+
+    Generates ``randperm(full_dataset_size)`` each epoch using a seeded
+    generator, then yields only positions that correspond to items kept
+    after filtering.  This ensures the filtered retrain sees items in the
+    same order the original full-dataset SFT run would have used, with
+    removed items simply skipped.
+
+    Each call to ``__iter__`` advances the generator state, so multi-epoch
+    training produces different (but deterministic) orderings per epoch,
+    matching the behaviour of ``RandomSampler``.
+    """
+
+    def __init__(
+        self,
+        full_dataset_size: int,
+        orig_to_pos: dict[int, int],
+        seed: int,
+    ):
+        self.full_size = full_dataset_size
+        self.orig_to_pos = orig_to_pos
+        self.generator = torch.Generator()
+        self.generator.manual_seed(seed)
+
+    def __iter__(self):
+        perm = torch.randperm(self.full_size, generator=self.generator)
+        for idx in perm.tolist():
+            if idx in self.orig_to_pos:
+                yield self.orig_to_pos[idx]
+
+    def __len__(self) -> int:
+        return len(self.orig_to_pos)
+
 
 def run_sft(
     cfg: FilterConfig,
     train: Dataset,
-    eval: Dataset,
-    output_dir: str,
-    model_name_or_path: str | None = None,
+    eval_ds: Dataset,
+    output_path: Path,
+    model_name: str | None = None,
     run_name: str | None = None,
+    sampler: Sampler[int] | None = None,
 ) -> dict:
-    """Run SFT. Uses HF Trainer which handles DDP automatically.
+    """SFT with HF Trainer, which handles DDP automatically.
     Returns the final eval metrics."""
-    if model_name_or_path is None:
-        model_name_or_path = cfg.model
+    model_name = model_name or cfg.model
 
     model = AutoModelForCausalLM.from_pretrained(
-        model_name_or_path,
-        torch_dtype=torch.float32,
+        model_name,
+        dtype=torch.float32,
         revision=cfg.revision,
     )
-    tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, max_length=8192)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, max_length=8192)
 
     if cfg.use_lora:
         lora_config = LoraConfig(
@@ -145,24 +211,28 @@ def run_sft(
             bias="none",
             task_type="CAUSAL_LM",
         )
-        model = get_peft_model(model, lora_config)
-        model.print_trainable_parameters()
+        model = get_peft_model(model, lora_config)  # type: ignore
+        model.print_trainable_parameters()  # type: ignore
 
-    num_train_steps = (len(train) // 32) * cfg.num_epochs
-    eval_steps = max(1, num_train_steps // 10)
+    effective_batch_size = 128
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    grad_acc_steps = effective_batch_size // world_size // cfg.pdbs
+    num_train_steps = (len(train) // effective_batch_size) * cfg.num_epochs
+    eval_steps = max(1, num_train_steps // 5)
 
     trainer = SFTTrainer(
         model=model,
         train_dataset=train,
-        eval_dataset=eval,
+        eval_dataset=eval_ds,
         args=SFTConfig(
+            # train_sampling_strategy="group_by_length",
             max_length=2048,
-            output_dir=output_dir,
-            per_device_train_batch_size=1,
-            per_device_eval_batch_size=1,
-            gradient_accumulation_steps=32,
-            gradient_checkpointing=True,
-            learning_rate=3e-4,
+            output_dir=str(output_path),
+            per_device_train_batch_size=cfg.pdbs,
+            per_device_eval_batch_size=cfg.pdbs,
+            gradient_accumulation_steps=grad_acc_steps,
+            # gradient_checkpointing=True,
+            learning_rate=cfg.learning_rate,
             num_train_epochs=cfg.num_epochs,
             warmup_ratio=0.1,
             lr_scheduler_type="cosine",
@@ -170,15 +240,21 @@ def run_sft(
             logging_steps=1,
             eval_strategy="steps",
             eval_steps=eval_steps,
-            save_steps=100,
-            save_total_limit=3,
-            group_by_length=True,
+            save_strategy="epoch",
+            save_total_limit=2,
+            dataloader_drop_last=True,
             ddp_find_unused_parameters=False,
+            report_to="wandb",
             dataset_kwargs={"skip_prepare_dataset": True},
             seed=cfg.seed,
             run_name=run_name,
         ),
     )
+
+    # Override the Trainer's default RandomSampler to replay the
+    # full-dataset shuffle order with unselected items removed.
+    if sampler is not None:
+        trainer._get_train_sampler = lambda _ds=None: sampler  # type: ignore[assignment]
 
     if cfg.dry_run:
         print("Dry run mode, exiting...")
@@ -187,11 +263,11 @@ def run_sft(
     trainer.train()
     metrics = trainer.evaluate()
     print(f"Final eval metrics: {metrics}")
-    trainer.save_model(output_dir)
-    tokenizer.save_pretrained(output_dir)
+    trainer.save_model(str(output_path))
+    tokenizer.save_pretrained(output_path)
 
     # Save eval metrics
-    with open(os.path.join(output_dir, "eval_metrics.json"), "w") as f:
+    with open(output_path / "eval_metrics.json", "w") as f:
         json.dump(metrics, f, indent=2)
 
     # Free GPU memory before next step
@@ -201,64 +277,123 @@ def run_sft(
     return metrics
 
 
-def build_index(args: FilterConfig, index_path: str, model: str) -> None:
-    """Build a bergson gradient index if it doesn't already exist."""
-    if Path(index_path).exists():
-        return
+_TORCHRUN_ENV_VARS = {
+    "RANK",
+    "LOCAL_RANK",
+    "WORLD_SIZE",
+    "LOCAL_WORLD_SIZE",
+    "GROUP_RANK",
+    "MASTER_ADDR",
+    "MASTER_PORT",
+    "TORCHELASTIC_RUN_ID",
+    "TORCHELASTIC_RESTART_COUNT",
+    "TORCHELASTIC_MAX_RESTARTS",
+    "TORCHELASTIC_USE_AGENT_STORE",
+}
 
-    split = args.split
-    if args.max_samples:
-        split = f"{split}[:{args.max_samples}]"
+
+def _file_barrier(
+    sentinel_dir: Path,
+    run_id: str,
+    local_rank: int,
+    world_size: int,
+):
+    """File-based barrier with cleanup.
+
+    Protocol:
+    1. Rank 0 creates the sentinel after finishing its subprocess.
+    2. Other ranks poll until the sentinel exists.
+    3. Each rank touches an ack file.
+    4. Rank 0 waits for all acks, then cleans up everything.
+    """
+    sentinel = sentinel_dir / f".barrier_{run_id}"
+    ack = sentinel_dir / f".ack_{run_id}_{local_rank}"
+
+    if local_rank == 0:
+        sentinel_dir.mkdir(parents=True, exist_ok=True)
+        sentinel.touch()
+    else:
+        while not sentinel.exists():
+            time.sleep(1)
+
+    ack.touch()
+
+    if local_rank == 0:
+        acks = [sentinel_dir / f".ack_{run_id}_{r}" for r in range(world_size)]
+        while not all(p.exists() for p in acks):
+            time.sleep(0.5)
+        sentinel.unlink(missing_ok=True)
+        for p in acks:
+            p.unlink(missing_ok=True)
+
+
+def _clean_dist_env() -> dict[str, str]:
+    """Return os.environ without torchrun distributed variables.
+
+    Subprocesses that manage their own distributed setup (bergson build,
+    bergson trackstar) must not inherit the parent torchrun's env vars.
+    """
+    return {k: v for k, v in os.environ.items() if k not in _TORCHRUN_ENV_VARS}
+
+
+def build_index(
+    cfg: FilterConfig, index_path: Path, train_split: str, model: str, rank: int = 0
+) -> None:
+    """Build a bergson gradient index if it doesn't already exist."""
+    if index_path.exists():
+        return
 
     cmd = [
         "bergson",
         "build",
-        index_path,
+        str(index_path),
         "--model",
         model,
         "--dataset",
-        args.dataset,
+        cfg.dataset,
         "--split",
-        split,
+        train_split,
         "--truncation",
         "--projection_dim",
-        str(args.projection_dim),
+        str(cfg.projection_dim),
         "--token_batch_size",
-        "8192",
+        "4096",
         "--precision",
         "auto",
         "--overwrite",
     ]
-    if args.prompt_column:
-        cmd += ["--prompt_column", args.prompt_column]
-    if args.completion_column:
-        cmd += ["--completion_column", args.completion_column]
-    if args.conversation_column:
-        cmd += ["--conversation_column", args.conversation_column]
+    if cfg.subset:
+        cmd += ["--subset", cfg.subset]
+    if cfg.prompt_column:
+        cmd += ["--prompt_column", cfg.prompt_column]
+    if cfg.completion_column:
+        cmd += ["--completion_column", cfg.completion_column]
+    if cfg.conversation_column:
+        cmd += ["--conversation_column", cfg.conversation_column]
 
     print(f"Building index: {' '.join(cmd)}")
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, env=_clean_dist_env())
     if result.returncode != 0:
         raise RuntimeError(f"bergson build failed with exit code {result.returncode}")
 
 
-def run_trackstar(
-    args: FilterConfig, trackstar_path: str, model: str, num_gpus: int = 1
+def collect_trackstar_scores(
+    cfg: FilterConfig,
+    trackstar_path: Path,
+    train_split: str,
+    eval_split: str,
+    model: str,
 ) -> None:
     """Run the bergson trackstar pipeline to score the dataset."""
-    scores_path = Path(trackstar_path) / "scores"
-    if scores_path.exists() and not args.overwrite:
+    scores_path = trackstar_path / "scores"
+    if scores_path.exists() and not cfg.overwrite:
         print(f"Trackstar scores already exist at {scores_path}, skipping.")
         return
-
-    split = args.split
-    if args.max_samples:
-        split = f"{split}[:{args.max_samples}]"
 
     cmd = [
         "bergson",
         "trackstar",
-        trackstar_path,
+        str(trackstar_path),
         "--model",
         model,
         "--normalizer",
@@ -267,15 +402,14 @@ def run_trackstar(
         "10000",
         # Value dataset (the training data to score)
         "--data.dataset",
-        args.dataset,
+        cfg.dataset,
         "--data.split",
-        split,
+        train_split,
         "--data.truncation",
-        # Query dataset (same data — self-attribution)
         "--query.dataset",
-        args.dataset,
+        cfg.dataset,
         "--query.split",
-        split,
+        eval_split,
         "--query.truncation",
         # Score settings
         "--unit_normalize",
@@ -283,102 +417,108 @@ def run_trackstar(
         "mean",
         "--normalize_aggregated_grad",
         "--projection_dim",
-        str(args.projection_dim),
+        str(cfg.projection_dim),
         "--token_batch_size",
-        "8192",
+        "4096",
         "--stats_token_batch_size",
         "4096",
         "--nproc_per_node",
-        str(num_gpus),
+        str(torch.cuda.device_count()),
         "--overwrite",
+        "--index_cfg.precision",
+        cfg.precision,
     ]
+    if cfg.subset:
+        cmd += ["--data.subset", cfg.subset]
+        cmd += ["--query.subset", cfg.subset]
     # PEFT models need explicit tokenizer since adapter dir has no tokenizer config
-    if args.use_lora:
-        cmd += ["--tokenizer", args.model]
-    if args.conversation_column:
-        cmd += ["--data.conversation_column", args.conversation_column]
-        cmd += ["--query.conversation_column", args.conversation_column]
-    if args.prompt_column:
-        cmd += ["--data.prompt_column", args.prompt_column]
-        cmd += ["--query.prompt_column", args.prompt_column]
-    if args.completion_column:
-        cmd += ["--data.completion_column", args.completion_column]
-        cmd += ["--query.completion_column", args.completion_column]
+    if cfg.use_lora:
+        cmd += ["--tokenizer", cfg.model]
+    if cfg.conversation_column:
+        cmd += ["--data.conversation_column", cfg.conversation_column]
+        cmd += ["--query.conversation_column", cfg.conversation_column]
+    if cfg.prompt_column:
+        cmd += ["--data.prompt_column", cfg.prompt_column]
+        cmd += ["--query.prompt_column", cfg.prompt_column]
+    if cfg.completion_column:
+        cmd += ["--data.completion_column", cfg.completion_column]
+        cmd += ["--query.completion_column", cfg.completion_column]
 
     print(f"Running trackstar: {' '.join(cmd)}")
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, env=_clean_dist_env())
     if result.returncode != 0:
         raise RuntimeError(
             f"bergson trackstar failed with exit code {result.returncode}"
         )
 
 
-def sft_full(args: FilterConfig, output_dir: str) -> str:
+def sft_full(
+    ds,
+    eval_ds,
+    cfg: FilterConfig,
+    tokenizer,
+    data_config,
+    output_path: Path,
+    initial_sft_run_name: str,
+) -> Path:
     """SFT on the full dataset. Returns the checkpoint path.
 
-    This is step 1 of the DA workflow: finetune on the data you want to
+    This is a step in the DA workflow: fine-tune on the data you want to
     attribute so that the gradients are meaningful.
     """
     # Check for actual model files, not just directory existence
-    output_path = Path(output_dir)
     has_model = (output_path / "config.json").exists() or (
         output_path / "adapter_config.json"
     ).exists()
     if has_model:
-        print(f"SFT checkpoint already exists at {output_dir}, skipping.")
-        return output_dir
+        print(f"SFT checkpoint already exists at {output_path}, skipping.")
+        return output_path
 
-    dataset = assert_type(Dataset, load_dataset(args.dataset, split=args.split))
-    if args.max_samples:
-        dataset = dataset.select(range(min(args.max_samples, len(dataset))))
-
-    split = dataset.train_test_split(test_size=0.05, seed=args.seed)
-    train_ds, eval_ds = split["train"], split["test"]
-
-    tokenizer = AutoTokenizer.from_pretrained(args.model, max_length=8192)
-    data_config = DataConfig(
-        prompt_column=args.prompt_column,
-        completion_column=args.completion_column,
-        conversation_column=args.conversation_column,
-    )
-    train_ds = train_ds.map(
-        tokenize, batched=True, fn_kwargs=dict(args=data_config, tokenizer=tokenizer)
+    ds = ds.map(
+        tokenize,
+        batched=True,
+        fn_kwargs=dict(args=data_config, tokenizer=tokenizer, max_length=2048),
     )
     eval_ds = eval_ds.map(
-        tokenize, batched=True, fn_kwargs=dict(args=data_config, tokenizer=tokenizer)
+        tokenize,
+        batched=True,
+        fn_kwargs=dict(args=data_config, tokenizer=tokenizer, max_length=2048),
     )
 
-    print(f"SFT on full dataset ({len(train_ds)} examples)...")
-    run_sft(args, train_ds, eval_ds, output_dir)
-    print(f"SFT checkpoint saved to {output_dir}")
+    print(f"SFT on ({len(ds)} examples)...")
+    metrics = run_sft(
+        cfg,
+        ds,
+        eval_ds,
+        output_path,
+        run_name=initial_sft_run_name,
+    )
+    print(f"SFT checkpoint saved to {output_path}")
+    print(f"\n{'='*60}")
+    if metrics:
+        print(f"Final train loss: {metrics.get('train_loss', 'N/A')}")
+        print(f"Final eval loss: {metrics.get('eval_loss', 'N/A')}")
+    print(f"{'='*60}\n")
 
-    return output_dir
-
-
-def set_seeds(seed: int):
-    """Set all random seeds for reproducibility."""
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed(seed)
+    return output_path
 
 
 def _get_attribution_indices(
-    args: FilterConfig,
-    train: Dataset,
-    run_name: str,
-    query_method: Literal["mean", "nearest"] = "mean",
+    cfg: FilterConfig, train: Dataset, run_name: str
 ) -> Tensor:
-    """Score gradient dataset and return selected indices."""
-    if args.query_scores:
+    """Score gradient dataset using Hessian-free cosine similarity
+    scores and return selected indices."""
+    if cfg.query_scores:
         query_dataset = train.filter(lambda x: x["quality"] == "excellent")
-    elif args.query_dataset:
+    elif cfg.query_dataset:
         query_dataset = load_gradient_dataset(
-            Path(args.query_dataset), structured=False
+            Path(cfg.query_dataset), structured=False
         ).with_format("torch")
     else:
         query_dataset = train
 
     # Compute the mean of the normalized gradients in the query index
-    if query_method == "mean":
+    if cfg.query_method == "mean":
         acc = {"sum": torch.zeros_like(query_dataset[0]["gradients"], device="cuda")}
 
         def sum_(col):
@@ -389,34 +529,19 @@ def _get_attribution_indices(
         # nproc solution must use reduce as in
         # https://colab.research.google.com/drive/1jCLv31Y4cDfqD0lhO0AnqEv3Or-LLvWe?usp=sharing
         query_dataset.map(
-            sum_, input_columns="gradients", batched=True, batch_size=args.batch_size
+            sum_,
+            input_columns="gradients",
+            batched=True,
+            batch_size=cfg.map_batch_size,
         )
 
         query = acc["sum"] / len(query_dataset)
-    elif query_method == "nearest":
+    elif cfg.query_method == "nearest":
         query = assert_type(Tensor, query_dataset["gradients"]).cuda()
-
-    if args.precondition:
-        index_ds_path = Path(args.index_dataset)
-        preconditioner_path = (
-            args.query_dataset if args.query_dataset else args.index_dataset
-        )
-        h_inv = get_trackstar_preconditioner(
-            preconditioner_path, device=torch.device("cuda"), power=-1
-        )
-
-        # Get ordered module names from info.json
-        with open(index_ds_path / "info.json") as f:
-            ordered_modules = json.load(f)["dtype"]["names"]
-
-        query = precondition_flat_grads(
-            query.unsqueeze(0), h_inv, ordered_modules
-        ).squeeze(0)
     else:
-        h_inv = {}
-        ordered_modules = []
+        raise NotImplementedError
 
-    query /= query.norm()
+    query /= query.norm(dim=-1, keepdim=True)
 
     del query_dataset
 
@@ -426,11 +551,6 @@ def _get_attribution_indices(
     def score(batch):
         gradients_batch = batch.cuda()
 
-        if h_inv:
-            gradients_batch = precondition_flat_grads(
-                gradients_batch, h_inv, ordered_modules
-            )
-
         gradients_batch /= gradients_batch.norm(dim=1, keepdim=True)
         batch_scores = gradients_batch @ query
 
@@ -438,11 +558,6 @@ def _get_attribution_indices(
 
     def score_nearest(batch):
         gradients_batch = batch.cuda()
-
-        if h_inv:
-            gradients_batch = precondition_flat_grads(
-                gradients_batch, h_inv, ordered_modules
-            )
 
         gradients_batch /= gradients_batch.norm(dim=1, keepdim=True)
         batch_scores = gradients_batch @ query.T
@@ -453,9 +568,11 @@ def _get_attribution_indices(
 
         acc["scores"].append(batch_scores)
 
-    score_fn = score_nearest if query_method == "nearest" else score
     train.map(
-        score_fn, input_columns="gradients", batched=True, batch_size=args.batch_size
+        score_nearest if cfg.query_method == "nearest" else score,
+        input_columns="gradients",
+        batched=True,
+        batch_size=cfg.map_batch_size,
     )
     importance_scores = torch.cat(acc["scores"], dim=0).cuda()
 
@@ -470,135 +587,194 @@ def _get_attribution_indices(
     os.makedirs(f"examples/runs/{run_name}", exist_ok=True)
     torch.save(importance_scores, f"examples/runs/{run_name}/importance_scores.pt")
 
-    if args.sample:
-        probs = torch.softmax(importance_scores / args.temperature, dim=0)
-        selected_indices = torch.multinomial(
-            probs, args.num_examples, replacement=False
-        )
+    if cfg.sample:
+        probs = torch.softmax(importance_scores / cfg.temperature, dim=0)
+        selected_indices = torch.multinomial(probs, cfg.num_examples, replacement=False)
     else:
-        # Select the top-k items
+        # Select the indices of the top-k (or bottom-k) scored items
         sorted_scores = torch.argsort(importance_scores)
         selected_indices = (
-            sorted_scores[: args.num_examples]
-            if args.lowest
-            else sorted_scores[-args.num_examples :]
+            sorted_scores[: cfg.num_examples]
+            if cfg.lowest
+            else sorted_scores[-cfg.num_examples :]
         )
 
+    # Sort so the filtered dataset is in original order (required for the
+    # OrderedFilterSampler mapping; harmless otherwise since the Trainer shuffles).
+    selected_indices, _ = selected_indices.sort()
     return selected_indices
 
 
-def main(
-    args: FilterConfig,
-):
-    set_seeds(args.seed)
-    print("Running")
+def load_ds(cfg: FilterConfig):
+    train_split = f"{cfg.split}[:95%]"
+    eval_split = f"{cfg.split}[-1:]"
 
-    if args.name is None:
-        run_name = (
-            f"{args.model.split('/')[-1]}-{args.dataset.split('/')[-1]}-{args.filter}"
-            f"{'-lora' if args.use_lora else ''}"
-            f"{'-lowest' if args.lowest else ''}"
-            f"-n={args.num_examples}"
-            f"-s={args.seed}"
+    if cfg.subset:
+        train_ds = assert_type(
+            Dataset, load_dataset(cfg.dataset, cfg.subset, split=train_split)
         )
     else:
-        run_name = args.name
+        train_ds = assert_type(Dataset, load_dataset(cfg.dataset, split=train_split))
 
-    # Always load the original text dataset for training.
-    # Don't shuffle here — order must match the gradient index built by bergson.
-    orig_dataset = assert_type(Dataset, load_dataset(args.dataset, split=args.split))
-    if args.max_samples:
-        orig_dataset = orig_dataset.select(
-            range(min(args.max_samples, len(orig_dataset)))
+    if cfg.subset:
+        eval_ds = assert_type(
+            Dataset, load_dataset(cfg.dataset, cfg.subset, split=eval_split)
+        )
+    else:
+        eval_ds = assert_type(Dataset, load_dataset(cfg.dataset, split=eval_split))
+
+    if cfg.max_samples < len(train_ds):
+        train_split = f"{cfg.split}[:{cfg.max_samples}]"
+        train_ds = train_ds.select(range(min(cfg.max_samples, len(train_ds))))
+
+    # Add an index column so any shuffles can be undone.
+    train_ds = train_ds.add_column("_orig_idx", list(range(len(train_ds))))
+
+    return train_ds, eval_ds, train_split, eval_split
+
+
+def build_paths(cfg: FilterConfig):
+    # Set up data paths
+    model_name = cfg.model.split("/")[-1]
+    dataset_name = cfg.dataset.split("/")[-1]
+    lora_suffix = "_lora" if cfg.use_lora else ""
+    proj_suffix = f"_p{cfg.projection_dim}" if cfg.projection_dim != 16 else ""
+
+    trackstar_path = (
+        f"examples/runs/{model_name}_{dataset_name}"
+        f"_trackstar{lora_suffix}{proj_suffix}{cfg.tag}_{cfg.precision}_{cfg.seed}"
+        f"{cfg.ordered}{cfg.max_samples}"
+    )
+    index_path = cfg.index_dataset or (
+        f"examples/runs/{model_name}_{dataset_name}"
+        f"_index{lora_suffix}{proj_suffix}_{cfg.seed}_{cfg.learning_rate}"
+        f"_{cfg.ordered}{cfg.max_samples}"
+    )
+    run_name = cfg.name or (
+        f"{cfg.model.split('/')[-1]}-{cfg.dataset.split('/')[-1]}-{cfg.filter}"
+        f"{cfg.max_samples}{'-lora' if cfg.use_lora else ''}"
+        f"{'-lowest' if cfg.lowest else ''}"
+        f"-n={cfg.num_examples}"
+        f"-s={cfg.seed}"
+        f"-p{cfg.precision}"
+    )
+
+    sft_path = Path(
+        f"examples/runs/{model_name}_{dataset_name}_sft{lora_suffix}_"
+        f"{cfg.learning_rate}_{cfg.seed}_{cfg.max_samples}"
+    )
+    initial_sft_run_name = (
+        f"Full SFT {cfg.dataset} {cfg.learning_rate} "
+        f"{cfg.model} lora={cfg.use_lora}"
+    )
+
+    return (
+        sft_path,
+        initial_sft_run_name,
+        run_name,
+        Path(trackstar_path),
+        Path(index_path),
+    )
+
+
+def main(
+    cfg: FilterConfig,
+):
+    set_seeds(cfg.seed)
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    if local_rank == 0:
+        print("Running")
+        # Set by torchrun
+        print("local_rank", local_rank)
+
+    is_distributed = "RANK" in os.environ
+    # MASTER_PORT is unique per torchrun invocation so stale sentinel
+    # files from previous runs don't cause false-positive barrier passes.
+    run_id = os.environ.get("MASTER_PORT", "0")
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    # Set up data paths
+    sft_path, initial_sft_run_name, run_name, trackstar_path, index_path = build_paths(
+        cfg
+    )
+
+    # Load the dataset for training.
+    ds, eval_ds, train_split, eval_split = load_ds(cfg)
+
+    # Define data config
+    tokenizer = AutoTokenizer.from_pretrained(cfg.model, max_length=8192)
+    data_config = DataConfig(
+        prompt_column=cfg.prompt_column,
+        completion_column=cfg.completion_column,
+        conversation_column=cfg.conversation_column,
+        truncation=True,
+    )
+
+    # SFT on the dataset if training statistics are required
+    sft_model_path = None
+    if cfg.filter in ("attribution", "loss", "trackstar"):
+        sft_model_path = sft_full(
+            ds, eval_ds, cfg, tokenizer, data_config, sft_path, initial_sft_run_name
         )
 
-    # Add original index column so we can map back after train_test_split shuffles
-    orig_dataset = orig_dataset.add_column("_orig_idx", list(range(len(orig_dataset))))
+        # Destroy NCCL process group before launching multi-GPU subprocesses
+        # to free GPU NCCL resources. The subprocess manages its own dist.
+        if dist.is_initialized():
+            dist.destroy_process_group()
 
-    # Split original dataset (same seed ensures consistent eval set)
-    print("Splitting...")
-    orig_split = orig_dataset.train_test_split(test_size=0.05, seed=args.seed)
-    orig_train, orig_eval = orig_split["train"], orig_split["test"]
+    # Collect artifacts for filtering using evaluation set
+    grad_ds = None
+    if cfg.filter in ("attribution", "loss"):
+        # Collect gradients and final losses from the fine-tuned model
+        if local_rank == 0:
+            build_index(
+                cfg, index_path, train_split, str(sft_model_path), rank=local_rank
+            )
+        if is_distributed:
+            _file_barrier(index_path, run_id, local_rank, world_size)
 
-    model_name = args.model.split("/")[-1]
-    dataset_name = args.dataset.split("/")[-1]
+        grad_ds = load_gradient_dataset(index_path, structured=False)
+        grad_ds.set_format("torch")
+    elif cfg.filter == "trackstar":
+        if local_rank == 0:
+            collect_trackstar_scores(
+                cfg, trackstar_path, train_split, eval_split, model=str(sft_model_path)
+            )
+        if is_distributed:
+            _file_barrier(trackstar_path, run_id, local_rank, world_size)
 
-    lora_suffix = "_lora" if args.use_lora else ""
-    proj_suffix = f"_p{args.projection_dim}" if args.projection_dim != 16 else ""
+    # Filter the training set
+    if local_rank == 0:
+        print("Filtering...")
 
-    if args.filter in ("attribution", "loss"):
-        # Step 1: SFT on the full dataset so gradients are meaningful
-        sft_dir = f"examples/runs/{model_name}_{dataset_name}_sft{lora_suffix}"
-        sft_model_path = sft_full(args, sft_dir)
+    if cfg.filter == "trackstar":
+        scores = load_scores(trackstar_path / "scores")
+        scores = torch.from_numpy(scores[:].flatten().astype("float32"))
 
-        # Step 2: Build gradient index using the finetuned checkpoint
-        if not args.index_dataset:
-            args.index_dataset = (
-                f"examples/runs/{model_name}_{dataset_name}"
-                f"_index{lora_suffix}{proj_suffix}"
+        if local_rank == 0:
+            print(
+                f"Trackstar score stats: min={scores.min():.4f}, "
+                f"max={scores.max():.4f}, "
+                f"mean={scores.mean():.4f}, "
+                f"std={scores.std():.4f}"
             )
 
-        build_index(args, args.index_dataset, model=sft_model_path)
-        grad_dataset = load_gradient_dataset(Path(args.index_dataset), structured=False)
-
-        # Split gradient dataset the same way
-        grad_split = grad_dataset.train_test_split(test_size=0.05, seed=args.seed)
-        grad_train = grad_split["train"]
-        grad_train.set_format("torch")
-
-    elif args.filter == "trackstar":
-        # Step 1: SFT on the full dataset so gradients are meaningful
-        sft_dir = f"examples/runs/{model_name}_{dataset_name}_sft{lora_suffix}"
-        sft_model_path = sft_full(args, sft_dir)
-
-        # Step 2: Run trackstar pipeline for scoring
-        trackstar_path = (
-            f"examples/runs/{model_name}_{dataset_name}"
-            f"_trackstar{lora_suffix}{proj_suffix}"
-        )
-        run_trackstar(
-            args,
-            trackstar_path,
-            model=sft_model_path,
-            num_gpus=torch.cuda.device_count(),
-        )
-
-    # Step 3: Filter the training set
-    print("Filtering...")
-    if args.num_examples == 0:
-        train = orig_train
-    elif args.filter == "trackstar":
-        scores_path = Path(trackstar_path) / "scores"
-        scores = load_scores(scores_path)
-        # Scores are in original dataset order (before train/test split).
-        # Use _orig_idx to map train split positions to original indices.
-        all_scores = torch.from_numpy(scores[:].flatten().astype("float32"))
-        train_orig_indices = torch.tensor(orig_train["_orig_idx"])
-        train_scores = all_scores[train_orig_indices]
-
-        print(
-            f"Trackstar score stats: min={train_scores.min():.4f}, "
-            f"max={train_scores.max():.4f}, "
-            f"mean={train_scores.mean():.4f}, "
-            f"std={train_scores.std():.4f}"
-        )
-
-        sorted_local = torch.argsort(train_scores)
+        sorted_local = torch.argsort(scores)
         selected_indices = (
-            sorted_local[: args.num_examples]
-            if args.lowest
-            else sorted_local[-args.num_examples :]
+            sorted_local[: cfg.num_examples]
+            if cfg.lowest
+            else sorted_local[-cfg.num_examples :]
         )
-        train = orig_train.select(selected_indices)
-    elif args.filter == "attribution":
-        selected_indices = _get_attribution_indices(
-            args, grad_train, run_name, query_method=args.query_method
-        )
-        train = orig_train.select(selected_indices)
-    elif args.filter == "classification":
-        if "score" in orig_train.column_names:
-            train = orig_train.sort("score", reverse=not args.lowest)
-            train = train.select(range(min(args.num_examples, len(train))))
+        selected_indices, _ = selected_indices.sort()
+        train = ds.select(selected_indices)
+    elif cfg.filter == "attribution":
+        selected_indices = _get_attribution_indices(cfg, grad_ds, run_name)
+        train = ds.select(selected_indices)
+    elif cfg.filter == "classification":
+        if "score" in ds.column_names:
+            train = ds.sort("score", reverse=not cfg.lowest)
+            train = train.select(range(min(cfg.num_examples, len(train))))
         else:
             ranks = {"excellent": 4, "good": 3, "average": 2, "poor": 1, "very poor": 0}
 
@@ -607,70 +783,85 @@ def main(
                 return {"_q": ranks.get(q, -1)}
 
             train = (
-                orig_train.map(add_rank)
+                ds.map(add_rank)
                 .filter(lambda x: x["_q"] >= 0)
-                .sort("_q", reverse=not args.lowest)
-                .select(range(min(args.num_examples, len(orig_train))))
-                .remove_columns("_q")
+                .sort("_q", reverse=not cfg.lowest)
             )
-    elif args.filter == "loss":
-        grad_train_loss = grad_train.map(
+            train = train.select(
+                range(min(cfg.num_examples, len(train)))
+            ).remove_columns("_q")
+        # Restore original order so the sampler mapping is well-defined
+        train = train.sort("_orig_idx")
+    elif cfg.filter == "loss":
+        # Filter based on the final item loss
+        grad_loss = grad_ds.map(
             lambda x: {"loss_val": x["loss"].item()},
         )
-        sorted_scores = torch.argsort(torch.tensor(grad_train_loss["loss_val"]))
+        sorted_scores = torch.argsort(torch.tensor(grad_loss["loss_val"]))
         selected_indices = (
-            sorted_scores[: args.num_examples]
-            if args.lowest
-            else sorted_scores[-args.num_examples :]
+            sorted_scores[: cfg.num_examples]
+            if cfg.lowest
+            else sorted_scores[-cfg.num_examples :]
         )
-        train = orig_train.select(selected_indices)
-    elif args.filter == "random":
-        train = orig_train.select(range(min(args.num_examples, len(orig_train))))
+        selected_indices, _ = selected_indices.sort()
+        train = ds.select(selected_indices)
+    elif cfg.filter == "random":
+        generator = torch.Generator().manual_seed(cfg.seed)
+        perm = torch.randperm(len(ds), generator=generator)
+        selected_indices = perm[: min(cfg.num_examples, len(ds))]
+        selected_indices, _ = selected_indices.sort()
+        train = ds.select(selected_indices)
     else:
-        raise ValueError(f"Invalid filter: {args.filter}")
+        raise ValueError(f"Invalid filter: {cfg.filter}")
 
-    eval_ds = orig_eval
+    # Build the ordered sampler before removing _orig_idx.
+    # The sampler replays randperm(full_dataset_size) each epoch and yields
+    # only positions corresponding to items kept after filtering, so the
+    # retrain sees items in the same order as the original full-dataset run.
+    sampler = None
+    if cfg.ordered:
+        orig_to_pos = {int(idx): pos for pos, idx in enumerate(train["_orig_idx"])}
+        sampler = OrderedFilterSampler(len(ds), orig_to_pos, cfg.seed)
 
-    # Remove internal index column before training
     if "_orig_idx" in train.column_names:
         train = train.remove_columns("_orig_idx")
-    if "_orig_idx" in eval_ds.column_names:
-        eval_ds = eval_ds.remove_columns("_orig_idx")
 
-    # Step 4: SFT from the base model on the filtered subset
-    tokenizer = AutoTokenizer.from_pretrained(args.model, max_length=8192)
-    data_config = DataConfig(
-        prompt_column=args.prompt_column,
-        completion_column=args.completion_column,
-        conversation_column=args.conversation_column,
-    )
+    # Tokenize and retrain from the base model on the filtered subset
+    if local_rank == 0:
+        print(f"Training on {len(train)} examples out of {len(ds)}.")
 
     train = train.map(
         tokenize,
         batched=True,
-        fn_kwargs=dict(args=data_config, tokenizer=tokenizer),
+        fn_kwargs=dict(args=data_config, tokenizer=tokenizer, max_length=2048),
     )
     eval_ds = eval_ds.map(
         tokenize,
         batched=True,
-        fn_kwargs=dict(args=data_config, tokenizer=tokenizer),
+        fn_kwargs=dict(args=data_config, tokenizer=tokenizer, max_length=2048),
     )
 
-    print(f"Training on {len(train)} examples, evaluating on {len(eval_ds)} examples.")
     metrics = run_sft(
-        args, train, eval_ds, f"examples/runs/{run_name}", run_name=run_name
+        cfg,
+        train,
+        eval_ds,
+        Path(f"examples/runs/{run_name}"),
+        run_name=run_name,
+        sampler=sampler,
     )
 
-    print(f"\n{'='*60}")
-    print(f"Run: {run_name}")
-    print(f"Filter: {args.filter}")
-    print(f"Num training examples: {len(train)}")
-    if metrics:
-        print(f"Final eval loss: {metrics.get('eval_loss', 'N/A')}")
-    print(f"{'='*60}\n")
+    if local_rank == 0:
+        print(f"\n{'='*60}")
+        print(f"Run: {run_name}")
+        print(f"Filter: {cfg.filter}")
+        print(f"Num training examples: {len(train)}")
+        if metrics:
+            print(f"Final train loss: {metrics.get('train_loss', 'N/A')}")
+            print(f"Final eval loss: {metrics.get('eval_loss', 'N/A')}")
+        print(f"{'='*60}\n")
 
 
 if __name__ == "__main__":
-    args = parse(FilterConfig)
+    cfg = parse(FilterConfig)
 
-    main(args)
+    main(cfg)

--- a/examples/less.py
+++ b/examples/less.py
@@ -7,6 +7,7 @@ import logging
 import math
 import os
 import subprocess
+import sys
 import time
 import zipfile
 from dataclasses import dataclass
@@ -204,7 +205,7 @@ def run_sft(
 
     trainer = SFTTrainer(
         model=model,  # type: ignore
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         train_dataset=ds,
         args=SFTConfig(
             max_length=8192,
@@ -357,6 +358,8 @@ def build_subset_indices(
             continue
 
         cmd = [
+            sys.executable,
+            "-m",
             "bergson",
             "build",
             str(sub_index),
@@ -481,15 +484,23 @@ def _compute_epoch_scores(
 
     # Stack per-subject mean gradients into a (num_subjects, grad_dim) tensor
     query = torch.stack(eval_queries)
-    query /= query.norm(dim=-1, keepdim=True)
+    query_norms = query.norm(dim=-1, keepdim=True)
+    zero_query = (query_norms == 0).sum().item()
+    if zero_query:
+        print(f"WARNING: {zero_query}/{len(query)} eval query gradients have zero norm")
+    query = torch.nan_to_num(query / query_norms)
 
     # Score the training set
-    acc = {"scores": []}
+    acc = {"scores": [], "zero_norm_count": 0, "total_count": 0}
 
     def score_nearest(batch):
         gradients_batch = batch.cuda()
 
-        gradients_batch /= gradients_batch.norm(dim=1, keepdim=True)
+        norms = gradients_batch.norm(dim=1, keepdim=True)
+        acc["zero_norm_count"] += (norms == 0).sum().item()
+        acc["total_count"] += gradients_batch.shape[0]
+        gradients_batch = torch.nan_to_num(gradients_batch / norms)
+
         batch_scores = gradients_batch @ query.T
 
         # Take the maximum batch score for each item in the batch
@@ -504,6 +515,15 @@ def _compute_epoch_scores(
         batched=True,
         batch_size=cfg.map_batch_size,
     )
+
+    zero_pct = acc["zero_norm_count"] / max(acc["total_count"], 1) * 100
+    print(
+        f"Zero-norm train gradients: {acc['zero_norm_count']}/{acc['total_count']} "
+        f"({zero_pct:.2f}%)"
+    )
+    if zero_pct > 1:
+        print("WARNING: >1% zero-norm gradients — this may indicate a bug")
+
     return torch.cat(acc["scores"], dim=0).cuda()
 
 
@@ -723,10 +743,13 @@ def main(
 
     # Build gradient indices and score at each warmup epoch checkpoint,
     # weighting by the checkpoint's learning rate, then sum for final scores.
-    checkpoint_dirs = sorted(warmup_path.glob("checkpoint-*"))
-    assert checkpoint_dirs, f"No checkpoints found in {warmup_path}"
+    all_checkpoint_dirs = sorted(warmup_path.glob("checkpoint-*"))
+    assert all_checkpoint_dirs, f"No checkpoints found in {warmup_path}"
+    # TODO: use all checkpoints once fp16 eval index bug is fixed
+    checkpoint_dirs = [all_checkpoint_dirs[0], all_checkpoint_dirs[-1]]
     print(
-        f"Using {len(checkpoint_dirs)} checkpoints: {[d.name for d in checkpoint_dirs]}"
+        f"Using {len(checkpoint_dirs)}/{len(all_checkpoint_dirs)} checkpoints: "
+        f"{[d.name for d in checkpoint_dirs]}"
     )
 
     accumulated_scores: Tensor | None = None
@@ -741,7 +764,14 @@ def main(
         epoch_train_index = train_index_path / ckpt_dir.name
 
         lr: float = _get_checkpoint_lr(ckpt_dir)
-        print(f"Epoch checkpoint: {ckpt_dir.name}, lr={lr:.6e}")
+        # Use checkpoint-106's lr as a stand-in when lr is zero (end of cosine)
+        if lr == 0:
+            lr = 1.0
+            print(
+                f"Epoch checkpoint: {ckpt_dir.name}, lr=0 -> using lr=1.0 (equal weight)"
+            )
+        else:
+            print(f"Epoch checkpoint: {ckpt_dir.name}, lr={lr:.6e}")
 
         if local_rank == 0:
             # Use 1 GPU for eval (subjects have ~100 examples each)
@@ -762,37 +792,52 @@ def main(
                 adam_path=str(ckpt_dir),
             )
 
-        _file_barrier(eval_index_path, run_id, local_rank, world_size)
-
-        # Load train gradients for this epoch
-        train_grad_parts = []
-        for subdir in sorted(epoch_train_index.iterdir()):
-            if subdir.is_dir():
-                grad_ds = load_gradient_dataset(subdir, structured=False)
-                grad_ds = grad_ds.add_column("ds_name", [subdir.stem] * len(grad_ds))
-                train_grad_parts.append(grad_ds)
-
-        train_grad_ds = concatenate_datasets(train_grad_parts)
-        train_grad_ds.set_format("torch")
-
-        epoch_scores = _compute_epoch_scores(cfg, train_grad_ds, epoch_eval_index)
-        weighted_scores = epoch_scores * lr
-
-        if accumulated_scores is None:
-            accumulated_scores = weighted_scores
-        else:
-            accumulated_scores += weighted_scores
-
-        print(
-            f"Epoch {ckpt_dir.name} scores: "
-            f"mean={epoch_scores.mean():.4f}, lr={lr:.6e}, "
-            f"weighted_mean={weighted_scores.mean():.6e}"
+        _file_barrier(
+            eval_index_path, f"{run_id}_{ckpt_dir.name}", local_rank, world_size
         )
 
-    if local_rank == 0:
-        print("\nSelecting from accumulated lr-weighted scores...")
+        # Score on rank 0
+        if local_rank == 0:
+            train_grad_parts = []
+            for subdir in sorted(epoch_train_index.iterdir()):
+                if subdir.is_dir():
+                    grad_ds = load_gradient_dataset(subdir, structured=False)
+                    grad_ds = grad_ds.add_column(
+                        "ds_name", [subdir.stem] * len(grad_ds)
+                    )
+                    train_grad_parts.append(grad_ds)
 
-    selected_indices = _select_from_scores(cfg, accumulated_scores, scores_path)
+            train_grad_ds = concatenate_datasets(train_grad_parts)
+            train_grad_ds.set_format("torch")
+
+            epoch_scores = _compute_epoch_scores(cfg, train_grad_ds, epoch_eval_index)
+            weighted_scores = epoch_scores * lr
+
+            if accumulated_scores is None:
+                accumulated_scores = weighted_scores
+            else:
+                accumulated_scores += weighted_scores
+
+            print(
+                f"Epoch {ckpt_dir.name} scores: "
+                f"mean={epoch_scores.mean():.4f}, lr={lr:.6e}, "
+                f"weighted_mean={weighted_scores.mean():.6e}"
+            )
+            del train_grad_ds, train_grad_parts
+
+    # Scoring runs on rank 0 only; broadcast selected_indices to all ranks
+    if local_rank == 0:
+        assert accumulated_scores is not None
+        print("\nSelecting from accumulated lr-weighted scores...")
+        selected_indices = _select_from_scores(cfg, accumulated_scores, scores_path)
+        torch.save(selected_indices, scores_path.parent / "selected_indices.pt")
+
+    _file_barrier(scores_path.parent, "scoring", local_rank, world_size)
+
+    if local_rank != 0:
+        selected_indices = torch.load(
+            scores_path.parent / "selected_indices.pt", map_location="cpu"
+        )
     filtered_ds = ds.select(selected_indices)
 
     # Build the ordered sampler before removing _orig_idx.
@@ -821,22 +866,28 @@ def main(
     )
     print(f"SFT checkpoint saved to {final_path}")
 
-    # Load model from final checkpoint
-    final_model = AutoModelForCausalLM.from_pretrained(final_path)
+    # Re-init dist for MMLU eval (run_sft destroys the process group)
+    if not dist.is_initialized() and world_size > 1:
+        dist.init_process_group("nccl")
+
+    final_model = AutoModelForCausalLM.from_pretrained(
+        final_path, device_map={"": f"cuda:{local_rank}"}, torch_dtype=torch.bfloat16
+    )
     tokenizer = AutoTokenizer.from_pretrained(final_path)
 
-    # Evaluate on MMLU (limit to test subjects in test mode)
     eval_subjects = None
     if cfg.test:
         eval_subjects = sorted(p.name for p in eval_data_path.iterdir() if p.is_dir())
-    mmlu_results = evaluate_mmlu(final_model, tokenizer, subjects=eval_subjects)
+    mmlu_results = evaluate_mmlu(
+        final_model, tokenizer, subjects=eval_subjects, batch_size=32
+    )
 
-    print(f"SFT checkpoint saved to {final_path}")
-    print(f"\n{'='*60}")
-    print(f"MMLU 5-shot accuracy: {mmlu_results['overall_acc']:.4f}")
-    for subject, acc in sorted(mmlu_results["subject_accs"].items()):
-        print(f"  {subject}: {acc:.4f}")
-    print(f"{'='*60}\n")
+    if local_rank == 0:
+        print(f"\n{'='*60}")
+        print(f"MMLU 5-shot accuracy: {mmlu_results['overall_acc']:.4f}")
+        for subject, acc in sorted(mmlu_results["subject_accs"].items()):
+            print(f"  {subject}: {acc:.4f}")
+        print(f"{'='*60}\n")
 
 
 if __name__ == "__main__":

--- a/examples/less.py
+++ b/examples/less.py
@@ -1,0 +1,845 @@
+"""Launch this script with torchrun.
+torchrun --nproc_per_node 8 -m examples.less --pdbs 4
+"""
+
+import gc
+import logging
+import math
+import os
+import subprocess
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import torch
+import torch.distributed as dist
+from datasets import Dataset, concatenate_datasets, load_dataset
+from huggingface_hub import hf_hub_download
+from lm_eval import evaluator
+from lm_eval.models.huggingface import HFLM
+from peft import LoraConfig, get_peft_model
+from simple_parsing import parse
+from torch import Tensor
+from torch.utils.data import Sampler
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from trl import SFTConfig, SFTTrainer
+
+from bergson.config import DataConfig
+from bergson.data import load_gradient_dataset, tokenize
+from bergson.utils.utils import assert_type
+
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+@dataclass
+class LESSConfig:
+    """Config for building the index and running the model/dataset pipeline."""
+
+    model: str = "meta-llama/Llama-2-7b-hf"
+    """Model to load."""
+
+    split: str = "train"
+
+    name: str | None = None
+    """Name of the run, used to save the model and tokenizer."""
+
+    num_examples: int = 5_000
+    """Number of items to select from the training set after filtering."""
+
+    eval_ds: Literal["mmlu"] = "mmlu"
+
+    eval_split: str = "test"
+
+    eval_prompt_column: str = "inputs"
+    """Column in the dataset that contains the prompts."""
+
+    eval_completion_column: str = "targets"
+    """Optional column in the dataset that contains the completions."""
+
+    eval_conversation_column: str = ""
+
+    map_batch_size: int = 512
+    """Batch size for processing the dataset."""
+
+    seed: int = 42
+    """Seed for reproducibility."""
+
+    lowest: bool = False
+    """Select the lowest scores."""
+
+    warmup_epochs: int = 4
+    """Number of epochs to train for."""
+
+    warmup_fraction: float = 0.05
+
+    lora_rank: int = 128
+    """LoRA rank."""
+
+    projection_dim: int = 16
+    """Projection dimension for gradient index."""
+
+    pdbs: int = 1
+    "Per-device batch size"
+
+    learning_rate: float = 2e-5
+
+    precision: str = "fp32"
+
+    subset: str = ""
+
+    test: bool = False
+
+
+def set_seeds(seed: int):
+    """Set all random seeds for reproducibility."""
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+
+def download_less(rank: int = 0):
+    final_path = Path("runs/less/extracted_data")
+
+    # Skip if already extracted (avoids race condition under torchrun)
+    if (final_path / "data").exists() or rank != 0:
+        return final_path
+
+    # Download the zip file
+    path = hf_hub_download(
+        repo_id="princeton-nlp/less_data", filename="less-data.zip", repo_type="dataset"
+    )
+
+    # Unzip it
+    with zipfile.ZipFile(path, "r") as zip_ref:
+        zip_ref.extractall(final_path)
+
+    return final_path
+
+
+class OrderedFilterSampler(Sampler[int]):
+    """Replays the full-dataset shuffle, yielding only selected items.
+
+    Generates ``randperm(full_dataset_size)`` each epoch using a seeded
+    generator, then yields only positions that correspond to items kept
+    after filtering.  This ensures the filtered retrain sees items in the
+    same order the original full-dataset SFT run would have used, with
+    removed items simply skipped.
+
+    Each call to ``__iter__`` advances the generator state, so multi-epoch
+    training produces different (but deterministic) orderings per epoch,
+    matching the behaviour of ``RandomSampler``.
+    """
+
+    def __init__(
+        self,
+        full_dataset_size: int,
+        orig_to_pos: dict[int, int],
+        seed: int,
+    ):
+        self.full_size = full_dataset_size
+        self.orig_to_pos = orig_to_pos
+        self.generator = torch.Generator()
+        self.generator.manual_seed(seed)
+
+    def __iter__(self):
+        perm = torch.randperm(self.full_size, generator=self.generator)
+        for idx in perm.tolist():
+            if idx in self.orig_to_pos:
+                yield self.orig_to_pos[idx]
+
+    def __len__(self) -> int:
+        return len(self.orig_to_pos)
+
+
+def run_sft(
+    cfg: LESSConfig,
+    ds: Dataset,
+    output_path: Path,
+    num_epochs: int,
+    tokenizer,
+    data_config: DataConfig,
+    run_name: str | None = None,
+    sampler: Sampler[int] | None = None,
+):
+    """SFT with HF Trainer, which handles DDP automatically.
+    Returns the final eval metrics."""
+    # Check for actual model files, not just directory existence
+    has_model = (output_path / "config.json").exists() or (
+        output_path / "adapter_config.json"
+    ).exists()
+    if has_model:
+        print(f"SFT checkpoint already exists at {output_path}, skipping.")
+        return output_path
+
+    ds = ds.map(
+        tokenize,
+        batched=True,
+        fn_kwargs=dict(args=data_config, tokenizer=tokenizer, max_length=2048),
+    )
+
+    print(f"SFT on ({len(ds)} examples)...")
+
+    model = AutoModelForCausalLM.from_pretrained(
+        cfg.model,
+        dtype=torch.float32,
+    )
+
+    lora_config = LoraConfig(
+        r=cfg.lora_rank,
+        lora_alpha=512,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        lora_dropout=0.1,
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+    model = get_peft_model(model, lora_config)  # type: ignore
+    model.print_trainable_parameters()  # type: ignore
+
+    effective_batch_size = 128
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    grad_acc_steps = effective_batch_size // world_size // cfg.pdbs
+    # num_train_steps = (len(train) // effective_batch_size) * num_epochs
+    # eval_steps = max(1, num_train_steps // 5)
+
+    trainer = SFTTrainer(
+        model=model,  # type: ignore
+        tokenizer=tokenizer,
+        train_dataset=ds,
+        args=SFTConfig(
+            max_length=8192,
+            packing=True,
+            output_dir=str(output_path),
+            per_device_train_batch_size=cfg.pdbs,
+            per_device_eval_batch_size=cfg.pdbs,
+            gradient_accumulation_steps=grad_acc_steps,
+            learning_rate=cfg.learning_rate,
+            num_train_epochs=num_epochs,
+            warmup_ratio=0.05,
+            lr_scheduler_type="cosine",
+            bf16=True,
+            logging_steps=1,
+            save_strategy="epoch",
+            # eval_strategy="steps",
+            # eval_steps=eval_steps,
+            save_total_limit=num_epochs,
+            dataloader_drop_last=True,
+            ddp_find_unused_parameters=False,
+            report_to="wandb",
+            dataset_kwargs={"skip_prepare_dataset": True},
+            seed=cfg.seed,
+            run_name=run_name,
+        ),
+    )
+
+    # Override the Trainer's default RandomSampler to replay the
+    # full-dataset shuffle order with unselected items removed.
+    if sampler is not None:
+        trainer._get_train_sampler = lambda _ds=None: sampler  # type: ignore[assignment]
+
+    trainer.train()
+    trainer.save_model(str(output_path))
+    tokenizer.save_pretrained(output_path)
+
+    print(f"SFT checkpoint saved to {output_path}")
+
+    # Free GPU memory so subprocesses (bergson build) can use it.
+    # empty_cache is needed here to release memory to a *separate process*.
+    trainer.model.cpu()
+    if hasattr(trainer, "optimizer") and trainer.optimizer is not None:
+        # Move optimizer state off GPU
+        for state in trainer.optimizer.state.values():
+            for k, v in state.items():
+                if isinstance(v, torch.Tensor):
+                    state[k] = v.cpu()
+    del trainer, model
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # Destroy NCCL process group before launching multi-GPU subprocesses
+    # to free GPU NCCL resources. The subprocess manages its own dist.
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _file_barrier(
+    sentinel_dir: Path,
+    run_id: str,
+    local_rank: int,
+    world_size: int,
+):
+    """File-based barrier with cleanup.
+
+    Protocol:
+    1. Rank 0 creates the sentinel after finishing its subprocess.
+    2. Other ranks poll until the sentinel exists.
+    3. Each rank touches an ack file.
+    4. Rank 0 waits for all acks, then cleans up everything.
+    """
+    sentinel = sentinel_dir / f".barrier_{run_id}"
+    ack = sentinel_dir / f".ack_{run_id}_{local_rank}"
+
+    if local_rank == 0:
+        sentinel_dir.mkdir(parents=True, exist_ok=True)
+        sentinel.touch()
+    else:
+        while not sentinel.exists():
+            time.sleep(1)
+
+    ack.touch()
+
+    if local_rank == 0:
+        acks = [sentinel_dir / f".ack_{run_id}_{r}" for r in range(world_size)]
+        while not all(p.exists() for p in acks):
+            time.sleep(0.5)
+        sentinel.unlink(missing_ok=True)
+        for p in acks:
+            p.unlink(missing_ok=True)
+
+
+def _clean_dist_env() -> dict[str, str]:
+    """Return os.environ without torchrun distributed variables.
+
+    Subprocesses that manage their own distributed setup (bergson build,
+    bergson trackstar) must not inherit the parent torchrun's env vars.
+    """
+    _TORCHRUN_ENV_VARS = {
+        "RANK",
+        "LOCAL_RANK",
+        "WORLD_SIZE",
+        "LOCAL_WORLD_SIZE",
+        "GROUP_RANK",
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "TORCHELASTIC_RUN_ID",
+        "TORCHELASTIC_RESTART_COUNT",
+        "TORCHELASTIC_MAX_RESTARTS",
+        "TORCHELASTIC_USE_AGENT_STORE",
+    }
+
+    return {k: v for k, v in os.environ.items() if k not in _TORCHRUN_ENV_VARS}
+
+
+def build_subset_indices(
+    cfg: LESSConfig,
+    index_path: Path,
+    model: str,
+    data_path: Path,
+    format_template: str = "",
+    conversation_column: str = "",
+    adam_path: str = "",
+    nproc_per_node: int = 0,
+) -> None:
+    """Build a gradient index per subset found under *data_path*.
+
+    Each subdirectory is treated as a subset.  The dataset is resolved as
+    an HF ``save_to_disk`` directory (has ``dataset_info.json``) or the
+    first ``*.jsonl`` file found.
+    """
+    subsets: dict[str, str] = {}
+    for sub in sorted(data_path.iterdir()):
+        if not sub.is_dir():
+            continue
+        if (sub / "dataset_info.json").exists():
+            subsets[sub.name] = str(sub)
+        else:
+            jsonl_files = list(sub.glob("*.jsonl"))
+            if jsonl_files:
+                subsets[sub.name] = str(jsonl_files[0])
+
+    assert subsets, f"No subsets found under {data_path}"
+    print(f"Building {len(subsets)} subset indices under {index_path}")
+
+    for name, dataset_str in subsets.items():
+        sub_index = index_path / name
+        if sub_index.exists():
+            print(f"Skipping {name} (already built)")
+            continue
+
+        cmd = [
+            "bergson",
+            "build",
+            str(sub_index),
+            "--model",
+            model,
+            "--dataset",
+            dataset_str,
+            "--truncation",
+            "--projection_dim",
+            str(cfg.projection_dim),
+            "--token_batch_size",
+            "4096",
+            "--precision",
+            cfg.precision,
+            "--overwrite",
+        ]
+        if adam_path:
+            cmd += ["--adam_state_path", adam_path]
+        if format_template:
+            cmd += ["--format_template", format_template]
+        if conversation_column:
+            cmd += ["--conversation_column", conversation_column]
+        if nproc_per_node > 0:
+            cmd += ["--nproc_per_node", str(nproc_per_node)]
+
+        print(f"Building {name}: {' '.join(cmd)}")
+        result = subprocess.run(cmd, env=_clean_dist_env())
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"bergson build failed for {name} (exit code {result.returncode})"
+            )
+
+
+def evaluate_mmlu(model, tokenizer, num_fewshot=5, batch_size=8, subjects=None):
+    """Run MMLU evaluation and return accuracy.
+
+    Args:
+        model: HuggingFace model (already loaded).
+        tokenizer: Corresponding tokenizer.
+        num_fewshot: Number of few-shot examples (default 5).
+        batch_size: Eval batch size.
+        subjects: Optional list of MMLU subjects (e.g. ["abstract_algebra", "anatomy"]).
+                  If None, runs all 57 subjects.
+
+    Returns:
+        dict with "overall_acc" and per-subject "subject_accs".
+    """
+    lm = HFLM(pretrained=model, tokenizer=tokenizer)
+
+    if subjects:
+        tasks = [f"mmlu_{s}" for s in subjects]
+    else:
+        tasks = ["mmlu"]
+
+    results = evaluator.simple_evaluate(
+        model=lm,
+        tasks=tasks,
+        num_fewshot=num_fewshot,
+        batch_size=batch_size,
+    )
+    results = assert_type(dict, results)
+
+    subject_accs = {
+        task_name.removeprefix("mmlu_"): metrics["acc,none"]
+        for task_name, metrics in results["results"].items()
+        if task_name != "mmlu"
+    }
+
+    overall_acc = results["results"].get("mmlu", {}).get("acc,none")
+    if overall_acc is None and subject_accs:
+        overall_acc = sum(subject_accs.values()) / len(subject_accs)
+
+    return {
+        "overall_acc": overall_acc,
+        "subject_accs": subject_accs,
+    }
+
+
+def _get_checkpoint_lr(checkpoint_path: Path) -> float:
+    """Extract the current learning rate from a checkpoint's optimizer state."""
+    opt_path = checkpoint_path / "optimizer.pt"
+    if not opt_path.exists():
+        raise FileNotFoundError(f"No optimizer.pt in {checkpoint_path}")
+    opt_state = torch.load(opt_path, map_location="cpu", weights_only=True)
+    return opt_state["param_groups"][0]["lr"]
+
+
+def _compute_epoch_scores(
+    cfg: LESSConfig,
+    train_grad_ds: Dataset,
+    eval_index_path: Path,
+) -> Tensor:
+    """Compute cosine-similarity scores between train and eval gradients.
+
+    Returns a 1-D tensor of scores (one per training example), without
+    any selection applied.
+    """
+    eval_queries = []
+    for subdir in sorted(eval_index_path.iterdir()):
+        if subdir.is_dir():
+            eval_grad_ds = load_gradient_dataset(subdir, structured=False)
+            eval_grad_ds.set_format("torch")
+
+            # Compute the mean of the gradients in the evaluation subset
+            acc = {"sum": torch.zeros_like(eval_grad_ds[0]["gradients"], device="cuda")}
+
+            def sum_(col):
+                acc["sum"] += col.cuda().sum(0)
+
+            # Do not use num_proc because we are accumulating in a single variable
+            # https://colab.research.google.com/drive/1jCLv31Y4cDfqD0lhO0AnqEv3Or-LLvWe?usp=sharing
+            eval_grad_ds.map(
+                sum_,
+                input_columns="gradients",
+                batched=True,
+                batch_size=cfg.map_batch_size,
+            )
+            query = acc["sum"] / len(eval_grad_ds)
+
+            # Append the mean gradient to the query set
+            eval_queries.append(query)
+
+    # Stack per-subject mean gradients into a (num_subjects, grad_dim) tensor
+    query = torch.stack(eval_queries)
+    query /= query.norm(dim=-1, keepdim=True)
+
+    # Score the training set
+    acc = {"scores": []}
+
+    def score_nearest(batch):
+        gradients_batch = batch.cuda()
+
+        gradients_batch /= gradients_batch.norm(dim=1, keepdim=True)
+        batch_scores = gradients_batch @ query.T
+
+        # Take the maximum batch score for each item in the batch
+        # (query has multiple rows)
+        batch_scores = batch_scores.max(dim=-1).values
+
+        acc["scores"].append(batch_scores)
+
+    train_grad_ds.map(
+        score_nearest,
+        input_columns="gradients",
+        batched=True,
+        batch_size=cfg.map_batch_size,
+    )
+    return torch.cat(acc["scores"], dim=0).cuda()
+
+
+def _select_from_scores(
+    cfg: LESSConfig,
+    importance_scores: Tensor,
+    scores_path: Path,
+) -> Tensor:
+    """Select top-k (or bottom-k) indices from pre-computed scores."""
+    print(
+        f"Score stats: min={importance_scores.min():.4f}, "
+        f"max={importance_scores.max():.4f}, "
+        f"mean={importance_scores.mean():.4f}, "
+        f"std={importance_scores.std():.4f}"
+    )
+
+    print("Saving importance scores to disk.")
+    torch.save(importance_scores, scores_path)
+
+    # Select the indices of the top-k (or bottom-k) scored items
+    sorted_scores = torch.argsort(importance_scores)
+    selected_indices = (
+        sorted_scores[: cfg.num_examples]
+        if cfg.lowest
+        else sorted_scores[-cfg.num_examples :]
+    )
+
+    # Sort so the filtered dataset is in original order (required for the
+    # OrderedFilterSampler mapping)
+    selected_indices, _ = selected_indices.sort()
+    return selected_indices
+
+
+def load_ds(cfg: LESSConfig, rank: int = 0):
+    dataset_paths = download_less(rank)
+
+    if dist.is_initialized():
+        dist.barrier()
+
+    base = dataset_paths / "data"
+
+    # Load and merge train datasets, tagging each with its source name.
+    train_ds_path = base / "train" / "processed"
+    train_datasets = []
+    for ds_name in ["cot", "dolly", "flan_v2", "oasst1"]:
+        ds = load_dataset(
+            "json",
+            data_files=str(train_ds_path / ds_name / "*.jsonl"),
+            split="train",
+        )
+        ds = ds.add_column("ds_name", [ds_name] * len(ds))
+        train_datasets.append(ds)
+
+    train_ds = concatenate_datasets(train_datasets)
+
+    # Add an index column so any shuffles can be undone.
+    train_ds = train_ds.add_column("_orig_idx", list(range(len(train_ds))))
+
+    # Process MMLU eval CSVs into per-subject HF datasets matching the MCQA
+    # template format: question (str), choices (list[str]), answer (int index).
+    eval_path = base / "eval" / "mmlu_processed"
+    eval_path.mkdir(parents=True, exist_ok=True)
+    answer_to_idx = {"A": 0, "B": 1, "C": 2, "D": 3}
+    for csv_file in sorted((base / "eval" / "mmlu" / cfg.eval_split).glob("*.csv")):
+        subject = csv_file.stem.removesuffix(f"_{cfg.eval_split}")
+        subject_path = eval_path / subject
+        if (subject_path / "dataset_info.json").exists():
+            continue
+        ds = load_dataset(
+            "csv",
+            data_files=str(csv_file),
+            column_names=["question", "A", "B", "C", "D", "answer"],
+            split="train",
+        )
+        ds = ds.map(
+            lambda row: {
+                "choices": [row["A"], row["B"], row["C"], row["D"]],
+                "answer": answer_to_idx[row["answer"]],
+            }
+        )
+        ds = ds.remove_columns(["A", "B", "C", "D"])
+        ds.save_to_disk(str(subject_path))
+
+    train_data_config = DataConfig(
+        prompt_column="",
+        completion_column="",
+        conversation_column="messages",
+        truncation=True,
+    )
+
+    return train_ds, train_ds_path, eval_path, train_data_config
+
+
+def build_paths(cfg: LESSConfig):
+    # Set up data paths
+    model_name = cfg.model.split("/")[-1]
+
+    if cfg.test:
+        run_path = Path(
+            f"runs/less-test/{model_name}"
+            f"p{cfg.projection_dim}_s{cfg.seed}_lr{cfg.learning_rate}"
+        )
+    else:
+        run_path = Path(
+            f"runs/less/{model_name}"
+            f"p{cfg.projection_dim}_s{cfg.seed}_lr{cfg.learning_rate}"
+        )
+    os.makedirs(run_path, exist_ok=True)
+
+    run_name = run_path.stem
+    warmup_run_name = f"warmup_{run_path.stem}_{cfg.pdbs}"
+
+    warmup_path = run_path / "warmup"
+    eval_index_path = run_path / "eval_index"
+    train_index_path = run_path / "train_index"
+    final_path = run_path / "filtered_model"
+    scores_path = run_path / "importance_scores.pt"
+
+    return (
+        warmup_path,
+        warmup_run_name,
+        train_index_path,
+        eval_index_path,
+        final_path,
+        run_name,
+        scores_path,
+    )
+
+
+def main(
+    cfg: LESSConfig,
+):
+    set_seeds(cfg.seed)
+
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    run_id = os.environ.get("MASTER_PORT", "0")
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    # Set up data paths
+    (
+        warmup_path,
+        warmup_run_name,
+        train_index_path,
+        eval_index_path,
+        final_path,
+        run_name,
+        scores_path,
+    ) = build_paths(cfg)
+
+    # Load the dataset for training.
+    if cfg.test:
+        # Reduce defaults for quick test runs
+        cfg.num_examples = 20
+        cfg.warmup_epochs = 1
+
+        ds = load_dataset("argilla/magpie-ultra-v1.0", split="train[:100]")
+        ds = ds.select_columns(["conversation"])
+        ds = ds.rename_column("conversation", "messages")
+        ds = ds.add_column("_orig_idx", list(range(len(ds))))
+
+        # Save a small train subset for gradient index building
+        train_data_path = warmup_path.parent / "test_train_data" / "magpie"
+        train_data_path.mkdir(parents=True, exist_ok=True)
+        if not (train_data_path / "dataset_info.json").exists():
+            ds.save_to_disk(str(train_data_path))
+        # Point at the parent so build_subset_indices finds the "magpie" subdir
+        train_data_path = train_data_path.parent
+
+        # Use a couple of MMLU subjects for eval (load full LESS data, then
+        # symlink just 2 subjects into a test-specific eval directory)
+        _, _, full_eval_path, _ = load_ds(cfg)
+        eval_data_path = warmup_path.parent / "test_eval_data"
+        eval_data_path.mkdir(parents=True, exist_ok=True)
+        test_subjects = sorted(p.name for p in full_eval_path.iterdir() if p.is_dir())[
+            :2
+        ]
+        for subj in test_subjects:
+            link = eval_data_path / subj
+            if not link.exists():
+                link.symlink_to((full_eval_path / subj).resolve())
+
+        train_data_config = DataConfig(
+            prompt_column="",
+            completion_column="",
+            conversation_column="messages",
+            truncation=True,
+        )
+    else:
+        ds, train_data_path, eval_data_path, train_data_config = load_ds(cfg)
+
+    # Define data config
+    tokenizer = AutoTokenizer.from_pretrained(cfg.model, max_length=8192)
+
+    # Define the chat template
+    tokenizer.chat_template = (
+        "{% for message in messages %}"
+        "{% if message['role'] == 'user' %}"
+        "[INST] {{ message['content'] }} [/INST]"
+        "{% elif message['role'] == 'assistant' %}"
+        "{{ message['content'] }}{{ eos_token }}"
+        "{% endif %}"
+        "{% endfor %}"
+    )
+
+    warmup_ds = ds.select(range(math.ceil(len(ds) * cfg.warmup_fraction)))
+
+    # Warm up SFT on the dataset
+    run_sft(
+        cfg,
+        warmup_ds,
+        warmup_path,
+        cfg.warmup_epochs,
+        tokenizer,
+        train_data_config,
+        warmup_run_name,
+    )
+
+    # Build gradient indices and score at each warmup epoch checkpoint,
+    # weighting by the checkpoint's learning rate, then sum for final scores.
+    checkpoint_dirs = sorted(warmup_path.glob("checkpoint-*"))
+    assert checkpoint_dirs, f"No checkpoints found in {warmup_path}"
+    print(
+        f"Using {len(checkpoint_dirs)} checkpoints: {[d.name for d in checkpoint_dirs]}"
+    )
+
+    accumulated_scores: Tensor | None = None
+
+    for ckpt_dir in checkpoint_dirs:
+        assert (
+            ckpt_dir / "optimizer.pt"
+        ).exists(), f"Skipping {ckpt_dir.name} (no optimizer.pt)"
+
+        # # e.g. "checkpoint-106"
+        epoch_eval_index = eval_index_path / ckpt_dir.name
+        epoch_train_index = train_index_path / ckpt_dir.name
+
+        lr: float = _get_checkpoint_lr(ckpt_dir)
+        print(f"Epoch checkpoint: {ckpt_dir.name}, lr={lr:.6e}")
+
+        if local_rank == 0:
+            # Use 1 GPU for eval (subjects have ~100 examples each)
+            build_subset_indices(
+                cfg,
+                epoch_eval_index,
+                str(ckpt_dir),
+                eval_data_path,
+                format_template="bergson/templates/mcqa.yaml",
+                nproc_per_node=1,
+            )
+            build_subset_indices(
+                cfg,
+                epoch_train_index,
+                str(ckpt_dir),
+                train_data_path,
+                conversation_column="messages",
+                adam_path=str(ckpt_dir),
+            )
+
+        _file_barrier(eval_index_path, run_id, local_rank, world_size)
+
+        # Load train gradients for this epoch
+        train_grad_parts = []
+        for subdir in sorted(epoch_train_index.iterdir()):
+            if subdir.is_dir():
+                grad_ds = load_gradient_dataset(subdir, structured=False)
+                grad_ds = grad_ds.add_column("ds_name", [subdir.stem] * len(grad_ds))
+                train_grad_parts.append(grad_ds)
+
+        train_grad_ds = concatenate_datasets(train_grad_parts)
+        train_grad_ds.set_format("torch")
+
+        epoch_scores = _compute_epoch_scores(cfg, train_grad_ds, epoch_eval_index)
+        weighted_scores = epoch_scores * lr
+
+        if accumulated_scores is None:
+            accumulated_scores = weighted_scores
+        else:
+            accumulated_scores += weighted_scores
+
+        print(
+            f"Epoch {ckpt_dir.name} scores: "
+            f"mean={epoch_scores.mean():.4f}, lr={lr:.6e}, "
+            f"weighted_mean={weighted_scores.mean():.6e}"
+        )
+
+    if local_rank == 0:
+        print("\nSelecting from accumulated lr-weighted scores...")
+
+    selected_indices = _select_from_scores(cfg, accumulated_scores, scores_path)
+    filtered_ds = ds.select(selected_indices)
+
+    # Build the ordered sampler before removing _orig_idx.
+    # The sampler replays randperm(full_dataset_size) each epoch and yields
+    # only positions corresponding to items kept after filtering, so the
+    # retrain sees items in the same order as the original full-dataset run.
+    orig_to_pos = {int(idx): pos for pos, idx in enumerate(filtered_ds["_orig_idx"])}
+    sampler = OrderedFilterSampler(len(ds), orig_to_pos, cfg.seed)
+
+    if "_orig_idx" in filtered_ds.column_names:
+        filtered_ds = filtered_ds.remove_columns("_orig_idx")
+
+    # Tokenize and retrain from the base model on the filtered subset
+    if local_rank == 0:
+        print(f"Training on {len(filtered_ds)} examples out of {len(ds)}.")
+
+    run_sft(
+        cfg,
+        filtered_ds,
+        final_path,
+        num_epochs=1,
+        run_name=run_name,
+        tokenizer=tokenizer,
+        data_config=train_data_config,
+        sampler=sampler,
+    )
+    print(f"SFT checkpoint saved to {final_path}")
+
+    # Load model from final checkpoint
+    final_model = AutoModelForCausalLM.from_pretrained(final_path)
+    tokenizer = AutoTokenizer.from_pretrained(final_path)
+
+    # Evaluate on MMLU (limit to test subjects in test mode)
+    eval_subjects = None
+    if cfg.test:
+        eval_subjects = sorted(p.name for p in eval_data_path.iterdir() if p.is_dir())
+    mmlu_results = evaluate_mmlu(final_model, tokenizer, subjects=eval_subjects)
+
+    print(f"SFT checkpoint saved to {final_path}")
+    print(f"\n{'='*60}")
+    print(f"MMLU 5-shot accuracy: {mmlu_results['overall_acc']:.4f}")
+    for subject, acc in sorted(mmlu_results["subject_accs"].items()):
+        print(f"  {subject}: {acc:.4f}")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    cfg = parse(LESSConfig)
+
+    main(cfg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ example = [
     "bitsandbytes>=0.49.0",
     "pydantic>=2.12.5",
     "trl",
+    "lm_eval",
+    "sentencepiece"
 ]
 faiss = [
     "faiss-gpu-cu12",

--- a/tests/test_adam_state_loading.py
+++ b/tests/test_adam_state_loading.py
@@ -1,0 +1,93 @@
+import pytest
+import torch
+import torch.nn as nn
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from bergson.gradients import AdamNormalizer
+from bergson.utils.load_adam_state import load_from_optimizer
+
+
+def _create_model():
+    config = AutoConfig.from_pretrained("trl-internal-testing/tiny-Phi3ForCausalLM")
+    return AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
+
+
+def _create_fake_optimizer_state(model, lr=1e-3):
+    """Create a fake optimizer state dict matching the model's parameters."""
+    state = {}
+    param_groups = [{"lr": lr, "params": []}]
+
+    for idx, (name, param) in enumerate(model.named_parameters()):
+        param_groups[0]["params"].append(idx)
+        # Only create exp_avg_sq for 2D (weight) params
+        if param.ndim == 2:
+            state[idx] = {
+                "step": torch.tensor(100),
+                "exp_avg": torch.zeros_like(param),
+                "exp_avg_sq": torch.rand_like(param).abs() * 0.01,
+            }
+        else:
+            state[idx] = {
+                "step": torch.tensor(100),
+                "exp_avg": torch.zeros_like(param),
+                "exp_avg_sq": torch.rand_like(param).abs() * 0.01,
+            }
+
+    return {"state": state, "param_groups": param_groups}
+
+
+def test_load_from_optimizer_file(tmp_path):
+    """Load normalizers from a bare optimizer.pt file."""
+    model = _create_model()
+    opt_state = _create_fake_optimizer_state(model)
+
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    normalizers = load_from_optimizer(model, str(opt_path))
+
+    # Should have normalizers for all linear layers with 2D weights
+    assert len(normalizers) > 0
+    for name, norm in normalizers.items():
+        assert isinstance(norm, AdamNormalizer)
+        assert norm.weight_avg_sq.ndim == 2
+
+
+def test_load_from_checkpoint_dir(tmp_path):
+    """Load normalizers from a checkpoint directory containing optimizer.pt."""
+    model = _create_model()
+    opt_state = _create_fake_optimizer_state(model)
+
+    checkpoint_dir = tmp_path / "checkpoint-100"
+    checkpoint_dir.mkdir()
+    torch.save(opt_state, checkpoint_dir / "optimizer.pt")
+
+    normalizers = load_from_optimizer(model, str(checkpoint_dir))
+    assert len(normalizers) > 0
+
+
+def test_target_modules_filter(tmp_path):
+    """Only layers in target_modules are loaded."""
+    model = _create_model()
+    opt_state = _create_fake_optimizer_state(model)
+
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    # Get all linear layer names
+    all_linear = {
+        name for name, module in model.named_modules() if isinstance(module, nn.Linear)
+    }
+    # Pick a subset
+    subset = set(list(all_linear)[:2])
+
+    normalizers = load_from_optimizer(model, str(opt_path), target_modules=subset)
+    assert set(normalizers.keys()) == subset
+
+
+def test_missing_optimizer_file(tmp_path):
+    """Error when directory has no optimizer.pt."""
+    model = _create_model()
+
+    with pytest.raises(FileNotFoundError):
+        load_from_optimizer(model, str(tmp_path))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -6,7 +6,12 @@ import pytest
 import torch
 from transformers import AutoModelForCausalLM
 
-from bergson import GradientProcessor, collect_gradients
+from bergson import (
+    CollectorComputer,
+    GradientProcessor,
+    InMemoryCollector,
+    collect_gradients,
+)
 from bergson.config import AttentionConfig, IndexConfig
 from bergson.data import load_gradients
 
@@ -77,6 +82,44 @@ def test_build_consistency(tmp_path: Path, model, dataset):
     first_module_grad = index[index.dtype.names[0]][0]
 
     assert np.allclose(first_module_grad, cached_item_grad, atol=1e-6)
+    assert np.allclose(first_module_grad, cached_item_grad, atol=1e-6)
+    assert np.allclose(first_module_grad, cached_item_grad, atol=1e-3)
+
+    # Test BF16 consistency
+    model = model.to(torch.bfloat16)
+    cfg = IndexConfig(
+        run_path=str(tmp_path),
+        skip_preconditioners=True,
+        token_batch_size=1024,
+        precision="bf16",
+    )
+
+    collector = InMemoryCollector(
+        model.base_model,
+        processor=GradientProcessor(projection_dim=cfg.projection_dim),
+        data=dataset,
+        cfg=cfg,
+    )
+    computer = CollectorComputer(
+        model=model,  # type: ignore
+        data=dataset,
+        collector=collector,
+        batches=[[idx] for idx in range(len(dataset))],
+        cfg=cfg,
+    )
+    computer.run_with_collector_hooks(desc="New worker - Collecting gradients")
+
+    print(list(collector.gradients.keys()))
+    first_bf16_mod_grad = collector.gradients[index.dtype.names[0]][0]
+
+    # Assert BF16 gradients are relatively close to FP32 ones
+    assert (
+        torch.nn.functional.cosine_similarity(
+            first_bf16_mod_grad, torch.from_numpy(cached_item_grad), dim=0
+        )
+        > 0.99
+    )
+    assert np.allclose(first_bf16_mod_grad.float().numpy(), cached_item_grad, atol=1e-3)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
- Always leave optimizers and preconditioners in fp32
- Use mixed precision fwd-bwd

My conclusions from the test below are basically:
- In practice this makes retraining effects in either fp32 or bf16 essentially indistinguishable
- TrackStar in its current form is lame for coreset selection
- Eval selection results TODO
- Single item-based selection results TODO

**Coreset selection** (last regression: https://github.com/EleutherAI/bergson/pull/178):

I tried to repeat the analysis from the last PR but I became suspicious of the results because the training loss drop on this dataset sucks, because the model has already undergone IFT. So I did a second round using Qwen + LoRA + a dataset Qwen's bad at (sheet music) so get a smooth loss drop:

```
 torchrun --nproc_per_node 8 -m examples.filter_data \
    --model Qwen/Qwen2.5-1.5B \
    --dataset sander-wood/irishman \
    --prompt_column "abc notation" \
    --max_samples 10000 \
    --num_examples 1000 \
    --num_epochs 1 \
    --precision fp32 \
    --learning_rate 5e-5 \
    --subset default \
    --filter random 
```

I used an effective batch size of 128, LoRA rank 64, projection dim 16  and took the query over the entire dataset (should not have an eval set for coreset)

**ordered=False Leave-90%-out coreset selection (train loss), seed=42, 10k full dataset** (works, narrowly)

"Attribution": 2.77 (raw grad cosine sim)
Random: 2.52
TrackStar BF16: **2.38**
TrackStar FP32: 2.43
Full dataset: 1.77

**ordered=True Leave-90%-out coreset selection (train loss), seed=42, 50k full dataset** (works, narrowly)

Full dataset: 1.287
Random: 1.878
TrackStar BF16: **1.763**
TrackStar FP32: **1.763**

**ordered=True Leave-80%-out retrain train loss, seed=42, 50k full dataset** (actually kind of sucks because loss does a big spike at the end for trackstar fp16 and bf16, which are almost exactly the same. probably they work better if you can maintain stability still but the gains here aren't large enough for me to keep experimenting).

Full dataset: 1.287
Random: 1.52
TrackStar BF16: 1.58
TrackStar FP32: 1.57

I tried the eval set query filtering, one step closer to the core thing TrackStar is supposed to be good at:

**ordered=True Leave-90%-out retrain eval loss, seed=42, 50k full dataset**

Full dataset:
Random:
TrackStar BF16:
TrackStar FP32:

<img width="1149" height="825" alt="image" src="https://github.com/user-attachments/assets/248aa533-b98a-4658-bfac-277ae130bffc" />


Note that mixed precision attribution matches our mixed precision training so it may have some predictive advantage over single precision attribution.

TODO
- check we maintain correct dtype outside trackstar, in normalizers
- make coreset selection clean for future regression testing