### PR TITLE
Expose apply_hessian as a top-level CLI command

### DIFF
--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Union, get_args
 
 from simple_parsing import ArgumentParser, ConflictResolution, Serializable
@@ -9,6 +9,7 @@ from bergson.hessians.pipeline import hessian_pipeline
 
 from .build import build
 from .config import (
+    DistributedConfig,
     HessianConfig,
     HessianPipelineConfig,
     IndexConfig,
@@ -18,6 +19,8 @@ from .config import (
     TrackstarConfig,
 )
 from .diagnose import DiagnoseConfig, diagnose
+from .distributed import launch_distributed_run
+from .hessians.apply_hessian import EkfacConfig, apply_worker
 from .hessians.hessian_approximations import approximate_hessians
 from .magic import MagicConfig, run_magic
 from .query.query_index import query
@@ -25,6 +28,31 @@ from .score.score import score_dataset
 from .trackstar import trackstar
 from .utils.worker_utils import validate_run_path
 from .yaml_pipeline import run_pipeline
+
+
+@dataclass
+class Apply_Hessian(Serializable):
+    """Apply a precomputed inverse Hessian to a saved query gradient.
+
+    Reads the Hessian factors written by `bergson hessian` and the mean
+    query gradient written by `bergson build` (with `aggregation: mean`),
+    and writes the inverse-Hessian-vector product (transformed query) to
+    `ekfac_cfg.run_path`. Used as the middle step of the EKFAC influence
+    flow, between building the query gradient and scoring training data
+    against it.
+    """
+
+    ekfac_cfg: EkfacConfig
+
+    distributed_cfg: DistributedConfig = field(default_factory=DistributedConfig)
+
+    def execute(self):
+        launch_distributed_run(
+            "apply_hessian",
+            apply_worker,
+            [self.ekfac_cfg],
+            self.distributed_cfg,
+        )
 
 
 @dataclass
@@ -182,6 +210,7 @@ class Main:
     """Routes to the subcommands."""
 
     command: Union[
+        Apply_Hessian,
         Build,
         Ekfac,
         Hessian,

--- a/bergson/hessians/apply_hessian.py
+++ b/bergson/hessians/apply_hessian.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from safetensors.torch import load_file
-from simple_parsing import ArgumentParser
+from simple_parsing import ArgumentParser, Serializable
 from torch import Tensor
 
 from bergson.data import create_index, load_gradients
@@ -17,7 +17,7 @@ from bergson.utils.logger import get_logger
 
 
 @dataclass
-class EkfacConfig:
+class EkfacConfig(Serializable):
     hessian_method_path: str
     gradient_path: str
     run_path: str

--- a/examples/pipelines/build_EKFAC.yaml
+++ b/examples/pipelines/build_EKFAC.yaml
@@ -1,0 +1,18 @@
+# Build the reusable half of an EKFAC influence run: fit Hessian factors
+# (eigen-decompositions of activation/gradient covariances + per-layer
+# eigenvalue corrections) on the training dataset. The resulting
+# `runs/ekfac/hessian/kfac/` directory is consumed by `query_EKFAC.yaml`
+# once per query you want to ask — it does not depend on the query data.
+
+- hessian:
+    hessian_cfg:
+      method: kfac
+      ev_correction: true   # the "E" in EKFAC
+    index_cfg:
+      run_path: runs/ekfac/hessian
+      model: gpt2
+      data:
+        dataset: Salesforce/wikitext
+        subset: wikitext-2-raw-v1
+        split: "train[:512]"
+        chunk_length: 128

--- a/examples/pipelines/query_EKFAC.yaml
+++ b/examples/pipelines/query_EKFAC.yaml
@@ -1,0 +1,49 @@
+# Run the per-query half of the EKFAC influence flow against the Hessian
+# factors written by `build_EKFAC.yaml`. Three steps:
+#   1. build  — collect the mean query gradient across the query dataset
+#   2. apply_hessian — multiply that mean gradient by H^{-1} in eigenbasis
+#   3. score  — score every training example against the transformed query
+
+# Step 1 — mean query gradient.
+# `aggregation: mean` averages across the dataset; `projection_dim: 0` and
+# `skip_preconditioners: true` skip work this step doesn't need.
+- build:
+    index_cfg:
+      run_path: runs/ekfac/query
+      model: gpt2
+      projection_dim: 0
+      skip_preconditioners: true
+      data:
+        dataset: Salesforce/wikitext
+        subset: wikitext-2-raw-v1
+        split: "validation[:32]"
+        chunk_length: 128
+    preprocess_cfg:
+      aggregation: mean
+
+# Step 2 — apply inverse Hessian to the mean query gradient.
+# `hessian_method_path` points at the per-method subdir produced by
+# build_EKFAC (`<hessian_run_path>/<method>/`). For method=kfac that's
+# `runs/ekfac/hessian/kfac`.
+- apply_hessian:
+    ekfac_cfg:
+      hessian_method_path: runs/ekfac/hessian/kfac
+      gradient_path: runs/ekfac/query
+      run_path: runs/ekfac/kfac_query
+      lambda_damp_factor: 0.1
+
+# Step 3 — score training examples against the transformed query.
+- score:
+    index_cfg:
+      run_path: runs/ekfac/scores
+      model: gpt2
+      projection_dim: 0
+      skip_preconditioners: true
+      data:
+        dataset: Salesforce/wikitext
+        subset: wikitext-2-raw-v1
+        split: "train[:512]"
+        chunk_length: 128
+    score_cfg:
+      query_path: runs/ekfac/kfac_query
+    preprocess_cfg: {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 SUBCOMMANDS = [
+    "apply_hessian",
     "build",
     "ekfac",
     "hessian",

--- a/tests/test_yaml_pipeline.py
+++ b/tests/test_yaml_pipeline.py
@@ -4,13 +4,17 @@ These tests exercise parsing only — they never call `.execute()`, so they
 need no GPU and no model downloads.
 """
 
+from pathlib import Path
 from typing import get_args
 
 import pytest
 
-from bergson.__main__ import Build, Hessian, Main
+from bergson.__main__ import Apply_Hessian, Build, Hessian, Main, Score
 from bergson.config import HessianConfig, IndexConfig, PreprocessConfig
+from bergson.hessians.apply_hessian import EkfacConfig
 from bergson.yaml_pipeline import parse_pipeline
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples" / "pipelines"
 
 
 @pytest.fixture
@@ -114,6 +118,37 @@ def test_unknown_command_raises(tmp_path, registry):
     )
     with pytest.raises(ValueError, match="unknown command 'not_a_real_command'"):
         parse_pipeline(yaml_path, registry)
+
+
+def test_build_ekfac_example_parses(registry):
+    """`build_EKFAC.yaml` must parse into a single hessian step."""
+    steps = parse_pipeline(str(EXAMPLES / "build_EKFAC.yaml"), registry)
+    assert len(steps) == 1
+    name, cmd = steps[0]
+    assert name == "hessian"
+    assert isinstance(cmd, Hessian)
+    assert cmd.hessian_cfg.method == "kfac"
+    assert cmd.hessian_cfg.ev_correction is True
+
+
+def test_query_ekfac_example_parses(registry):
+    """`query_EKFAC.yaml` must parse build → apply_hessian → score."""
+    steps = parse_pipeline(str(EXAMPLES / "query_EKFAC.yaml"), registry)
+    assert [name for name, _ in steps] == ["build", "apply_hessian", "score"]
+
+    _, build_cmd = steps[0]
+    assert isinstance(build_cmd, Build)
+    assert build_cmd.preprocess_cfg.aggregation == "mean"
+
+    _, apply_cmd = steps[1]
+    assert isinstance(apply_cmd, Apply_Hessian)
+    assert isinstance(apply_cmd.ekfac_cfg, EkfacConfig)
+    assert apply_cmd.ekfac_cfg.hessian_method_path == "runs/ekfac/hessian/kfac"
+
+    _, score_cmd = steps[2]
+    assert isinstance(score_cmd, Score)
+    # The score step's query_path must point at apply_hessian's output.
+    assert score_cmd.score_cfg.query_path == apply_cmd.ekfac_cfg.run_path
 
 
 def test_empty_step_body_uses_dataclass_defaults(tmp_path, registry):


### PR DESCRIPTION
**Stacked on top of #246** — please review/merge that one first. This PR will be rebased onto `main` automatically once #246 lands.

## Summary

Lifts the EKFAC inverse-Hessian-vector-product step out of the private `apply_worker` inside `bergson/hessians/pipeline.py` and registers it as a `bergson apply_hessian ...` top-level command. This unblocks expressing the per-query half of the EKFAC influence flow as a YAML pipeline, so the `query_EKFAC.yaml` artifact named in the Linear ticket becomes a real, runnable file rather than aspirational documentation.

- **`bergson/__main__.py`** — adds `Apply_Hessian(Serializable)` with an `EkfacConfig` and a `DistributedConfig` field; `execute()` calls `launch_distributed_run("apply_hessian", apply_worker, …)` exactly as the existing `hessian_pipeline` orchestrator does internally. Adds `Apply_Hessian` to the `Main.command` Union so it's reachable from every input shape (CLI flags, single-command YAML, multi-step pipeline).
- **`bergson/hessians/apply_hessian.py`** — `EkfacConfig` now inherits from `simple_parsing.Serializable` so it picks up `from_dict`/`load`. No behavior change for the existing `python -m bergson.hessians.apply_hessian` entry point.
- **`examples/pipelines/build_EKFAC.yaml`** — single-step pipeline that fits Hessian factors with `ev_correction: true`. Output is reusable across queries.
- **`examples/pipelines/query_EKFAC.yaml`** — three-step pipeline: `build` (mean query gradient with `aggregation: mean`) → `apply_hessian` (multiply by H^{-1}) → `score` (training examples vs transformed query). Inline comments explain why each step's config has the non-default fields it does.

## Test plan

- [x] `tests/test_yaml_pipeline.py` — two new parse-only tests that hydrate both example YAMLs and assert the expected step types, values, and that `query_EKFAC.yaml`'s `score.query_path` matches `apply_hessian.run_path`.
- [x] `tests/test_cli.py` — `apply_hessian` added to the help-output regression list.
- [x] Local: 19/19 tests pass in 31s (no GPU needed for any of these).
- [ ] Cluster smoke test: `bergson pipeline examples/pipelines/build_EKFAC.yaml` then `bergson pipeline examples/pipelines/query_EKFAC.yaml` (both should complete on a single A40 against the small wikitext slice).

## Notes for reviewers

- I deliberately did **not** delete the `if __name__ == \"__main__\":` block at the bottom of `bergson/hessians/apply_hessian.py`. It's redundant with the new top-level command but removing it would break any script invoking `python -m bergson.hessians.apply_hessian ...` directly. Easy to drop later in a separate cleanup PR if no one is using it.
- `Apply_Hessian` uses underscore_separated capitalization to match the existing `Test_Model_Configuration` convention so the lowercased CLI name reads naturally (`bergson apply_hessian …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)