### PR TITLE
ELE-11: Add YAML-mediated search pipeline to Bergson

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ You can also aggregate your query dataset into a single mean or sum gradient as 
 bergson build <output_path> --model <model_name> --dataset <dataset_name> --aggregation mean --unit_normalize --preconditioner_path <path_to_preconditioner>
 ```
 
+## Run a Multi-Step Pipeline
+
+Many workflows chain several Bergson commands together. Rather than running each command separately, you can express the whole sequence as a YAML file and run it with a single command:
+
+```bash
+bergson pipeline <path_to_yaml>
+```
+
+The YAML is a list of single-key entries, one per step, each holding that command's full config. See [`examples/pipelines/hessian_then_build.yaml`](examples/pipelines/hessian_then_build.yaml) for a runnable Hessian → build example.
+
 ## Query an On-Disk Gradient Index
 
 We provide a query Attributor which supports unit normalized gradients and KNN search out of the box. Access it via CLI with

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -24,6 +24,7 @@ from .query.query_index import query
 from .score.score import score_dataset
 from .trackstar import trackstar
 from .utils.worker_utils import validate_run_path
+from .yaml_pipeline import run_pipeline
 
 
 @dataclass
@@ -199,18 +200,38 @@ class Main:
 
 
 def main():
-    """Parse CLI arguments and dispatch to the selected subcommand."""
-    # Check to see if the user is passing in a yaml or json config file directly
+    """Parse CLI arguments and dispatch to the selected subcommand.
+
+    Three input shapes are supported:
+      1. `bergson pipeline <file.yaml>`        — multi-step pipeline mode
+      2. `bergson <command> <file.yaml|json>`  — single-command config-file mode
+      3. `bergson <command> --flag value ...`  — single-command CLI-flag mode
+    """
     args = sys.argv[1:]
+
+    # Build the {command_name: command_class} lookup once; both the pipeline
+    # branch and the single-command branch use it to resolve the user's verb.
+    command_classes = get_args(Main.__dataclass_fields__["command"].type)
+    command_registry = {cls.__name__.lower(): cls for cls in command_classes}
+
+    # Branch 1 — Pipeline mode: a YAML listing several commands to run in
+    # sequence. Delegates parsing + execution to `run_pipeline`.
+    if len(args) == 2 and args[0].lower() == "pipeline" and os.path.isfile(args[-1]):
+        run_pipeline(args[1], command_registry)
+        return
+
+    # Branch 2 — Single-command config-file mode: the user passes a command
+    # name and a path to a YAML or JSON file. `Serializable.load` sniffs the
+    # file extension and hydrates the matching dataclass.
     if len(args) == 2 and os.path.isfile(args[-1]):
         cmd_str, config_path = args
-
-        args = get_args(Main.__dataclass_fields__["command"].type)
-        names = {cls.__name__.lower(): cls for cls in args}
         try:
-            cmd_cls = names[cmd_str.lower()]
+            cmd_cls = command_registry[cmd_str.lower()]
         except KeyError:
-            print(f"Invalid command '{cmd_str}'. Valid commands are: {list(names)}")
+            print(
+                f"Invalid command '{cmd_str}'. "
+                f"Valid commands are: {list(command_registry)}"
+            )
             sys.exit(1)
 
         try:
@@ -218,6 +239,7 @@ def main():
         except RuntimeError as e:
             print(f"Failed to load config file {config_path}: {e}")
             sys.exit(1)
+    # Branch 3 — CLI-flag mode: standard argparse-style flag parsing.
     else:
         parser = ArgumentParser(conflict_resolution=ConflictResolution.EXPLICIT)
         parser.add_arguments(Main, dest="prog")

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -203,9 +203,10 @@ def main():
     """Parse CLI arguments and dispatch to the selected subcommand.
 
     Three input shapes are supported:
-      1. `bergson pipeline <file.yaml>`        — multi-step pipeline mode
-      2. `bergson <command> <file.yaml|json>`  — single-command config-file mode
-      3. `bergson <command> --flag value ...`  — single-command CLI-flag mode
+      `bergson <command> --flag value ...`  — single-command CLI-flag mode
+      `bergson pipeline <file.yaml>`        — multi-step pipeline mode
+      `bergson <command> <file.yaml|json>`  — single-command config-file mode
+
     """
     args = sys.argv[1:]
 
@@ -214,32 +215,31 @@ def main():
     command_classes = get_args(Main.__dataclass_fields__["command"].type)
     command_registry = {cls.__name__.lower(): cls for cls in command_classes}
 
-    # Branch 1 — Pipeline mode: a YAML listing several commands to run in
+    # Pipeline mode: a YAML listing several commands to run in
     # sequence. Delegates parsing + execution to `run_pipeline`.
     if len(args) == 2 and args[0].lower() == "pipeline" and os.path.isfile(args[-1]):
         run_pipeline(args[1], command_registry)
         return
 
-    # Branch 2 — Single-command config-file mode: the user passes a command
-    # name and a path to a YAML or JSON file. `Serializable.load` sniffs the
-    # file extension and hydrates the matching dataclass.
+    # Single-command config-file mode: the user passes a command
+    # name and a path to a YAML or JSON file.
     if len(args) == 2 and os.path.isfile(args[-1]):
         cmd_str, config_path = args
         try:
             cmd_cls = command_registry[cmd_str.lower()]
-        except KeyError:
-            print(
+        except KeyError as e:
+            raise ValueError(
                 f"Invalid command '{cmd_str}'. "
                 f"Valid commands are: {list(command_registry)}"
-            )
-            sys.exit(1)
+            ) from e
 
         try:
             prog = cmd_cls.load(config_path)
         except RuntimeError as e:
             print(f"Failed to load config file {config_path}: {e}")
             sys.exit(1)
-    # Branch 3 — CLI-flag mode: standard argparse-style flag parsing.
+
+    # CLI-flag mode: standard argparse-style flag parsing.
     else:
         parser = ArgumentParser(conflict_resolution=ConflictResolution.EXPLICIT)
         parser.add_arguments(Main, dest="prog")

--- a/bergson/yaml_pipeline.py
+++ b/bergson/yaml_pipeline.py
@@ -1,0 +1,63 @@
+"""Run a sequence of bergson commands defined in a YAML file."""
+
+import yaml
+
+
+def parse_pipeline(
+    config_path: str, command_registry: dict[str, type]
+) -> list[tuple[str, object]]:
+    """Read a pipeline YAML and hydrate each step into a command instance.
+
+    The YAML must be a list of single-key mappings. Each entry names a
+    registered command and contains that command's full, self-contained
+    config (the same shape that command accepts as a single-command YAML):
+
+        - hessian:
+            hessian_cfg:
+              method: kfac
+            index_cfg:
+              run_path: tests/build_path
+        - build:
+            index_cfg:
+              run_path: tests/build_path
+            preprocess_cfg: {}
+
+    All steps are parsed up-front so config errors fail fast, before any
+    expensive step runs.
+    """
+    with open(config_path) as f:
+        steps = yaml.safe_load(f)
+
+    if not isinstance(steps, list):
+        raise ValueError(
+            f"Pipeline YAML at {config_path} must be a list of step entries; "
+            f"got a top-level {type(steps).__name__}."
+        )
+
+    parsed: list[tuple[str, object]] = []
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict) or len(step) != 1:
+            raise ValueError(
+                f"Pipeline step {i} must be a single-key mapping "
+                f"(e.g. `- hessian: {{...}}`); got {step!r}."
+            )
+        ((cmd_name, cmd_dict),) = step.items()
+        try:
+            cmd_cls = command_registry[cmd_name.lower()]
+        except KeyError:
+            raise ValueError(
+                f"Pipeline step {i}: unknown command '{cmd_name}'. "
+                f"Valid commands: {sorted(command_registry)}."
+            ) from None
+        parsed.append((cmd_name, cmd_cls.from_dict(cmd_dict or {})))
+
+    return parsed
+
+
+def run_pipeline(config_path: str, command_registry: dict[str, type]) -> None:
+    """Parse a pipeline YAML and execute every step in order."""
+    steps = parse_pipeline(config_path, command_registry)
+    total = len(steps)
+    for i, (cmd_name, cmd) in enumerate(steps, start=1):
+        print(f"\n[pipeline] step {i}/{total}: {cmd_name}")
+        cmd.execute()

--- a/bergson/yaml_pipeline.py
+++ b/bergson/yaml_pipeline.py
@@ -1,11 +1,13 @@
 """Run a sequence of bergson commands defined in a YAML file."""
 
+from typing import Any
+
 import yaml
 
 
 def parse_pipeline(
     config_path: str, command_registry: dict[str, type]
-) -> list[tuple[str, object]]:
+) -> list[tuple[str, Any]]:
     """Read a pipeline YAML and hydrate each step into a command instance.
 
     The YAML must be a list of single-key mappings. Each entry names a
@@ -34,7 +36,7 @@ def parse_pipeline(
             f"got a top-level {type(steps).__name__}."
         )
 
-    parsed: list[tuple[str, object]] = []
+    parsed: list[tuple[str, Any]] = []
     for i, step in enumerate(steps):
         if not isinstance(step, dict) or len(step) != 1:
             raise ValueError(

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -1,12 +1,18 @@
 # NOTE: model is pinned to Pythia (nn.Linear) instead of GPT-2 because KFAC's
 # _init_covariance_dict assumes nn.Linear weight ordering and crashes on
 # HuggingFace Conv1D modules. See issue #254 — swap back to gpt2 once fixed.
+#
+# The two steps write to separate run_paths and each sets overwrite: true so
+# re-running the pipeline doesn't require manual `rm -r` of prior outputs.
+# (validate_run_path refuses to write into a non-empty directory unless
+# overwrite is set.)
 
 - hessian:
     hessian_cfg:
       method: kfac
     index_cfg:
-      run_path: runs/autocorrelation_and_index
+      run_path: runs/example_hessian
+      overwrite: true
       model: EleutherAI/pythia-14m
       token_batch_size: 1024
       data:
@@ -14,7 +20,8 @@
 
 - build:
     index_cfg:
-      run_path: runs/autocorrelation_and_index
+      run_path: runs/example_build
+      overwrite: true
       model: EleutherAI/pythia-14m
       token_batch_size: 1024
       data:

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -10,14 +10,14 @@
       run_path: runs/autocorrelation_and_index
       model: gpt2
       token_batch_size: 1024
-    data:
-      chunk_length: 1024
+      data:
+        chunk_length: 1024
 
 - build:
     index_cfg:
       run_path: runs/autocorrelation_and_index
       model: gpt2
       token_batch_size: 1024
-    data:
-      chunk_length: 1024
+      data:
+        chunk_length: 1024
     preprocess_cfg: {}

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -1,9 +1,13 @@
+# NOTE: model is pinned to Pythia (nn.Linear) instead of GPT-2 because KFAC's
+# _init_covariance_dict assumes nn.Linear weight ordering and crashes on
+# HuggingFace Conv1D modules. See issue #254 — swap back to gpt2 once fixed.
+
 - hessian:
     hessian_cfg:
       method: kfac
     index_cfg:
       run_path: runs/autocorrelation_and_index
-      model: gpt2
+      model: EleutherAI/pythia-14m
       token_batch_size: 1024
       data:
         chunk_length: 1024
@@ -11,7 +15,7 @@
 - build:
     index_cfg:
       run_path: runs/autocorrelation_and_index
-      model: gpt2
+      model: EleutherAI/pythia-14m
       token_batch_size: 1024
       data:
         chunk_length: 1024

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -9,9 +9,11 @@
     index_cfg:
       run_path: runs/autocorrelation_and_index
       model: gpt2
+      token_batch_size: 1024
 
 - build:
     index_cfg:
       run_path: runs/autocorrelation_and_index
       model: gpt2
+      token_batch_size: 1024
     preprocess_cfg: {}

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -1,11 +1,6 @@
 # NOTE: model is pinned to Pythia (nn.Linear) instead of GPT-2 because KFAC's
 # _init_covariance_dict assumes nn.Linear weight ordering and crashes on
 # HuggingFace Conv1D modules. See issue #254 — swap back to gpt2 once fixed.
-#
-# The two steps write to separate run_paths and each sets overwrite: true so
-# re-running the pipeline doesn't require manual `rm -r` of prior outputs.
-# (validate_run_path refuses to write into a non-empty directory unless
-# overwrite is set.)
 
 - hessian:
     hessian_cfg:

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -1,8 +1,3 @@
-# Each list entry is a single registered command (see `bergson --help`).
-# Each step is fully self-contained: it carries every sub-config the
-# matching command would need on its own. There is intentionally no
-# top-level shared state — repeat values like `run_path` in every step.
-
 - hessian:
     hessian_cfg:
       method: kfac

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -10,10 +10,14 @@
       run_path: runs/autocorrelation_and_index
       model: gpt2
       token_batch_size: 1024
+    data:
+      chunk_length: 1024
 
 - build:
     index_cfg:
       run_path: runs/autocorrelation_and_index
       model: gpt2
       token_batch_size: 1024
+    data:
+      chunk_length: 1024
     preprocess_cfg: {}

--- a/examples/pipelines/hessian_then_build.yaml
+++ b/examples/pipelines/hessian_then_build.yaml
@@ -1,0 +1,17 @@
+# Each list entry is a single registered command (see `bergson --help`).
+# Each step is fully self-contained: it carries every sub-config the
+# matching command would need on its own. There is intentionally no
+# top-level shared state — repeat values like `run_path` in every step.
+
+- hessian:
+    hessian_cfg:
+      method: kfac
+    index_cfg:
+      run_path: runs/autocorrelation_and_index
+      model: gpt2
+
+- build:
+    index_cfg:
+      run_path: runs/autocorrelation_and_index
+      model: gpt2
+    preprocess_cfg: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "scipy",
     "peft>=0.17.0",
     "pyarrow",
+    "pyyaml",
     "simple-parsing",
     "torch",
     "torchopt",

--- a/tests/test_yaml_pipeline.py
+++ b/tests/test_yaml_pipeline.py
@@ -1,0 +1,133 @@
+"""Unit tests for the multi-step YAML pipeline runner.
+
+These tests exercise parsing only — they never call `.execute()`, so they
+need no GPU and no model downloads.
+"""
+
+from typing import get_args
+
+import pytest
+
+from bergson.__main__ import Build, Hessian, Main
+from bergson.config import HessianConfig, IndexConfig, PreprocessConfig
+from bergson.yaml_pipeline import parse_pipeline
+
+
+@pytest.fixture
+def registry() -> dict[str, type]:
+    classes = get_args(Main.__dataclass_fields__["command"].type)
+    return {cls.__name__.lower(): cls for cls in classes}
+
+
+def write(tmp_path, body: str) -> str:
+    path = tmp_path / "pipeline.yaml"
+    path.write_text(body)
+    return str(path)
+
+
+def test_parse_pipeline_hydrates_steps_in_order(tmp_path, registry):
+    """A valid two-step pipeline produces typed commands with the right configs."""
+    yaml_path = write(
+        tmp_path,
+        """
+- hessian:
+    hessian_cfg:
+      method: tkfac
+    index_cfg:
+      run_path: runs/test
+      model: gpt2
+- build:
+    index_cfg:
+      run_path: runs/test
+      model: gpt2
+    preprocess_cfg: {}
+""",
+    )
+
+    steps = parse_pipeline(yaml_path, registry)
+
+    assert [name for name, _ in steps] == ["hessian", "build"]
+
+    _, hessian_cmd = steps[0]
+    assert isinstance(hessian_cmd, Hessian)
+    assert isinstance(hessian_cmd.hessian_cfg, HessianConfig)
+    assert hessian_cmd.hessian_cfg.method == "tkfac"
+    assert isinstance(hessian_cmd.index_cfg, IndexConfig)
+    assert hessian_cmd.index_cfg.run_path == "runs/test"
+    assert hessian_cmd.index_cfg.model == "gpt2"
+
+    _, build_cmd = steps[1]
+    assert isinstance(build_cmd, Build)
+    assert isinstance(build_cmd.index_cfg, IndexConfig)
+    assert build_cmd.index_cfg.run_path == "runs/test"
+    assert isinstance(build_cmd.preprocess_cfg, PreprocessConfig)
+
+
+def test_command_name_is_case_insensitive(tmp_path, registry):
+    yaml_path = write(
+        tmp_path,
+        """
+- Hessian:
+    hessian_cfg: {method: kfac}
+    index_cfg: {run_path: runs/test}
+""",
+    )
+    steps = parse_pipeline(yaml_path, registry)
+    assert isinstance(steps[0][1], Hessian)
+
+
+def test_top_level_must_be_a_list(tmp_path, registry):
+    yaml_path = write(
+        tmp_path,
+        """
+hessian:
+  hessian_cfg: {method: kfac}
+""",
+    )
+    with pytest.raises(ValueError, match="must be a list"):
+        parse_pipeline(yaml_path, registry)
+
+
+def test_step_must_be_single_key_mapping(tmp_path, registry):
+    yaml_path = write(
+        tmp_path,
+        """
+- hessian:
+    hessian_cfg: {method: kfac}
+    index_cfg: {run_path: runs/test}
+  build:
+    index_cfg: {run_path: runs/test}
+    preprocess_cfg: {}
+""",
+    )
+    with pytest.raises(ValueError, match="single-key mapping"):
+        parse_pipeline(yaml_path, registry)
+
+
+def test_unknown_command_raises(tmp_path, registry):
+    yaml_path = write(
+        tmp_path,
+        """
+- not_a_real_command:
+    foo: bar
+""",
+    )
+    with pytest.raises(ValueError, match="unknown command 'not_a_real_command'"):
+        parse_pipeline(yaml_path, registry)
+
+
+def test_empty_step_body_uses_dataclass_defaults(tmp_path, registry):
+    """An entry with no body should still hydrate."""
+    yaml_path = write(
+        tmp_path,
+        """
+- hessian:
+    hessian_cfg: {}
+    index_cfg: {run_path: runs/test}
+""",
+    )
+    steps = parse_pipeline(yaml_path, registry)
+    _, cmd = steps[0]
+    assert isinstance(cmd, Hessian)
+    # `method` has a default on HessianConfig — round-trip leaves it intact.
+    assert cmd.hessian_cfg.method == HessianConfig().method


### PR DESCRIPTION
See notes in [Linear](https://linear.app/eleutherai-interpretability/issue/ELE-11/add-yaml-mediated-search-pipeline-to-bergson) on the test, which seemed to expose a bug deeper in the library. (I've now dealt with this bug [here](https://github.com/EleutherAI/bergson/pull/252).

Adds a generic `bergson pipeline <file.yaml>` command that runs a sequence of existing bergson subcommands defined in a YAML file. This unblocks pipelines (`build_EKFAC.yaml`, `query_EKFAC.yaml`, …) without writing a new Python entry point per pipeline.

- **New module** — `bergson/yaml_pipeline.py`: `parse_pipeline()` reads the YAML once, validates its shape, and hydrates each step into the matching command dataclass via `simple_parsing`'s `Serializable.from_dict`. Defaults from the existing dataclasses fill in any unspecified fields automatically. All steps are parsed up-front so a config error in step N fails before step 1 burns compute. `run_pipeline()` parses then executes in order.
- **`bergson/__main__.py`**: adds a third branch to `main()` for pipeline mode alongside the existing single-command-from-file and CLI-flag modes. Hoists the `{name: class}` registry out of the existing branch so both branches share it. 
- **`pyproject.toml`**: declares `pyyaml` as a direct dep. (It was already required transitively by `Serializable.load` for the existing single-command YAML flow; this just documents that.)
- **Example** — `examples/pipelines/hessian_then_build.yaml`: minimal hessian-then-build pipeline.

## YAML format

A pipeline is a **list of single-key mappings**. Each entry's key is a registered command name (case-insensitive) and its value is the same config tree that command accepts as a single-command YAML so each step is fully self-contained.

```yaml
- hessian:
    hessian_cfg:
      method: kfac
    index_cfg:
      run_path: runs/example
      model: gpt2
