### PR TITLE
Fix test_build_consistency by matching the cached loss reduction

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -58,6 +58,7 @@ def test_build_consistency(tmp_path: Path, model, dataset):
         run_path=str(tmp_path),
         skip_preconditioners=True,
         token_batch_size=1024,
+        loss_reduction="mean",
     )
     collect_gradients(
         model=model,


### PR DESCRIPTION
The cached gradient in runs/test_build_cache.npy was generated with loss_reduction="mean", but the test was using the IndexConfig default of "sum", causing the consistency check to fail.