### PR TITLE
Fix tests

### DIFF
--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -1,0 +1,115 @@
+"""Tests for conversation tokenization with label masking."""
+
+import pytest
+from transformers import AutoTokenizer
+
+from bergson.config import DataConfig
+from bergson.data import tokenize
+
+
+@pytest.fixture
+def tokenizer():
+    return AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM2-135M-Instruct")
+
+
+def _make_batch(convos):
+    """Wrap a list of conversations into a batch dict."""
+    return {"conversation": convos}
+
+
+def test_single_turn_labels(tokenizer):
+    """Assistant response in a single-turn conversation gets labels."""
+    batch = _make_batch(
+        [
+            [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        ]
+    )
+    cfg = DataConfig(conversation_column="conversation")
+    result = tokenize(batch, args=cfg, tokenizer=tokenizer)
+    labels = result["labels"][0]
+    # Some labels should be active (not -100)
+    assert any(l != -100 for l in labels)
+
+
+def test_multi_turn_labels(tokenizer):
+    """All assistant turns get labels in a multi-turn conversation."""
+    batch = _make_batch(
+        [
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "user", "content": "How are you?"},
+                {"role": "assistant", "content": "I'm great, thanks!"},
+            ]
+        ]
+    )
+    cfg = DataConfig(conversation_column="conversation")
+    result = tokenize(batch, args=cfg, tokenizer=tokenizer)
+    labels = result["labels"][0]
+    active = [i for i, l in enumerate(labels) if l != -100]
+    # Should have two non-contiguous active regions (one per assistant turn)
+    assert len(active) > 2
+    # Check there's a gap (labels for user content are -100)
+    gaps = [active[i + 1] - active[i] for i in range(len(active) - 1)]
+    assert any(g > 1 for g in gaps), "Expected gap between assistant turns"
+
+
+def test_truncation_preserves_partial_span(tokenizer):
+    """When truncation cuts through an assistant response, labels should be
+    assigned up to the truncation boundary — not dropped entirely."""
+    # Create a conversation where the assistant response is long enough to
+    # extend past a short max_length
+    short_answer = "Short."
+    long_answer = "word " * 200  # ~200 tokens, will be truncated
+    batch = _make_batch(
+        [
+            [
+                {"role": "user", "content": "Q1"},
+                {"role": "assistant", "content": short_answer},
+                {"role": "user", "content": "Q2"},
+                {"role": "assistant", "content": long_answer},
+            ]
+        ]
+    )
+    cfg = DataConfig(conversation_column="conversation", truncation=True)
+    max_length = 64
+    result = tokenize(batch, args=cfg, tokenizer=tokenizer, max_length=max_length)
+
+    labels = result["labels"][0]
+    tokens = result["input_ids"][0]
+    assert len(labels) == len(tokens) == max_length
+
+    # The second assistant response should have SOME active labels even though
+    # it's truncated — this was the bug: they were all set to -100
+    active = sum(1 for l in labels if l != -100)
+    assert active > 0, (
+        "Truncated assistant span should still have active labels "
+        "up to the truncation boundary"
+    )
+
+
+def test_fully_truncated_span_skipped(tokenizer):
+    """When an entire assistant span is past the truncation boundary, it should
+    be skipped without error."""
+    # First turn is very long, second turn is entirely truncated
+    long_answer = "word " * 500
+    batch = _make_batch(
+        [
+            [
+                {"role": "user", "content": "Q1"},
+                {"role": "assistant", "content": long_answer},
+                {"role": "user", "content": "Q2"},
+                {"role": "assistant", "content": "This will be truncated away"},
+            ]
+        ]
+    )
+    cfg = DataConfig(conversation_column="conversation", truncation=True)
+    max_length = 64
+    result = tokenize(batch, args=cfg, tokenizer=tokenizer, max_length=max_length)
+
+    labels = result["labels"][0]
+    assert len(labels) == max_length
+    # Should not raise, and should still have some labels from the first turn

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -115,7 +115,9 @@ def test_long_documents_truncated(tmp_path, model, token_batch_size):
 def test_long_documents_fail_without_truncation(tmp_path, model, token_batch_size):
     """Without truncation, we fail when a document exceeds token_batch_size."""
     doc_tokens = token_batch_size + 1
