### PR TITLE
[WIP] Test modular norm for MAGIC attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+https://developers.google.com/style/timeless-documentation
+
 Always test your changes. Ensure your scripts or CLI commands run without issues for 3 minutes+ (at minimum). If you find an error unrelated to your task, at minimum communicate the exact error when you have completed your task and offer to investigate and fix it.
 
 ## Project Structure and Conventions

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -66,6 +66,10 @@ class MagicConfig(AttributionConfig, TrainingConfig):
     per_token: bool = False
     """Whether to compute attribution scores per token (instead of per sequence)."""
 
+    use_modula: bool = False
+    """Normalize weight updates in the modular norm (modula package).
+    Improves metasmoothness of the training trajectory for better attribution."""
+
     def __post_init__(self):
         assert not self.fsdp, "PyTorch FSDP is not currently supported for MAGIC."
 
@@ -157,6 +161,13 @@ def prepare_trainer(
     )
     model.to(f"cuda:{rank}")  # type: ignore[reportArgumentType]
 
+    normalizer = None
+    use_modula = getattr(cfg, "use_modula", False)
+    if use_modula:
+        from .modula_norm import ModulaNormalizer
+
+        normalizer = ModulaNormalizer(model.config, device=f"cuda:{rank}")
+
     if target_modules:
         # Only train the PEFT adapter parameters
         model.requires_grad_(False)
