### PR TITLE
GPT-2 Fine-Tune Replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,20 @@ pip install bergson
 
 To construct an index of randomly projected gradients:
 
-```
+```bash
 bergson build runs/index --model EleutherAI/pythia-14m --dataset NeelNanda/pile-10k --truncation --token_batch_size 4096
 ```
 
 To collect Trackstar attribution scores:
 
-```
+```bash
 bergson trackstar runs/trackstar --model EleutherAI/pythia-14m --query.dataset NeelNanda/pile-10k --data.dataset NeelNanda/pile-10k --data.truncation --token_batch_size 4096 --query.truncation --query.split "train[:20]"
+```
+
+To use MAGIC on a GPT-2 WikiText fine-tune:
+
+```bash
+bergson magic examples/gpt2_wikitext.yaml
 ```
 
 # Usage

--- a/bergson/config.py
+++ b/bergson/config.py
@@ -137,17 +137,54 @@ class ModelConfig(ABC):
 
 
 @dataclass
+class LRScheduleConfig(Serializable):
+    """Learning rate schedule configuration."""
+
+    lr: float = 1e-5
+    """The peak learning rate."""
+
+    lr_scheduler_type: Literal[
+        "linear",
+        "cosine",
+        "cosine_with_restarts",
+        "polynomial",
+        "constant",
+        "constant_with_warmup",
+    ] = "linear"
+    """The learning rate scheduler type."""
+
+    lr_start: float = 0.0
+    """Initial learning rate at the beginning of warmup."""
+
+    lr_end: float = 0.0
+    """Final learning rate after decay (only available for polynomial)."""
+
+    warmup_steps: float = 0
+    """Number of warmup steps before applying base lr.
+    A value >= 1 is an exact step count; a value in [0, 1)
+    is interpreted as a fraction of total training steps."""
+
+    num_cycles: float = 0.5
+    """Number of cosine cycles (used by cosine and cosine_with_restarts).
+    Default 0.5 gives a single half-cosine decay."""
+
+    power: float = 1.0
+    """Exponent for polynomial decay."""
+
+
+@dataclass
 class TrainingConfig(ModelConfig, Serializable):
     """Configuration for the MAGIC trainer."""
 
-    lr: float = 1e-5
-    """Base learning rate after warmup."""
-
-    warmup_steps: int = 10
-    """Number of warmup steps before applying base lr."""
+    lr_schedule: LRScheduleConfig = field(default_factory=LRScheduleConfig)
+    """Learning rate schedule configuration."""
 
     batch_size: int = 16
