### PR TITLE
Update loss reduction default

### DIFF
--- a/bergson/config.py
+++ b/bergson/config.py
@@ -364,7 +364,7 @@ class IndexConfig(AttributionConfig, Serializable):
     loss_fn: Literal["ce", "kl"] = "ce"
     """Loss function to use."""
 
-    loss_reduction: Literal["mean", "sum"] = "mean"
+    loss_reduction: Literal["mean", "sum"] = "sum"
     """Reduction method for the loss function."""
 
     label_smoothing: float = 0.0


### PR DESCRIPTION
This will more closely match TrackStar.

This will require any runs in EM coupled to Bergson's defaults to explicitly set `loss_reduction`="mean" to maintain reproducibility