- build:
    index_cfg:
      run_path: runs/example
      model: gpt2
    preprocess_cfg: {}
```

A list (not a mapping) is required because YAML mappings can't preserve order or duplicates, and pipelines need both.

## What's deferred

- **Shared values across steps** (e.g. one `run_path` injected into every step) are not supported — each step must currently repeat its config. Easy to layer on later via a top-level `defaults:` block; should we do this, @luciaquirke?
- **`Test_Model_Configuration` can't be a pipeline step** because `DiagnoseConfig` isn't `Serializable`. This is a pre-existing limitation — `bergson test_model_configuration <yaml>` doesn't work today either — and out of scope here.

## Follow-up needed for `build_EKFAC.yaml` and `query_EKFAC.yaml`

- **`build_EKFAC.yaml`** would work today by wrapping the existing `hessian` command.
- **`query_EKFAC.yaml`** is partially blocked: step 3 of the EKFAC flow (\"apply inverse Hessian to the mean query gradient\") is not currently exposed as a top-level CLI command — it lives as `apply_worker` inside `bergson/hessians/pipeline.py`. A small follow-up PR will lift it into an `apply_hessian` command so the full query pipeline can be expressed as YAML.

(@luciaquirke I had a go at this with Claude [here](https://github.com/EleutherAI/bergson/pull/247) but closed that PR so we can focus on this one. Not looked at that yet.)