-    """Batch size for both training and query streams. Adjust based on GPU memory."""
+    """Batch size for both training and query streams.
+    Adjust based on GPU memory."""
+
+    num_epochs: int = 1
+    """Number of full passes over the training data."""
 
     adam_beta1: float = 0.95
     """Beta1 for AdamW optimizer."""

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -94,7 +94,13 @@ def shallow_copy(tensor_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor
         tid = id(t)
         if tid not in seen:
             if isinstance(t, DTensor):
-                t2 = DTensor.from_local(t.to_local(), t.device_mesh, t.placements)
+                t2 = DTensor.from_local(
+                    t.to_local(),
+                    t.device_mesh,
+                    t.placements,
+                    shape=t.shape,
+                    stride=t.stride(),
+                )
             else:
                 t2 = torch.Tensor(t.data)
             t2.requires_grad_(t.requires_grad)

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -1,9 +1,10 @@
+import math
 import os
 import shutil
 from dataclasses import asdict, dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 
 import torch
 import torch.distributed as dist
@@ -13,7 +14,6 @@ from scipy.stats import describe, spearmanr
 from simple_parsing import ArgumentParser, field
 from torch.distributed.tensor import init_device_mesh
 from torchopt.pytree import tree_iter
-from torchopt.typing import Numeric
 from tqdm import tqdm
 
 from ..config import AttributionConfig, DataConfig, TrainingConfig
@@ -53,6 +53,9 @@ class MagicConfig(AttributionConfig, TrainingConfig):
 
     wandb_project: str = ""
     """Weights & Biases project name. If set, logs training loss to W&B."""
+
+    resume: bool = False
+    """Resume a previously interrupted run from the last checkpoint."""
 
     def __post_init__(self):
         assert not self.fsdp, "PyTorch FSDP is not currently supported for MAGIC."
@@ -100,7 +103,102 @@ def compute_query_gradients(
     return grad_accum, float(loss_accum)
 
 
-def prepare_trainer(cfg: TrainingConfig, rank: int, world_size: int):
+def get_schedule(lr_cfg, num_steps: int):
+    """Return a learning rate schedule function: step → lr.
+
+    Supports HF-compatible scheduler types and an optional non-zero warmup
+    start (``lr_start``).
+    """
+    if lr_cfg.warmup_steps >= 1:
+        warmup_steps = int(lr_cfg.warmup_steps)
+    else:
+        warmup_steps = math.ceil(num_steps * lr_cfg.warmup_steps)
+
+    lr = lr_cfg.lr
+    lr_start = lr_cfg.lr_start
+    decay_steps = max(num_steps - warmup_steps, 1)
+
+    def _warmup(step):
+        """Linear warmup from lr_start to lr."""
+        progress = step / max(warmup_steps, 1)
+        return lr_start + (lr - lr_start) * progress
+
+    scheduler_type = lr_cfg.lr_scheduler_type
+
+    if scheduler_type == "constant":
+
+        def _schedule(step):
+            return lr
+
+    elif scheduler_type == "constant_with_warmup":
+
+        def _schedule(step):
+            if step < warmup_steps:
+                return _warmup(step)
+            return lr
+
+    elif scheduler_type == "linear":
+
+        def _schedule(step):
+            if step < warmup_steps:
+                return _warmup(step)
+            progress = (step - warmup_steps) / decay_steps
+            return lr * (1 - progress)
+
+    elif scheduler_type == "cosine":
+
+        def _schedule(step):
+            if step < warmup_steps:
+                return _warmup(step)
+            progress = (step - warmup_steps) / decay_steps
+            return (
+                lr * 0.5 * (1 + math.cos(math.pi * lr_cfg.num_cycles * 2.0 * progress))
+            )
+
+    elif scheduler_type == "cosine_with_restarts":
+
+        def _schedule(step):
+            if step < warmup_steps:
+                return _warmup(step)
+            progress = (step - warmup_steps) / decay_steps
+            return (
+                lr
+                * 0.5
+                * (1 + math.cos(math.pi * ((lr_cfg.num_cycles * progress) % 1.0) * 2.0))
+            )
+
+    elif scheduler_type == "polynomial":
+
+        def _schedule(step):
+            if step < warmup_steps:
+                return _warmup(step)
+            progress = (step - warmup_steps) / decay_steps
+            return lr_cfg.lr_end + (lr - lr_cfg.lr_end) * (1 - progress) ** lr_cfg.power
+
+    else:
+        raise ValueError(f"Unknown lr_scheduler_type: {scheduler_type!r}")
+
+    return _schedule
+
+
+def validate_batch_size(cfg, trainer, fwd_state, stream):
+    """Validate that the batch size fits in GPU memory for a training step."""
+    batch = stream[0]
+    try:
+        trainer.step(fwd_state, batch)
+    except torch.cuda.OutOfMemoryError:
+        raise RuntimeError(
+            f"Test batch shape {batch['input_ids'].shape}, batch_size={cfg.batch_size}"
+            f" produced an out of memory error."
+        ) from None
+
+
+def prepare_trainer(
+    cfg: TrainingConfig,
+    rank: int,
+    world_size: int,
+    schedule: Callable,
+):
     """Prepare the model, optimizer, and trainer for training."""
     torch.cuda.set_device(rank)
 
@@ -133,7 +231,7 @@ def prepare_trainer(cfg: TrainingConfig, rank: int, world_size: int):
             init_method=f"tcp://{addr}:{port}",
             device_id=torch.device(f"cuda:{rank}"),
             rank=rank,
-            timeout=timedelta(hours=1),
+            timeout=timedelta(minutes=10),
             world_size=world_size,
         )
 
@@ -141,11 +239,6 @@ def prepare_trainer(cfg: TrainingConfig, rank: int, world_size: int):
         mesh = init_device_mesh("cuda", (world_size,))
         with mesh:
             model = simple_fsdp(model)
-
-    def schedule(step: Numeric) -> Numeric:
-        if step < cfg.warmup_steps:
-            return 0.0
-        return cfg.lr
 
     opt = torchopt.adamw(
         schedule,
@@ -166,15 +259,16 @@ def worker(
     num_query_docs: int,
     run_cfg: MagicConfig,
 ):
-    trainer, fwd_state, model = prepare_trainer(run_cfg, rank, world_size)
+    if run_cfg.num_epochs > 1:
+        train_dataset = train_dataset.repeat(run_cfg.num_epochs)
 
-    ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")
-    path0 = os.path.join(ckpts_path, "state0.pt")
-    log_fn = None
-    if run_cfg.wandb_project and global_rank == 0:
-        log_fn = wandb_log_fn(run_cfg.wandb_project, config=asdict(run_cfg))
+    # Ensure total effective batch size is divisible by world size
+    assert run_cfg.batch_size % world_size == 0
 
-    save_fut = fwd_state.save(path0)
+    # Drop items that are nondivisible by batch_size to prevent deadlock
+    remainder = len(train_dataset) % run_cfg.batch_size
+    if remainder:
+        train_dataset = train_dataset.select(range(len(train_dataset) - remainder))
 
     stream = DataStream(
         train_dataset,
@@ -183,6 +277,29 @@ def worker(
         input_key=run_cfg.data.prompt_column,
         num_docs=num_train_docs,
     )
+
+    log_fn = None
+    if run_cfg.wandb_project and global_rank == 0:
+        log_fn = wandb_log_fn(run_cfg.wandb_project, config=asdict(run_cfg))
+
+    schedule = get_schedule(run_cfg.lr_schedule, len(stream))
+    trainer, fwd_state, model = prepare_trainer(
+        run_cfg,
+        rank,
+        world_size,
+        schedule,
+    )
+    validate_batch_size(run_cfg, trainer, fwd_state, stream)
+
+    ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")
+    path0 = os.path.join(ckpts_path, "state0.pt")
+
+    resume = run_cfg.resume and os.path.exists(path0)
+
+    save_fut = None
+    if not resume:
+        save_fut = fwd_state.save(path0)
+
     fwd_state = trainer.train(
         fwd_state,
         stream,
@@ -191,7 +308,24 @@ def worker(
         save_dir=ckpts_path,
         save_mode=run_cfg.save_mode,
         log_fn=log_fn,
+        resume=resume,
     )
+
+    if save_fut is not None:
+        save_fut.result()  # ensure state0 is saved before validation loads it
+
+    # Drop items that are nondivisible by batch_size to prevent deadlock
+    query_remainder = len(query_dataset) % run_cfg.batch_size
+    if query_remainder:
+        query_dataset = query_dataset.select(
+            range(len(query_dataset) - query_remainder)
+        )
+    if len(query_dataset) < run_cfg.batch_size:
+        raise ValueError(
+            f"Query dataset has {len(query_dataset)} examples, fewer than "
+            f"batch_size={run_cfg.batch_size}. Use a larger query split or "
+            f"smaller batch_size."
+        )
 
     # Compute query gradients
     query_stream = DataStream(
@@ -246,8 +380,6 @@ def worker(
     subsets = perm.chunk(run_cfg.num_subsets)
 
     pbar = tqdm(subsets, desc="Validating", disable=global_rank != 0)
-    save_fut.result()  # ensure state0 is saved before loading in loop
-
     for subset in pbar:
         fwd_state.load(path0)
 
@@ -281,15 +413,16 @@ def worker(
 
 def run_magic(run_cfg: MagicConfig):
     run_path = Path(run_cfg.run_path)
-    if run_path.exists():
+    if run_path.exists() and not run_cfg.resume:
         if run_cfg.overwrite:
             shutil.rmtree(run_path)
         else:
             raise FileExistsError(
-                f"Run path {run_path} already exists. Use --overwrite to overwrite it."
+                f"Run path {run_path} already exists. "
+                f"Use --overwrite to overwrite it."
             )
 
-    run_path.mkdir(parents=True)
+    run_path.mkdir(parents=True, exist_ok=True)
     run_cfg.save_yaml(run_path / "run_config.yaml")
 
     train_ds, train_n = setup_data_pipeline(run_cfg)

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -181,18 +181,6 @@ def get_schedule(lr_cfg, num_steps: int):
     return _schedule
 
 
-def validate_batch_size(cfg, trainer, fwd_state, stream):
-    """Validate that the batch size fits in GPU memory for a training step."""
-    batch = stream[0]
-    try:
-        trainer.step(fwd_state, batch)
-    except torch.cuda.OutOfMemoryError:
-        raise RuntimeError(
-            f"Test batch shape {batch['input_ids'].shape}, batch_size={cfg.batch_size}"
-            f" produced an out of memory error."
-        ) from None
-
-
 def prepare_trainer(
     cfg: TrainingConfig,
     rank: int,
@@ -268,7 +256,13 @@ def worker(
     # Drop items that are nondivisible by batch_size to prevent deadlock
     remainder = len(train_dataset) % run_cfg.batch_size
     if remainder:
-        train_dataset = train_dataset.select(range(len(train_dataset) - remainder))
+        total = len(train_dataset)
+        train_dataset = train_dataset.select(range(total - remainder))
+        if global_rank == 0:
+            print(
+                f"Train: dropped {remainder}/{total} examples "
+                f"({remainder / total * 100:.1f}%) to even batches"
+            )
 
     stream = DataStream(
         train_dataset,
@@ -289,7 +283,6 @@ def worker(
         world_size,
         schedule,
     )
-    validate_batch_size(run_cfg, trainer, fwd_state, stream)
 
     ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")
     path0 = os.path.join(ckpts_path, "state0.pt")
@@ -317,9 +310,13 @@ def worker(
     # Drop items that are nondivisible by batch_size to prevent deadlock
     query_remainder = len(query_dataset) % run_cfg.batch_size
     if query_remainder:
-        query_dataset = query_dataset.select(
-            range(len(query_dataset) - query_remainder)
-        )
+        query_total = len(query_dataset)
+        query_dataset = query_dataset.select(range(query_total - query_remainder))
+        if global_rank == 0:
+            print(
+                f"Query: dropped {query_remainder}/{query_total} examples "
+                f"({query_remainder / query_total * 100:.1f}%) to even batches"
+            )
     if len(query_dataset) < run_cfg.batch_size:
         raise ValueError(
             f"Query dataset has {len(query_dataset)} examples, fewer than "
@@ -389,7 +386,7 @@ def worker(
         for x in stream:
             fwd_state = trainer.step(fwd_state, x)
 
-        with fwd_state.activate(model):
+        with fwd_state.activate(model), torch.no_grad():
             loss = torch.tensor(0.0, device=stream.weights.device)
             for batch in query_stream:
                 del batch["example_weight"]

--- a/bergson/magic/data_stream.py
+++ b/bergson/magic/data_stream.py
@@ -19,16 +19,14 @@ class DataStream:
         self.dataset = dataset
         self.device = torch.device(device)
         self.input_key = input_key
-
-        # Ceil division
-        n = len(dataset)
-        self.num_batches = (n + batch_size - 1) // batch_size
+        self.n = len(dataset)
+        self.num_batches = self.n // batch_size
 
         self.rank = dist.get_rank() if dist.is_initialized() else 0
         self.world_size = dist.get_world_size() if dist.is_initialized() else 1
 
         # If num_docs isn't provided, assume that each sequence contains one document
-        num_docs = num_docs or n
+        num_docs = num_docs or self.n
         self.weights = torch.nn.Parameter(torch.ones(num_docs, device=self.device))
 
     @property
@@ -45,7 +43,7 @@ class DataStream:
 
         rng = range(
             i * self.batch_size,
-            min((i + 1) * self.batch_size, len(self.dataset)),
+            (i + 1) * self.batch_size,
         )
         indices = list(rng)[self.rank :: self.world_size]
 

--- a/bergson/magic/data_stream.py
+++ b/bergson/magic/data_stream.py
@@ -43,7 +43,7 @@ class DataStream:
 
         rng = range(
             i * self.batch_size,
-            (i + 1) * self.batch_size,
+            min((i + 1) * self.batch_size, len(self.dataset)),
         )
         indices = list(rng)[self.rank :: self.world_size]
 

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -274,6 +274,30 @@ class Trainer:
         )
         return state
 
+    def resume(
+        self,
+        state: TrainerState,
+        save_dir: str,
+    ):
+        ckpt_list = sorted_checkpoints(save_dir)
+
+        # Filter out incomplete checkpoints (missing .metadata) and clean them up
+        valid_ckpts = []
+        for idx, path in ckpt_list:
+            metadata = os.path.join(path, ".metadata")
+            if os.path.exists(metadata):
+                valid_ckpts.append((idx, path))
+            else:
+                rmtree(path) if os.path.isdir(path) else os.remove(path)
+
+        # Load the most recent trainer state
+        last_idx, last_path = valid_ckpts[-1]
+        state.batch_index = last_idx
+        state.load(last_path)
+        state.detach_()
+
+        return state
+
     def train(
         self,
         state: TrainerState,
@@ -285,10 +309,16 @@ class Trainer:
         save_mode: Literal["all", "sqrt"] = "sqrt",
         trace: bool = False,
         log_fn: Callable[[int, float], None] | None = None,
+        resume: bool = False,
     ) -> TrainerState:
         # Make sure the save directory exists
         if save_dir is not None:
             os.makedirs(save_dir, exist_ok=True)
+
+        start = 0
+        if resume and save_dir is not None:
+            state = self.resume(state, save_dir)
+            start = state.batch_index
 
         chunk_size = math.isqrt(len(data)) if save_mode == "sqrt" else 1
         last_start = len(data) - chunk_size
@@ -296,9 +326,9 @@ class Trainer:
         pending_save: SaveFuture | None = None
 
         main = not dist.is_initialized() or dist.get_rank() == 0
-        pbar = tqdm(data, desc="Training", disable=not main)
+        pbar = tqdm(range(start, len(data)), desc="Training", disable=not main)
 
-        for i, x in enumerate(pbar):
+        for i in pbar:
             # Save checkpoint BEFORE each step. Step 0 is the initial state prior to
             # any updates, step 1 is the state after the first update, etc.
             if save_dir and (i % chunk_size == 0 or i >= last_start):
@@ -311,6 +341,7 @@ class Trainer:
                 p = os.path.join(save_dir, f"step_{i}.ckpt")
                 pending_save = state.save(p, debug_pbar=pbar if debug else None)
 
+            x = data[i]
             state = self.step(state, x, inplace=inplace, trace=trace)
 
             if log_fn is not None:

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -366,7 +366,7 @@ def setup_data_pipeline(
             tokenizer,
             chunk_size=data_cfg.chunk_length,
         )
-        return tokenized, len(tokenized)
+        return tokenized, len(ds)
 
     max_token_bz = getattr(cfg, "token_batch_size", BIG_NUM)
     if BIG_NUM > max_token_bz > max_model_length:
@@ -388,7 +388,6 @@ def setup_data_pipeline(
             truncation=data_cfg.truncation,
         )
 
-    num_docs = len(ds)
     if not ds.column_names or "input_ids" not in ds.column_names:
         ds = ds.map(
             tokenize,
@@ -447,4 +446,4 @@ def setup_data_pipeline(
     if remove_columns:
         ds = ds.remove_columns(list(remove_columns))
 
-    return ds, num_docs
+    return ds, len(ds)

--- a/examples/double_backward_pretrain.py
+++ b/examples/double_backward_pretrain.py
@@ -16,7 +16,7 @@ Usage:
         --query.split "train[:1]"
 """
 
-from bergson.config import DataConfig, DistributedConfig
+from bergson.config import DataConfig, DistributedConfig, LRScheduleConfig
 from bergson.magic import MagicConfig, run_magic
 
 
@@ -33,8 +33,7 @@ def main():
             dataset="EleutherAI/SmolLM2-135M-10B",
             split="train[:1]",
         ),
-        lr=1e-5,
-        warmup_steps=10,
+        lr_schedule=LRScheduleConfig(lr=1e-5, warmup_steps=10),
         batch_size=8,
         num_subsets=100,
         seed=42,

--- a/examples/gpt2_wikitext.yaml
+++ b/examples/gpt2_wikitext.yaml
@@ -1,0 +1,29 @@
+run_path: runs/gpt2_wikitext
+model: gpt2
+overwrite: true
+
+data:
+  dataset: Salesforce/wikitext
+  subset: wikitext-2-raw-v1
+  split: "train[:4608]"
+  chunk_length: 512
+
+query:
+  dataset: Salesforce/wikitext
+  subset: wikitext-2-raw-v1
+  split: "train[:4608]"
+  chunk_length: 512
+
+distributed:
+  nproc_per_node: 8
+
+batch_size: 64
+num_epochs: 4
+lr_schedule:
+  lr_scheduler_type: polynomial
+  lr: 0.0008
+  lr_start: 1e-6
+  lr_end: 0.00008
+  warmup_steps: 0.25
+
+wandb_project: magic

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -83,3 +83,46 @@ def test_magic_two_steps(model_name, dataset):
     scores = bwd_state.weight_grads.detach().cpu()
     assert scores.shape == (len(dataset),)
     assert scores.abs().sum() > 0, "Attribution scores are all zero"
+
+
+def test_magic_resume(dataset):
+    """Resume from a checkpoint mid-training and verify identical final state."""
+    device = "cpu"
+
+    torch.manual_seed(42)
+    config = AutoConfig.from_pretrained("trl-internal-testing/tiny-Phi3ForCausalLM")
+    model = AutoModelForCausalLM.from_config(
+        config, torch_dtype=torch.float32, attn_implementation="eager"
+    )
+    model.loss_function = weighted_causal_lm_ce
+    model.requires_grad_(True)
+
+    optimizer = torchopt.adamw(1e-4, betas=(0.95, 0.975), eps_root=1e-2)
+    trainer, fwd_state = Trainer.initialize(model, optimizer)
+
+    # batch_size=1 gives us 2 batches so resume has something to skip
+    train_stream = DataStream(dataset, batch_size=1, device=device)
+    assert len(train_stream) == 2
+
+    with tempfile.TemporaryDirectory() as ckpt_dir:
+        # Full training run (inplace=False to keep fwd_state intact)
+        final_state = trainer.train(
+            fwd_state,
+            train_stream,
+            inplace=False,
+            save_dir=ckpt_dir,
+            save_mode="all",
+        )
+
+        # Resume from checkpoints with the same initial state
+        resumed_state = trainer.train(
+            fwd_state,
+            train_stream,
+            inplace=False,
+            save_dir=ckpt_dir,
+            save_mode="all",
+            resume=True,
+        )
+
+        for k in final_state.params:
+            torch.testing.assert_close(resumed_state.params[k], final_state.params[k])


### PR DESCRIPTION
- Add a learning rate scheduler config to bring the available schedules in line with HF (with the addition of lr_start in polynomial, required for the GPT-2 fine-tune).
- Add Trainer resume option for training phase (future work: backward phase)
- Drop data that doesn't fit evenly into the world size or batch size
- Add GPT-2 fine-tune replication yaml
- Fix a bug in distributed.py DTensor usage that pops up when models have tensors that aren't cleanly divisible across ranks (only applies to GPT-2 so far)

- Add validate_batch_size. This function may be useless because it does the same thing as the first training step. But we've had issues in the past that haven't been fully diagnosed where a too-large batch size in FSDP can cause a NCCL hang rather than an immediate crash. This can happen mid-training if the batch size is variable. If this happens it might be nice to have it happen in a dedicated location. I'm not sure if this will be relevant to us yet, need to look into our planned batching strategies.
 
Future work:
- Add fake data to make batches even without dropping data, and ignore their gradients