### PR TITLE
Add --force_math_sdp flag and test_numerical_stability command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,20 +183,22 @@ bergson build <output_path> --model <model_name> --force_math_sdp --precision fp
 
 ### Performance impact
 
-The overhead of `--force_math_sdp` varies by model. Benchmarked on A100-80GB with 500 documents from pile-10k:
+The overhead of `--force_math_sdp` and `--precision fp32` varies by model. Benchmarked on A100-80GB with 500 documents from pile-10k:
 
-| Model | Precision | `--force_math_sdp` | Build time | Overhead | Needs it? |
-|-------|-----------|-------------------|------------|----------|-----------|
-| Pythia-160M | bf16 | no | 30.2s | baseline | |
-| Pythia-160M | bf16 | yes | 30.4s | +0.8% | |
-| Pythia-160M | fp32 | no | 35.6s | baseline | |
-| Pythia-160M | fp32 | yes | 39.6s | +11.5% | Yes (needs both) |
-| OLMo-2-1B | bf16 | no | 43.1s | baseline | No |
-| OLMo-2-1B | bf16 | yes | 53.6s | +24.5% | |
-| OLMo-2-7B | bf16 | no | 105.5s | baseline | |
-| OLMo-2-7B | bf16 | yes | 151.1s | +43.2% | Yes (`--force_math_sdp` only) |
-| OLMo-2-7B | fp32 | no | 569.2s | baseline | |
-| OLMo-2-7B | fp32 | yes | 603.6s | +6.1% | |
+| Model | Settings | Build time | vs bf16 baseline |
+|-------|----------|------------|------------------|
+| Pythia-160M | bf16 | 30.2s | — |
+| Pythia-160M | bf16 + `--force_math_sdp` | 30.4s | +0.8% |
+| Pythia-160M | fp32 | 35.6s | +17.9% |
+| Pythia-160M | fp32 + `--force_math_sdp` | 39.6s | +31.1% |
+| OLMo-2-1B | bf16 | 43.1s | — |
+| OLMo-2-1B | bf16 + `--force_math_sdp` | 53.6s | +24.5% |
+| OLMo-2-1B | fp32 | 132.8s | +208.1% |
+| OLMo-2-1B | fp32 + `--force_math_sdp` | 141.8s | +229.0% |
+| OLMo-2-7B | bf16 | 105.5s | — |
+| OLMo-2-7B | bf16 + `--force_math_sdp` | 151.1s | +43.2% |
+| OLMo-2-7B | fp32 | 569.2s | +439.5% |
+| OLMo-2-7B | fp32 + `--force_math_sdp` | 603.6s | +472.1% |
 
 Not all models are affected — run `bergson test_numerical_stability` before enabling these flags to avoid unnecessary overhead.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,43 @@ Where a reward signal is available we compute gradients using a weighted advanta
 bergson build <output_path> --model <model_name> --dataset <dataset_name> --reward_column <reward_column_name>
 ```
 
+## Numerical Stability
+
+Some models produce inconsistent per-example gradients when sequences of different lengths are batched together. This is caused by optimized SDPA attention backends (flash, memory-efficient) computing slightly different results depending on the padding length.
+
+Use the built-in diagnostic to check your model:
+
+```bash
+bergson test_numerical_stability --model <model_name>
+```
+
+This automatically tests escalating configurations and reports exactly which flags (if any) you need. If your model fails the default test, add the recommended flags to your `build`/`score`/`trackstar` commands:
+
+```bash
+bergson build <output_path> --model <model_name> --force_math_sdp
+# or if needed:
+bergson build <output_path> --model <model_name> --force_math_sdp --precision fp32
+```
+
+### Performance impact
+
+The overhead of `--force_math_sdp` varies by model. Benchmarked on A100-80GB with 500 documents from pile-10k:
+
+| Model | Precision | `--force_math_sdp` | Build time | Overhead | Needs it? |
+|-------|-----------|-------------------|------------|----------|-----------|
+| Pythia-160M | bf16 | no | 30.2s | baseline | |
+| Pythia-160M | bf16 | yes | 30.4s | +0.8% | |
+| Pythia-160M | fp32 | no | 35.6s | baseline | |
+| Pythia-160M | fp32 | yes | 39.6s | +11.5% | Yes (needs both) |
+| OLMo-2-1B | bf16 | no | 43.1s | baseline | No |
+| OLMo-2-1B | bf16 | yes | 53.6s | +24.5% | |
+| OLMo-2-7B | bf16 | no | 105.5s | baseline | |
+| OLMo-2-7B | bf16 | yes | 151.1s | +43.2% | Yes (`--force_math_sdp` only) |
+| OLMo-2-7B | fp32 | no | 569.2s | baseline | |
+| OLMo-2-7B | fp32 | yes | 603.6s | +6.1% | |
+
+Not all models are affected — run `bergson test_numerical_stability` before enabling these flags to avoid unnecessary overhead.
+
 # Benchmarks
 
 ![CLI Benchmark](docs/benchmarks/cli_benchmark_NVIDIA_GH200_120GB.png)

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -13,6 +13,7 @@ from .config import (
     ScoreConfig,
     TrackstarConfig,
 )
+from .diagnose import DiagnoseConfig, diagnose
 from .hessians.hessian_approximations import approximate_hessians
 from .magic import MagicConfig, run_magic
 from .query.query_index import query
@@ -150,11 +151,34 @@ class Magic:
 
 
 @dataclass
+class Test_Numerical_Stability:
+    """Test gradient consistency across padding and batch composition.
+
+    Tests whether a model produces consistent gradients regardless of how
+    documents are batched together. If inconsistencies are found, recommends
+    using --force_math_sdp on build/score/trackstar commands."""
+
+    diagnose_cfg: DiagnoseConfig
+
+    def execute(self):
+        """Run the diagnostic."""
+        diagnose(self.diagnose_cfg)
+
+
+@dataclass
 class Main:
     """Routes to the subcommands."""
 
     command: Union[
-        Build, Query, Preconditioners, Reduce, Score, Hessian, Trackstar, Magic
+        Build,
+        Query,
+        Preconditioners,
+        Reduce,
+        Score,
+        Hessian,
+        Trackstar,
+        Magic,
+        Test_Numerical_Stability,
     ]
 
     def execute(self):

--- a/bergson/config.py
+++ b/bergson/config.py
@@ -220,6 +220,12 @@ class IndexConfig:
     overwrite: bool = False
     """Whether to overwrite any existing index in the run path."""
 
+    force_math_sdp: bool = False
+    """Disable flash and memory-efficient SDPA backends, forcing the
+    math-only kernel. Some models produce inconsistent gradients across
+    different padding lengths when using optimized attention backends.
+    Run `bergson diagnose` to check whether your model needs this."""
+
     distributed: DistributedConfig = field(default_factory=DistributedConfig)
     """Configuration for multi-node distributed preconditioner computation."""
 

--- a/bergson/diagnose.py
+++ b/bergson/diagnose.py
@@ -1,0 +1,292 @@
+"""Test gradient consistency across padding and batch composition.
+
+Loads a model and dataset, samples random pairs of documents with different
+lengths, and checks whether the shorter document's gradient changes when
+it is batched alongside a longer document (padding divergence).
+
+Automatically tests escalating configurations (default → force_math_sdp →
+fp32 → both) to determine the minimum settings needed for consistency.
+"""
+
+import random
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from datasets import load_dataset
+from simple_parsing import field
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from bergson.data import pad_and_tensor
+
+
+@dataclass
+class DiagnoseConfig:
+    """Config for the numerical stability test."""
+
+    model: str = "EleutherAI/pythia-160m"
+    """HuggingFace model to test."""
+
+    dataset: str = "NeelNanda/pile-10k"
+    """Dataset to sample document pairs from."""
+
+    split: str = "train"
+    """Dataset split."""
+
+    n_trials: int = 100
+    """Number of random document pairs to test per configuration."""
+
+    seed: int = 42
+    """Random seed for reproducibility."""
+
+    precision: str = field(
+        default="bf16", metadata=dict(choices=["bf16", "fp16", "fp32"])
+    )
+    """Base precision for model parameters."""
+
+    device: str = "cuda:0"
+    """Device to run the test on."""
+
+    max_len: int = 512
+    """Truncate documents longer than this."""
+
+    min_len: int = 4
+    """Skip documents shorter than this."""
+
+    threshold: float = 0.99
+    """Cosine similarity below this is flagged as problematic."""
+
+
+DTYPE_MAP = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+
+
+def _get_example_loss(model, x, y, idx=0):
+    """Get loss for example `idx` in the batch."""
+    logits = model(x).logits[:, :-1]
+    masks = y[:, 1:] != -100
+    per_token = F.cross_entropy(
+        logits.reshape(-1, logits.size(-1)),
+        y[:, 1:].flatten(),
+        reduction="none",
+    ).reshape_as(y[:, 1:])
+    return per_token[idx][masks[idx]].sum()
+
+
+def _measure(model, short_ids, long_ids, device):
+    """Measure gradient cosine similarity: alone vs mixed batch."""
+    x_alone, y_alone, _ = pad_and_tensor([short_ids], device=device)
+    x_mixed, y_mixed, _ = pad_and_tensor([short_ids, long_ids], device=device)
+
+    # Pass 1: alone
+    model.zero_grad()
+    loss_alone = _get_example_loss(model, x_alone, y_alone)
+    loss_alone.backward()
+    grads_alone = {}
+    for n, p in model.named_parameters():
+        if p.grad is not None:
+            grads_alone[n] = p.grad.detach().clone()
+
+    # Pass 2: mixed
+    model.zero_grad()
+    loss_mixed = _get_example_loss(model, x_mixed, y_mixed)
+    loss_mixed.backward()
+
+    dot = 0.0
+    norm_a_sq = 0.0
+    norm_b_sq = 0.0
+    for n, p in model.named_parameters():
+        if p.grad is not None and n in grads_alone:
+            ga = grads_alone[n]
+            gb = p.grad.detach()
+            dot += (ga * gb).sum().item()
+            norm_a_sq += (ga * ga).sum().item()
+            norm_b_sq += (gb * gb).sum().item()
+
+    del grads_alone
+    cos_sim = dot / (norm_a_sq**0.5 * norm_b_sq**0.5 + 1e-12)
+    loss_diff = (loss_mixed - loss_alone).abs().item()
+
+    return cos_sim, loss_diff
+
+
+def _run_trials(model, all_docs, n_trials, seed, threshold, device):
+    """Run n_trials gradient consistency checks. Returns (min_cos_sim, n_flagged, results)."""
+    rng = random.Random(seed)
+    results = []
+
+    for trial in range(n_trials):
+        i, j = rng.sample(range(len(all_docs)), 2)
+        doc_a, doc_b = all_docs[i], all_docs[j]
+        if len(doc_a) > len(doc_b):
+            doc_a, doc_b = doc_b, doc_a
+
+        cos_sim, loss_diff = _measure(model, doc_a, doc_b, device)
+        results.append(
+            {
+                "trial": trial,
+                "short_len": len(doc_a),
+                "long_len": len(doc_b),
+                "ratio": len(doc_b) / len(doc_a),
+                "cos_sim": cos_sim,
+                "loss_diff": loss_diff,
+            }
+        )
+
+    cos_sims = torch.tensor([r["cos_sim"] for r in results])
+    n_flagged = int((cos_sims < threshold).sum().item())
+    return cos_sims.min().item(), n_flagged, results
+
+
+def _print_results(results, threshold):
+    """Print detailed trial results and summary."""
+    cos_sims = torch.tensor([r["cos_sim"] for r in results])
+    n_flagged = int((cos_sims < threshold).sum().item())
+
+    header = (
+        f"{'trial':>6s} {'short':>6s} {'long':>6s} {'ratio':>6s}"
+        f" {'cos_sim':>10s} {'loss_diff':>12s}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        marker = " <<<" if r["cos_sim"] < threshold else ""
+        print(
+            f"{r['trial']:>6d} {r['short_len']:>6d} {r['long_len']:>6d}"
+            f" {r['ratio']:>6.1f} {r['cos_sim']:>10.6f}"
+            f" {r['loss_diff']:>12.6f}{marker}"
+        )
+
+    print()
+    print(
+        f"  Cos sim:  mean={cos_sims.mean():.6f}  std={cos_sims.std():.6f}"
+        f"  min={cos_sims.min():.6f}  max={cos_sims.max():.6f}"
+    )
+    print(f"  Flagged:  {n_flagged}/{len(results)} trials below {threshold}")
+
+
+def diagnose(diagnose_cfg: DiagnoseConfig):
+    """Run the gradient consistency test across escalating configurations."""
+    device = torch.device(
+        diagnose_cfg.device if torch.cuda.is_available() else "cpu"
+    )
+
+    print(f"Model:     {diagnose_cfg.model}")
+    print(f"Precision: {diagnose_cfg.precision}")
+    print(f"Device:    {device}")
+    print(f"Trials:    {diagnose_cfg.n_trials} per configuration")
+    print(f"Threshold: {diagnose_cfg.threshold}")
+
+    # Load and tokenize dataset
+    print(f"\nLoading {diagnose_cfg.dataset}...")
+    tokenizer = AutoTokenizer.from_pretrained(diagnose_cfg.model)
+    ds = load_dataset(diagnose_cfg.dataset, split=diagnose_cfg.split)
+    all_docs = []
+    for row in ds:
+        ids = tokenizer(row["text"])["input_ids"]
+        if len(ids) < diagnose_cfg.min_len:
+            continue
+        if len(ids) > diagnose_cfg.max_len:
+            ids = ids[: diagnose_cfg.max_len]
+        all_docs.append(ids)
+
+    print(
+        f"Documents: {len(all_docs)}"
+        f" (lengths {diagnose_cfg.min_len}-{diagnose_cfg.max_len})"
+    )
+
+    base_precision = diagnose_cfg.precision
+    base_dtype = DTYPE_MAP[base_precision]
+
+    # Define configurations to test in order of escalation.
+    # Each is (label, dtype, force_math_sdp).
+    # We skip configs that would be redundant (e.g. if base is already fp32).
+    configs = [
+        (f"defaults (precision={base_precision})", base_dtype, False),
+        (f"--force_math_sdp (precision={base_precision})", base_dtype, True),
+    ]
+    if base_precision != "fp32":
+        configs.append(("--precision fp32", torch.float32, False))
+        configs.append(("--precision fp32 --force_math_sdp", torch.float32, True))
+
+    config_results = {}  # label -> (n_flagged, min_cos_sim)
+    passing_config = None
+
+    for label, dtype, force_math_sdp in configs:
+        print(f"\n{'=' * 60}")
+        print(f"Testing: {label}")
+        print("=" * 60)
+
+        # Reset SDPA backends before each config
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(True)
+        if force_math_sdp:
+            torch.backends.cuda.enable_flash_sdp(False)
+            torch.backends.cuda.enable_mem_efficient_sdp(False)
+
+        model = AutoModelForCausalLM.from_pretrained(
+            diagnose_cfg.model,
+            torch_dtype=dtype,
+            attn_implementation="sdpa",
+        ).to(device)
+        model.eval()
+
+        min_cos_sim, n_flagged, results = _run_trials(
+            model,
+            all_docs,
+            diagnose_cfg.n_trials,
+            diagnose_cfg.seed,
+            diagnose_cfg.threshold,
+            device,
+        )
+
+        _print_results(results, diagnose_cfg.threshold)
+        config_results[label] = (n_flagged, min_cos_sim)
+
+        del model
+        torch.cuda.synchronize()
+
+        if n_flagged == 0:
+            passing_config = label
+            break
+
+    # Final report
+    print(f"\n{'=' * 60}")
+    print(f"Report for {diagnose_cfg.model}")
+    print("=" * 60)
+
+    for label, (n_flagged, min_cos_sim) in config_results.items():
+        status = "PASS" if n_flagged == 0 else "FAIL"
+        print(f"  {status}  {label}  (min cos_sim={min_cos_sim:.6f})")
+
+    print()
+    first_label = list(config_results.keys())[0]
+    first_n_flagged = config_results[first_label][0]
+
+    if first_n_flagged == 0:
+        print(
+            "RESULT: Gradients are consistent with default settings."
+            " No special flags needed."
+        )
+    elif passing_config is not None:
+        # Extract the flags from the passing config label
+        print(f"RESULT: Gradients require non-default settings for consistency.")
+        print(f"  Minimum required: {passing_config}")
+        # Build the recommended CLI flags
+        flags = []
+        for label, dtype, force_math_sdp in configs:
+            if label == passing_config:
+                if force_math_sdp:
+                    flags.append("--force_math_sdp")
+                if dtype == torch.float32 and base_precision != "fp32":
+                    flags.append("--precision fp32")
+                break
+        if flags:
+            flag_str = " ".join(flags)
+            print(f"\n  Add to your bergson commands:")
+            print(f"    bergson build <run_path> --model {diagnose_cfg.model} {flag_str}")
+    else:
+        print(
+            "RESULT: Gradient inconsistency persists across all tested"
+            " configurations. This model may have architecture-level"
+            " padding sensitivity."
+        )

--- a/bergson/diagnose.py
+++ b/bergson/diagnose.py
@@ -166,9 +166,7 @@ def _print_results(results, threshold):
 
 def diagnose(diagnose_cfg: DiagnoseConfig):
     """Run the gradient consistency test across escalating configurations."""
-    device = torch.device(
-        diagnose_cfg.device if torch.cuda.is_available() else "cpu"
-    )
+    device = torch.device(diagnose_cfg.device if torch.cuda.is_available() else "cpu")
 
     print(f"Model:     {diagnose_cfg.model}")
     print(f"Precision: {diagnose_cfg.precision}")
@@ -269,7 +267,7 @@ def diagnose(diagnose_cfg: DiagnoseConfig):
         )
     elif passing_config is not None:
         # Extract the flags from the passing config label
-        print(f"RESULT: Gradients require non-default settings for consistency.")
+        print("RESULT: Gradients require non-default settings for consistency.")
         print(f"  Minimum required: {passing_config}")
         # Build the recommended CLI flags
         flags = []
@@ -282,8 +280,10 @@ def diagnose(diagnose_cfg: DiagnoseConfig):
                 break
         if flags:
             flag_str = " ".join(flags)
-            print(f"\n  Add to your bergson commands:")
-            print(f"    bergson build <run_path> --model {diagnose_cfg.model} {flag_str}")
+            print("\n  Add to your bergson commands:")
+            print(
+                f"    bergson build <run_path> --model {diagnose_cfg.model} {flag_str}"
+            )
     else:
         print(
             "RESULT: Gradient inconsistency persists across all tested"

--- a/bergson/diagnose.py
+++ b/bergson/diagnose.py
@@ -110,7 +110,10 @@ def _measure(model, short_ids, long_ids, device):
 
 
 def _run_trials(model, all_docs, n_trials, seed, threshold, device):
-    """Run n_trials gradient consistency checks. Returns (min_cos_sim, n_flagged, results)."""
+    """Run n_trials gradient consistency checks.
+
+    Returns (min_cos_sim, n_flagged, results).
+    """
     rng = random.Random(seed)
     results = []
 
@@ -180,6 +183,7 @@ def diagnose(diagnose_cfg: DiagnoseConfig):
     ds = load_dataset(diagnose_cfg.dataset, split=diagnose_cfg.split)
     all_docs = []
     for row in ds:
+        assert isinstance(row, dict)
         ids = tokenizer(row["text"])["input_ids"]
         if len(ids) < diagnose_cfg.min_len:
             continue
@@ -225,7 +229,8 @@ def diagnose(diagnose_cfg: DiagnoseConfig):
             diagnose_cfg.model,
             torch_dtype=dtype,
             attn_implementation="sdpa",
-        ).to(device)
+            device_map={"": device},
+        )
         model.eval()
 
         min_cos_sim, n_flagged, results = _run_trials(

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -116,11 +116,26 @@ def create_processor(
     return processor
 
 
+def apply_force_math_sdp(cfg: IndexConfig) -> None:
+    """Disable flash and memory-efficient SDPA backends when requested.
+
+    Forces the math-only SDPA kernel, which produces consistent gradients
+    across different padding lengths and batch compositions.
+    """
+    if not cfg.force_math_sdp:
+        return
+
+    torch.backends.cuda.enable_flash_sdp(False)
+    torch.backends.cuda.enable_mem_efficient_sdp(False)
+    print("force_math_sdp: disabled flash and memory-efficient SDPA backends")
+
+
 def setup_model_and_peft(
     cfg: IndexConfig,
     device_map_auto: bool = False,
 ) -> tuple[PreTrainedModel, set | None]:
     """Handle model loading, quantization, FSDP, and PEFT detection"""
+    apply_force_math_sdp(cfg)
     local_rank = cfg.distributed.local_rank
 
     match cfg.precision:

--- a/tests/test_force_math_sdp.py
+++ b/tests/test_force_math_sdp.py
@@ -1,0 +1,134 @@
+"""Test that --force_math_sdp produces padding-invariant gradients."""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from bergson import GradientProcessor, collect_gradients
+from bergson.config import IndexConfig
+from bergson.data import load_gradients
+from bergson.utils.worker_utils import apply_force_math_sdp
+
+
+def test_apply_force_math_sdp_sets_backends():
+    """apply_force_math_sdp disables flash and mem-efficient SDPA."""
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(True)
+
+    cfg = IndexConfig(run_path="unused", force_math_sdp=True)
+    apply_force_math_sdp(cfg)
+
+    assert not torch.backends.cuda.flash_sdp_enabled()
+    assert not torch.backends.cuda.mem_efficient_sdp_enabled()
+
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(True)
+
+
+def test_apply_force_math_sdp_noop_when_false():
+    """apply_force_math_sdp is a no-op when force_math_sdp=False."""
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(True)
+
+    cfg = IndexConfig(run_path="unused", force_math_sdp=False)
+    apply_force_math_sdp(cfg)
+
+    assert torch.backends.cuda.flash_sdp_enabled()
+    assert torch.backends.cuda.mem_efficient_sdp_enabled()
+
+
+@pytest.fixture
+def short_and_long_dataset():
+    """Dataset with two documents of very different lengths.
+
+    The length difference triggers padding divergence in models that
+    use flash/mem-efficient SDPA with lower precision.
+    """
+    from datasets import Dataset
+
+    return Dataset.from_dict(
+        {
+            "input_ids": [
+                list(range(1, 8)),  # short doc (7 tokens)
+                list(range(1, 50)),  # long doc (49 tokens)
+            ],
+            "length": [7, 49],
+        }
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_force_math_sdp_persists_through_collect(
+    tmp_path: Path, model, short_and_long_dataset
+):
+    """force_math_sdp stays active after running collect_gradients,
+    and the collected gradients for the short doc are consistent
+    whether it is batched alone or with a longer doc."""
+    model = model.float()
+
+    cfg = IndexConfig(
+        run_path=str(tmp_path / "run"),
+        skip_preconditioners=True,
+        token_batch_size=1024,
+        force_math_sdp=True,
+        projection_dim=0,
+    )
+    apply_force_math_sdp(cfg)
+
+    # Collect gradients with both docs in one batch
+    collect_gradients(
+        model=model,
+        data=short_and_long_dataset,
+        processor=GradientProcessor(),
+        cfg=cfg,
+    )
+
+    # Verify SDPA backends are still disabled after collection
+    assert not torch.backends.cuda.flash_sdp_enabled(), (
+        "flash SDP was re-enabled during collect_gradients"
+    )
+    assert not torch.backends.cuda.mem_efficient_sdp_enabled(), (
+        "mem-efficient SDP was re-enabled during collect_gradients"
+    )
+
+    mixed_index = load_gradients(cfg.partial_run_path)
+    mixed_grad_short = torch.from_numpy(
+        mixed_index[mixed_index.dtype.names[0]][0].copy()
+    ).float()
+
+    # Now collect with only the short doc
+    cfg_alone = IndexConfig(
+        run_path=str(tmp_path / "run_alone"),
+        skip_preconditioners=True,
+        token_batch_size=1024,
+        force_math_sdp=True,
+        projection_dim=0,
+    )
+
+    alone_dataset = short_and_long_dataset.select([0])
+    collect_gradients(
+        model=model,
+        data=alone_dataset,
+        processor=GradientProcessor(),
+        cfg=cfg_alone,
+    )
+
+    alone_index = load_gradients(cfg_alone.partial_run_path)
+    alone_grad_short = torch.from_numpy(
+        alone_index[alone_index.dtype.names[0]][0].copy()
+    ).float()
+
+    cos_sim = torch.nn.functional.cosine_similarity(
+        mixed_grad_short.unsqueeze(0), alone_grad_short.unsqueeze(0)
+    ).item()
+
+    assert cos_sim > 0.999, (
+        f"Gradient cosine similarity {cos_sim:.6f} is too low."
+        " force_math_sdp + fp32 should produce near-identical gradients"
+        " regardless of batch composition."
+    )
+
+    # Restore
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(True)

--- a/tests/test_force_math_sdp.py
+++ b/tests/test_force_math_sdp.py
@@ -85,12 +85,12 @@ def test_force_math_sdp_persists_through_collect(
     )
 
     # Verify SDPA backends are still disabled after collection
-    assert not torch.backends.cuda.flash_sdp_enabled(), (
-        "flash SDP was re-enabled during collect_gradients"
-    )
-    assert not torch.backends.cuda.mem_efficient_sdp_enabled(), (
-        "mem-efficient SDP was re-enabled during collect_gradients"
-    )
+    assert (
+        not torch.backends.cuda.flash_sdp_enabled()
+    ), "flash SDP was re-enabled during collect_gradients"
+    assert (
+        not torch.backends.cuda.mem_efficient_sdp_enabled()
+    ), "mem-efficient SDP was re-enabled during collect_gradients"
 
     mixed_index = load_gradients(cfg.partial_run_path)
     mixed_grad_short = torch.from_numpy(


### PR DESCRIPTION
## Summary
- Adds `--force_math_sdp` flag to `IndexConfig`, available on `build`, `score`, `trackstar`, and other commands. Disables flash and memory-efficient SDPA backends to ensure gradient consistency across different padding lengths.
- Adds `bergson test_numerical_stability` CLI command that automatically tests escalating configurations (default → `--force_math_sdp` → `--precision fp32` → both) and reports the minimum flags needed for a given model.
  -   How it works: for each trial it
        1. Picks two random documents from the dataset
        2. Runs the shorter one alone → collects its gradient
        3. Runs the shorter one batched with the longer one (which adds padding) → collects the short doc's gradient again
        4. Computes cosine similarity between the two gradients
   - Then reports mean/std/min/max across all trials
- Adds tests verifying the flag persists through `collect_gradients` and that gradients are consistent when using math-only SDPA.

## Test plan
- [x] Unit tests for `apply_force_math_sdp` (enable/disable)
- [x] Integration test: `force_math_sdp` persists after `collect_gradients`, gradients consistent across batch composition
- [x] Full test suite passes (151 passed, 2 skipped)
- [x] `pre-commit run --all-files` passes
- [x] Manual test: `bergson test_numerical_stability --model EleutherAI/pythia-14m`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Example:

```
bergson test_numerical_stability --model EleutherAI/pythia-160m
[...]

============================================================
Report for EleutherAI/pythia-160m
============================================================
  FAIL  defaults (precision=bf16)  (min cos_sim=-0.422857)
  FAIL  --force_math_sdp (precision=bf16)  (min cos_sim=-0.059151)
  FAIL  --precision fp32  (min cos_sim=0.248888)
  PASS  --precision fp32 --force_math_sdp  (min cos_sim=0.999886)

RESULT: Gradients require non-default settings for consistency.
  Minimum required: --precision fp32 --force_math_sdp

  Add to your bergson commands:
    bergson build <run_path> --model EleutherAI/pythia-160m --force_math_sdp --precision fp32
```