-    with pytest.warns(UserWarning, match="longer than the model can handle"):
+    with pytest.warns(
+        UserWarning, match="longer than (the model can handle|token_batch_size)"
+    ):
         with pytest.raises(RuntimeError, match="too long"):
             run_pipeline(
                 tmp_path, model, token_batch_size, doc_tokens, truncation=False

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -11,10 +11,7 @@ from bergson.config import DataConfig, IndexConfig
 from bergson.data import allocate_batches
 from bergson.utils.worker_utils import setup_data_pipeline
 
-# GPT-2: model_max_length=max_position_embeddings
-# Pythia-14m: model_max_length=very large
 GPT2 = "openai-community/gpt2"
-PYTHIA = "EleutherAI/pythia-14m"
 
 
 def get_max_position_embeddings(model_name):
@@ -23,7 +20,6 @@ def get_max_position_embeddings(model_name):
 
 
 GPT2_MAX_POS_EMB = get_max_position_embeddings(GPT2)
-PYTHIA_MAX_POS_EMB = get_max_position_embeddings(PYTHIA)
 
 
 def create_documents_file(tmp_path, model, doc_tokens):
@@ -69,12 +65,8 @@ def run_pipeline(tmp_path, model_name, token_batch_size, doc_tokens, truncation)
     [
         # token_batch_size < max_position_embeddings
         (GPT2, GPT2_MAX_POS_EMB // 2),
-        (PYTHIA, PYTHIA_MAX_POS_EMB // 2),
         # token_batch_size = max_position_embeddings
         (GPT2, GPT2_MAX_POS_EMB),
-        (PYTHIA, PYTHIA_MAX_POS_EMB),
-        # token_batch_size > max_position_embeddings
-        (PYTHIA, PYTHIA_MAX_POS_EMB * 2),
     ],
 )
 def test_short_documents(tmp_path, model, token_batch_size, truncation):
@@ -94,14 +86,8 @@ def test_short_documents(tmp_path, model, token_batch_size, truncation):
     [
         # token_batch_size < max_position_embeddings: truncates to token_batch_size
         (GPT2, GPT2_MAX_POS_EMB // 2),
-        (PYTHIA, PYTHIA_MAX_POS_EMB // 2),
         # token_batch_size = max_position_embeddings: truncates to both
         (GPT2, GPT2_MAX_POS_EMB),
-        (PYTHIA, PYTHIA_MAX_POS_EMB),
-        # token_batch_size > max_position_embeddings:
-        # truncates to max_position_embeddings
-        # (for GPT2, see `test_token_batch_size_exceeds_model_max_length`)
-        (PYTHIA, PYTHIA_MAX_POS_EMB * 2),
     ],
 )
 def test_long_documents_truncated(tmp_path, model, token_batch_size):
@@ -122,13 +108,8 @@ def test_long_documents_truncated(tmp_path, model, token_batch_size):
     [
         # token_batch_size < max_position_embeddings
         (GPT2, GPT2_MAX_POS_EMB // 2),
-        (PYTHIA, PYTHIA_MAX_POS_EMB // 2),
         # token_batch_size = max_position_embeddings
         (GPT2, GPT2_MAX_POS_EMB),
-        (PYTHIA, PYTHIA_MAX_POS_EMB),
-        # token_batch_size > max_position_embeddings
-        # (for GPT2, see `test_token_batch_size_exceeds_model_max_length`)
-        (PYTHIA, PYTHIA_MAX_POS_EMB * 2),
     ],
 )
 def test_long_documents_fail_without_truncation(tmp_path, model, token_batch_size):
@@ -139,20 +120,6 @@ def test_long_documents_fail_without_truncation(tmp_path, model, token_batch_siz
             run_pipeline(
                 tmp_path, model, token_batch_size, doc_tokens, truncation=False
             )
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_long_documents_warn_without_truncation(tmp_path):
-    """Without truncation, we warn when a document exceeds max_position_embeddings
-    but not token_batch_size.
-    """
-    # Only possible when token_batch_size > max_position_embeddings (requires PYTHIA)
-    token_batch_size = PYTHIA_MAX_POS_EMB * 3
-    doc_tokens = (
-        PYTHIA_MAX_POS_EMB * 2
-    )  # max_position_embeddings < doc_tokens < token_batch_size
-    with pytest.warns(UserWarning, match="longer than the model can handle"):
-        run_pipeline(tmp_path, PYTHIA, token_batch_size, doc_tokens, truncation=False)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
- Remove some tests that were made invalid when we changed our strategy to raise an error when a sequence length or token batch size is longer than the model's max positional embedding position
- - Add this test_tokenize file that was in my working directory for some reason (good I hope)