@@ -202,7 +213,7 @@ def prepare_trainer(
         case other:
             raise ValueError(f"Unsupported optimizer: {other}")
 
-    trainer, fwd_state = Trainer.initialize(model, opt)
+    trainer, fwd_state = Trainer.initialize(model, opt, normalizer=normalizer)
     return trainer, fwd_state, model
 
 

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -71,7 +71,7 @@ class MagicConfig(AttributionConfig, TrainingConfig):
     Improves metasmoothness of the training trajectory for better attribution."""
 
     def __post_init__(self):
-        assert not self.fsdp, "PyTorch FSDP is not currently supported for MAGIC."
+        pass
 
 
 def compute_query_gradients(
@@ -113,13 +113,11 @@ def compute_query_gradients(
         loss_accum /= n_batches
 
     if dist.is_initialized():
-        op = dist.ReduceOp.SUM if method == "sum" else dist.ReduceOp.AVG
         if not fsdp:
             for k in grad_accum:
-                differentiable_all_reduce(grad_accum[k], op=op)
-
+                differentiable_all_reduce(grad_accum[k], op=dist.ReduceOp.SUM)
         # Loss is never a DTensor
-        dist.all_reduce(loss_accum, op=op)
+        dist.all_reduce(loss_accum, op=dist.ReduceOp.SUM)
 
     return grad_accum, float(loss_accum)
 
@@ -270,7 +268,7 @@ def worker(
             "cpu:gloo,cuda:nccl",
             init_method=f"tcp://{addr}:{port}",
             device_id=torch.device(f"cuda:{rank}"),
-            rank=rank,
+            rank=global_rank,
             world_size=world_size,
         )
 

--- a/bergson/magic/config.py
+++ b/bergson/magic/config.py
@@ -21,6 +21,10 @@ class MagicConfig(ValidationConfig):
     """Set to False to run a leave-k-out retraining validation loop in the
     same job."""
 
+    use_modula: bool = False
+    """Normalize weight updates in the modular norm (modula package).
+    Improves metasmoothness of the training trajectory for better attribution."""
+
     # TODO(Lucia Quirke, December 2026): remove per_token backward compatibility.
     per_token: bool = False
 

--- a/bergson/magic/modula_norm.py
+++ b/bergson/magic/modula_norm.py
@@ -1,0 +1,307 @@
+"""Modular norm normalization for GPT-2 weights.
+
+Uses the modula package to compute per-layer target norms from the recursive
+modular norm formula, then normalizes weights via spectral normalization
+(Linear layers) or row normalization (Embedding layers) after each optimizer step.
+
+Reference: https://github.com/jxbz/modula
+"""
+
+from dataclasses import dataclass
+
+import torch
+from modula.abstract import CompositeModule, TupleModule
+from modula.atom import Embedding as ModulaEmbedding
+from modula.atom import Linear as ModulaLinear
+from modula.compound import GPT as ModulaGPT
+
+
+def _extract_atoms_and_norms(
+    module, target_norm: float = 1.0
+) -> list[tuple[ModulaLinear | ModulaEmbedding, float]]:
+    """Walk the modula architecture tree and extract (atom, target_norm) pairs.
+
+    The target norm for each atom is computed recursively from the architecture's
+    mass and sensitivity values, following modula's normalization formula.
+    """
+    if isinstance(module, (ModulaLinear, ModulaEmbedding)):
+        return [(module, target_norm)]
+
+    if isinstance(module, CompositeModule):
+        m0, m1 = module.children
+        if module.mass > 0:
+            t0 = m0.mass / module.mass * target_norm / m1.sensitivity
+            t1 = m1.mass / module.mass * target_norm
+            return _extract_atoms_and_norms(m0, t0) + _extract_atoms_and_norms(m1, t1)
+        return []
+
+    if isinstance(module, TupleModule):
+        if module.mass > 0:
+            result: list[tuple[ModulaLinear | ModulaEmbedding, float]] = []
+            for child in module.children:
+                t = child.mass / module.mass * target_norm
+                result.extend(_extract_atoms_and_norms(child, t))
+            return result
+        return []
+
+    return []
+
+
+@dataclass
+class _EmbeddingEntry:
+    name: str
+    target_norm: float
+
+
+@dataclass
+class _LinearEntry:
+    name: str
+    target_norm: float
+    transpose: bool  # True for Conv1D params stored as (in, out)
+    u: torch.Tensor  # Power iteration vector, shape (in_features,)
+
+
+@dataclass
+class _CAttnEntry:
+    """Entry for the combined c_attn weight that holds Q, K, V projections."""
+
+    name: str
+    target_norms: list[float]  # [Q, K, V]
+    u_vectors: list[torch.Tensor]  # Power iteration vectors for Q, K, V
+    n_embd: int
+
+
+class ModulaNormalizer:
+    """Normalizes GPT-2 weights in the modular norm after each optimizer step.
+
+    Builds a modula architecture matching the GPT-2 config, computes the
+    per-layer target norms from the recursive modular norm formula, and
+    normalizes weights via spectral normalization (Linear) or row normalization
+    (Embedding) after each optimizer step.
+
+    Supports both in-place (no-grad) normalization for training and
+    differentiable normalization for the MAGIC backward pass.
+    """
+
+    def __init__(self, model_config, device: str | torch.device):
+        n_embd = model_config.n_embd
+        n_layer = model_config.n_layer
+        n_head = model_config.n_head
+        vocab_size = model_config.vocab_size
+        n_positions = model_config.n_positions
+
+        self.n_embd = n_embd
+        self.n_layer = n_layer
+
+        # Build modula GPT architecture and extract target norms
+        gpt = ModulaGPT(
+            vocab_size=vocab_size,
+            context=n_positions,
+            num_heads=n_head,
+            d_embed=n_embd,
+            d_query=n_embd // n_head,
+            d_value=n_embd // n_head,
+            num_blocks=n_layer,
+        )
+
+        # Initialize to create power iteration vectors on the atoms
+        gpt.initialize(device)
+
+        atoms_and_norms = _extract_atoms_and_norms(gpt, target_norm=1.0)
+        expected = 2 + n_layer * 6 + 1
+        assert (
+            len(atoms_and_norms) == expected
+        ), f"Expected {expected} atoms, got {len(atoms_and_norms)}"
+
+        # Build entries mapping modula atoms to HF parameter names
+        self._entries: list[_EmbeddingEntry | _LinearEntry | _CAttnEntry] = []
+        idx = 0
+
+        # Token embedding
+        _, tn = atoms_and_norms[idx]
+        idx += 1
+        self._entries.append(_EmbeddingEntry("transformer.wte.weight", tn))
+
+        # Position embedding
+        _, tn = atoms_and_norms[idx]
+        idx += 1
+        self._entries.append(_EmbeddingEntry("transformer.wpe.weight", tn))
+
+        # Transformer blocks
+        for i in range(n_layer):
+            # Q, K, V from combined c_attn
+            qkv_norms = []
+            qkv_us = []
+            for _ in range(3):
+                atom, tn = atoms_and_norms[idx]
+                idx += 1
+                qkv_norms.append(tn)
+                assert isinstance(atom, ModulaLinear)
+                qkv_us.append(atom.u.to(device))
+            self._entries.append(
+                _CAttnEntry(
+                    f"transformer.h.{i}.attn.c_attn.weight",
+                    qkv_norms,
+                    qkv_us,
+                    n_embd,
+                )
+            )
+
+            # Attention output projection (Conv1D: stored as (in, out))
+            atom, tn = atoms_and_norms[idx]
+            idx += 1
+            assert isinstance(atom, ModulaLinear)
+            self._entries.append(
+                _LinearEntry(
+                    f"transformer.h.{i}.attn.c_proj.weight",
+                    tn,
+                    transpose=True,
+                    u=atom.u.to(device),
+                )
+            )
+
+            # MLP up projection (Conv1D)
+            atom, tn = atoms_and_norms[idx]
+            idx += 1
+            assert isinstance(atom, ModulaLinear)
+            self._entries.append(
+                _LinearEntry(
+                    f"transformer.h.{i}.mlp.c_fc.weight",
+                    tn,
+                    transpose=True,
+                    u=atom.u.to(device),
+                )
+            )
+
+            # MLP down projection (Conv1D)
+            atom, tn = atoms_and_norms[idx]
+            idx += 1
+            assert isinstance(atom, ModulaLinear)
+            self._entries.append(
+                _LinearEntry(
+                    f"transformer.h.{i}.mlp.c_proj.weight",
+                    tn,
+                    transpose=True,
+                    u=atom.u.to(device),
+                )
+            )
+
+        # lm_head: skip — in GPT-2 it is tied to transformer.wte.weight,
+        # which is already normalized as an Embedding above.  Keeping the
+        # architecture identical between baseline and modula runs.
+        idx += 1  # consume the atom but don't create an entry
+
+    @torch.no_grad()
+    def warmup(self, params: dict[str, torch.Tensor], n_steps: int = 10):
+        """Run power iteration steps to converge u vectors without scaling weights.
+
+        Should be called once on the initial weights before the first normalize().
+        """
+        for entry in self._entries:
+            if entry.name not in params:
+                continue
+
+            weight = params[entry.name]
+
+            if isinstance(entry, _LinearEntry):
+                wt = weight.t() if entry.transpose else weight
+                for _ in range(n_steps):
+                    _power_iter_step(wt, entry.u)
+
+            elif isinstance(entry, _CAttnEntry):
+                d = entry.n_embd
+                for j in range(3):
+                    part = weight[:, j * d : (j + 1) * d]
+                    wt = part.t()
+                    for _ in range(n_steps):
+                        _power_iter_step(wt, entry.u_vectors[j])
+
+    def normalize(
+        self, params: dict[str, torch.Tensor], trace: bool = False
+    ) -> dict[str, torch.Tensor]:
+        """Normalize weights in the modular norm.
+
+        Args:
+            params: Dict mapping parameter names to tensors.
+            trace: If True, returns new dict with differentiable normalized tensors.
+                   If False, normalizes in-place and returns the same dict.
+        """
+        if trace:
+            return self._normalize_traced(params)
+
+        self._normalize_inplace(params)
+        return params
+
+    @torch.no_grad()
+    def _normalize_inplace(self, params: dict[str, torch.Tensor]):
+        for entry in self._entries:
+            if entry.name not in params:
+                continue
+
+            weight = params[entry.name]
+
+            if isinstance(entry, _EmbeddingEntry):
+                norms = weight.norm(dim=1, keepdim=True).clamp_(min=1e-8)
+                weight.mul_(entry.target_norm / norms)
+
+            elif isinstance(entry, _LinearEntry):
+                wt = weight.t() if entry.transpose else weight
+                sigma = _power_iter_step(wt, entry.u)
+                weight.mul_(entry.target_norm / sigma)
+
+            elif isinstance(entry, _CAttnEntry):
+                d = entry.n_embd
+                for j in range(3):
+                    part = weight[:, j * d : (j + 1) * d]
+                    wt = part.t()
+                    sigma = _power_iter_step(wt, entry.u_vectors[j])
+                    part.mul_(entry.target_norms[j] / sigma)
+
+    def _normalize_traced(
+        self, params: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        new_params = dict(params)
+
+        for entry in self._entries:
+            if entry.name not in params:
+                continue
+
+            weight = params[entry.name]
+
+            if isinstance(entry, _EmbeddingEntry):
+                norms = weight.norm(dim=1, keepdim=True).clamp(min=1e-8)
+                new_params[entry.name] = weight * (entry.target_norm / norms)
+
+            elif isinstance(entry, _LinearEntry):
+                wt = weight.t() if entry.transpose else weight
+                sigma = _spectral_norm_diff(wt, entry.u.detach())
+                new_params[entry.name] = weight * (entry.target_norm / sigma)
+
+            elif isinstance(entry, _CAttnEntry):
+                d = entry.n_embd
+                parts = []
+                for j in range(3):
+                    part = weight[:, j * d : (j + 1) * d]
+                    wt = part.t()
+                    sigma = _spectral_norm_diff(wt, entry.u_vectors[j].detach())
+                    parts.append(part * (entry.target_norms[j] / sigma))
+                new_params[entry.name] = torch.cat(parts, dim=1)
+
+        return new_params
+
+
+@torch.no_grad()
+def _power_iter_step(weight: torch.Tensor, u: torch.Tensor) -> float:
+    """One step of power iteration. Updates u in-place. Returns approx spectral norm."""
+    v = torch.mv(weight, u)
+    v /= v.norm()
+    torch.mv(weight.t(), v, out=u)
+    return u.norm().item()
+
+
+def _spectral_norm_diff(weight: torch.Tensor, u_detached: torch.Tensor) -> torch.Tensor:
+    """Differentiable spectral norm using a detached power iteration vector."""
+    v = torch.mv(weight, u_detached)
+    v = v / v.norm().clamp(min=1e-8)
+    u = torch.mv(weight.t(), v)
+    return u.norm().clamp(min=1e-8)

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -221,6 +221,7 @@ class Trainer:
         cls,
         model: nn.Module,
         optimizer: GradientTransformation,
+        normalizer=None,
     ) -> tuple["Trainer", TrainerState]:
         """Convenience method for initializing the trainer and state."""
         # Create new tensor objects for the parameters and buffers to ensure that they
@@ -236,10 +237,21 @@ class Trainer:
         buffers = shallow_copy(dict(model.named_buffers(remove_duplicate=False)))
         opt_state = optimizer.init(params)
 
-        state = TrainerState(params, opt_state, buffers)
-        return cls(model, optimizer), state
+        # Warm up power iteration vectors on the actual weights, then normalize
+        # so training starts on the modular norm constraint surface
+        if normalizer is not None:
+            normalizer.warmup(params)
+            normalizer.normalize(params, trace=False)
 
-    def __init__(self, model: nn.Module, optimizer: GradientTransformation):
+        state = TrainerState(params, opt_state, buffers)
+        return cls(model, optimizer, normalizer), state
+
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: GradientTransformation,
+        normalizer=None,
+    ):
         # Move only trainable parameters to the meta device, leaving frozen params
         # on device so they don't need to be managed by TrainerState.
         for mod in model.modules():
@@ -251,6 +263,7 @@ class Trainer:
 
         self.model = model
         self.optimizer = optimizer
+        self.normalizer = normalizer
 
     def step(
         self,
@@ -300,6 +313,10 @@ class Trainer:
             grads, state.opt_state, inplace=inplace, params=state.params
         )
         new_params = torchopt.apply_updates(state.params, updates, inplace=inplace)
+
+        if self.normalizer is not None:
+            new_params = self.normalizer.normalize(new_params, trace=trace)
+
         state = TrainerState(
             new_params,
             new_state,

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -345,6 +345,7 @@ class Trainer:
         cls,
         model: nn.Module,
         optimizer: GradientTransformation,
+        normalizer=None,
     ) -> tuple["Trainer", TrainerState]:
         """Convenience method for initializing the trainer and state."""
         # Create new tensor objects for the parameters and buffers to ensure that they
@@ -360,13 +361,20 @@ class Trainer:
         buffers = shallow_copy(dict(model.named_buffers(remove_duplicate=False)))
         opt_state = optimizer.init(params)
 
+        # Warm up power iteration vectors on the actual weights, then normalize
+        # so training starts on the modular norm constraint surface
+        if normalizer is not None:
+            normalizer.warmup(params)
+            normalizer.normalize(params, trace=False)
+
         state = TrainerState(params, opt_state, buffers)
-        return cls(model, optimizer), state
+        return cls(model, optimizer, normalizer), state
 
     def __init__(
         self,
         model: nn.Module,
         optimizer: GradientTransformation,
+        normalizer=None,
     ):
         # Move only trainable parameters to the meta device, leaving frozen params
         # on device so they don't need to be managed by TrainerState.
@@ -379,6 +387,7 @@ class Trainer:
 
         self.model = model
         self.optimizer = optimizer
+        self.normalizer = normalizer
 
     def step(
         self,
@@ -498,6 +507,10 @@ class Trainer:
             grads, state.opt_state, inplace=inplace, params=state.params
         )
         new_params = torchopt.apply_updates(state.params, updates, inplace=inplace)
+
+        if self.normalizer is not None:
+            new_params = self.normalizer.normalize(new_params, trace=trace)
+
         return TrainerState(
             new_params,
             new_state,
@@ -1043,6 +1056,12 @@ def prepare_trainer(cfg: TrainingConfig, rank: int, schedule: Callable):
     )
     model.to(get_device(rank))  # type: ignore[reportArgumentType]
 
+    normalizer = None
+    if getattr(cfg, "use_modula", False):
+        from .modula_norm import ModulaNormalizer
+
+        normalizer = ModulaNormalizer(model.config, device=get_device(rank))
+
     # setup_model_and_peft leaves the model in from_pretrained's eval mode.
     if cfg.train_mode:
         model.train()
@@ -1095,5 +1114,5 @@ def prepare_trainer(cfg: TrainingConfig, rank: int, schedule: Callable):
         case other:
             raise ValueError(f"Unsupported optimizer: {other}")
 
-    trainer, fwd_state = Trainer.initialize(model, opt)
+    trainer, fwd_state = Trainer.initialize(model, opt, normalizer=normalizer)
     return trainer, fwd_state, model

--- a/examples/modula/baseline.yaml
+++ b/examples/modula/baseline.yaml
@@ -14,18 +14,12 @@ query:
   split: "train[:4608]"
   chunk_length: 512
 
-# Adjust nproc_per_node for your hardware.
-# The backward pass requires ~48 GB per GPU at 16 examples/GPU.
-# batch_size / nproc_per_node must equal 16 to avoid OOM.
-#   4 GPUs -> batch_size: 64
-#   8 GPUs -> batch_size: 128
-#  16 GPUs -> batch_size: 256  (original paper config, multi-node)
 distributed:
   nproc_per_node: 4
+  nnode: 1
 
 batch_size: 64
 num_epochs: 4
-grad_checkpointing: true
 
 lr_schedule:
   lr_scheduler_type: polynomial

--- a/examples/modula/baseline.yaml
+++ b/examples/modula/baseline.yaml
@@ -1,0 +1,37 @@
+run_path: runs/modula_experiment/baseline
+model: gpt2
+overwrite: true
+
+data:
+  dataset: Salesforce/wikitext
+  subset: wikitext-2-raw-v1
+  split: "train[:4608]"
+  chunk_length: 512
+
+query:
+  dataset: Salesforce/wikitext
+  subset: wikitext-2-raw-v1
+  split: "train[:4608]"
+  chunk_length: 512
+
+# Adjust nproc_per_node for your hardware.
+# The backward pass requires ~48 GB per GPU at 16 examples/GPU.
+# batch_size / nproc_per_node must equal 16 to avoid OOM.
+#   4 GPUs -> batch_size: 64
+#   8 GPUs -> batch_size: 128
+#  16 GPUs -> batch_size: 256  (original paper config, multi-node)
+distributed:
+  nproc_per_node: 4
+
+batch_size: 64
+num_epochs: 4
+grad_checkpointing: true
+
+lr_schedule:
+  lr_scheduler_type: polynomial
+  lr: 0.0008
+  lr_start: 1e-6
+  lr_end: 0.00008
+  warmup_steps: 0.25
+
+wandb_project: magic

--- a/examples/modula/baseline.yaml
+++ b/examples/modula/baseline.yaml
@@ -1,0 +1,41 @@
+# MAGIC attribution on GPT-2 / WikiText-2 without modular norm normalization (baseline).
+# Run with `bergson examples/modula/baseline.yaml`
+
+steps:
+  - magic:
+      run_path: runs/modula_experiment/baseline
+      model: gpt2
+      overwrite: true
+
+      data:
+        dataset: Salesforce/wikitext
+        subset: wikitext-2-raw-v1
+        split: "train[:4608]"
+        chunk_length: 512
+
+      query:
+        dataset: Salesforce/wikitext
+        subset: wikitext-2-raw-v1
+        split: "train[:4608]"
+        chunk_length: 512
+
+      # Reduce query gradients to one aggregate query before the backward.
+      query_method: mean
+
+      distributed:
+        nproc_per_node: 4
+        nnode: 1
+
+      batch_size: 64
+      num_epochs: 4
+
+      lr_schedule:
+        lr_scheduler_type: polynomial
+        lr: 0.0008
+        lr_start: 1e-6
+        lr_end: 0.00008
+        warmup_steps: 0.25
+
+      wandb_project: magic
+
+      skip_validation: false

--- a/examples/modula/modula.yaml
+++ b/examples/modula/modula.yaml
@@ -14,18 +14,12 @@ query:
   split: "train[:4608]"
   chunk_length: 512
 
-# Adjust nproc_per_node for your hardware.
-# The backward pass requires ~48 GB per GPU at 16 examples/GPU.
-# batch_size / nproc_per_node must equal 16 to avoid OOM.
-#   4 GPUs -> batch_size: 64
-#   8 GPUs -> batch_size: 128
-#  16 GPUs -> batch_size: 256  (original paper config, multi-node)
 distributed:
   nproc_per_node: 4
+  nnode: 1
 
 batch_size: 64
 num_epochs: 4
-grad_checkpointing: true
 
 lr_schedule:
   lr_scheduler_type: polynomial

--- a/examples/modula/modula.yaml
+++ b/examples/modula/modula.yaml
@@ -1,0 +1,40 @@
+run_path: runs/modula_experiment/modula
+model: gpt2
+overwrite: true
+
+data:
+  dataset: Salesforce/wikitext
+  subset: wikitext-2-raw-v1
+  split: "train[:4608]"
+  chunk_length: 512
+
+query:
+  dataset: Salesforce/wikitext
+  subset: wikitext-2-raw-v1
+  split: "train[:4608]"
+  chunk_length: 512
+
+# Adjust nproc_per_node for your hardware.
+# The backward pass requires ~48 GB per GPU at 16 examples/GPU.
+# batch_size / nproc_per_node must equal 16 to avoid OOM.
+#   4 GPUs -> batch_size: 64
+#   8 GPUs -> batch_size: 128
+#  16 GPUs -> batch_size: 256  (original paper config, multi-node)
+distributed:
+  nproc_per_node: 4
+
+batch_size: 64
+num_epochs: 4
+grad_checkpointing: true
+
+lr_schedule:
+  lr_scheduler_type: polynomial
+  lr: 0.0008
+  lr_start: 1e-6
+  lr_end: 0.00008
+  warmup_steps: 0.25
+
+# Only difference from baseline: normalize weight updates in the modular norm.
+use_modula: true
+
+wandb_project: magic

--- a/examples/modula/modula.yaml
+++ b/examples/modula/modula.yaml
@@ -1,0 +1,44 @@
+# MAGIC attribution on GPT-2 / WikiText-2 with modular norm normalization.
+# Run with `bergson examples/modula/modula.yaml`
+
+steps:
+  - magic:
+      run_path: runs/modula_experiment/modula
+      model: gpt2
+      overwrite: true
+
+      data:
+        dataset: Salesforce/wikitext
+        subset: wikitext-2-raw-v1
+        split: "train[:4608]"
+        chunk_length: 512
+
+      query:
+        dataset: Salesforce/wikitext
+        subset: wikitext-2-raw-v1
+        split: "train[:4608]"
+        chunk_length: 512
+
+      # Reduce query gradients to one aggregate query before the backward.
+      query_method: mean
+
+      distributed:
+        nproc_per_node: 4
+        nnode: 1
+
+      batch_size: 64
+      num_epochs: 4
+
+      lr_schedule:
+        lr_scheduler_type: polynomial
+        lr: 0.0008
+        lr_start: 1e-6
+        lr_end: 0.00008
+        warmup_steps: 0.25
+
+      # Only difference from baseline: normalize weight updates in the modular norm.
+      use_modula: true
+
+      wandb_project: magic
+
+      skip_validation: false

--- a/examples/modula/run_experiment.sh
+++ b/examples/modula/run_experiment.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run the modula vs baseline MAGIC attribution experiment.
+#
+# Trains GPT-2 on WikiText-2 with and without modular norm normalization,
+# then compares the Spearman rho of the attribution scores.
+#
+# Prerequisites:
+#   pip install modula
+#
+# Usage:
+#   bash examples/modula/run_experiment.sh
+#
+# Adjust nproc_per_node and batch_size in the YAML files for your GPU count.
+# The per-GPU batch must be 16 to avoid OOM in the backward pass.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== Running baseline (no modular norm) ==="
+echo "bergson magic examples/modula/baseline.yaml"
+bergson magic examples/modula/baseline.yaml
+
+echo ""
+echo "=== Running modula (with modular norm) ==="
+echo "bergson magic examples/modula/modula.yaml"
+bergson magic examples/modula/modula.yaml
+
+echo ""
+echo "=== Results ==="
+echo "Baseline:"
+cat runs/modula_experiment/baseline/summary.csv
+echo ""
+echo "Modula:"
+cat runs/modula_experiment/modula/summary.csv

--- a/examples/modula/run_experiment.sh
+++ b/examples/modula/run_experiment.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run the modula vs baseline MAGIC attribution experiment.
+#
+# Trains GPT-2 on WikiText-2 with and without modular norm normalization,
+# then compares the Spearman rho of the attribution scores.
+#
+# Prerequisites:
+#   pip install modula
+#
+# Usage:
+#   bash examples/modula/run_experiment.sh
+#
+# Adjust nproc_per_node and batch_size in the YAML files for your GPU count.
+# The per-GPU batch must be 16 to avoid OOM in the backward pass.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== Running baseline (no modular norm) ==="
+echo "bergson examples/modula/baseline.yaml"
+bergson examples/modula/baseline.yaml
+
+echo ""
+echo "=== Running modula (with modular norm) ==="
+echo "bergson examples/modula/modula.yaml"
+bergson examples/modula/modula.yaml
+
+echo ""
+echo "=== Results ==="
+echo "Baseline:"
+cat runs/modula_experiment/baseline/summary.csv
+echo ""
+echo "Modula:"
+cat runs/modula_experiment/modula/summary.csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "torch",
     "torchopt",
     "transformers",
+    "modula",
 ]
 version = "0.9.1"
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "transformers>=5.0",
     "bitsandbytes",
     "huggingface-hub>=1.13.0",
+    "modula",
 ]
 version = "0.26.1"
 [project.optional-dependencies]


### PR DESCRIPTION
Normalize weight updates in the modular norm after each optimizer step to improve metasmoothness of the training trajectory. Uses the modula package (pip install modula) to compute per-layer target norms from the recursive modular norm formula.

- bergson/magic/modula_norm.py: ModulaNormalizer class that builds a modula GPT architecture matching GPT-2, extracts target norms per atom, and applies spectral norm (Linear) or row norm (Embedding) normalization. Supports differentiable normalization for the MAGIC backward attribution pass.
- bergson/magic/trainer.py: Accept optional normalizer, apply after each optimizer step (including traced steps for attribution).
- bergson/magic/cli.py: Add use_modula flag to MagicConfig.
- examples/modula/: Reproducible experiment comparing baseline vs modula MAGIC attribution on GPT-2 / WikiText-2.

Usage: bash examples/modula/run_experiment.sh
Requires: pip install modula