### PR TITLE
Require torch>=2.4 for FSDP2 fully_shard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "peft>=0.17.0",
     "pyarrow",
     "simple-parsing",
-    "torch",
+    "torch>=2.4",
     "torchopt",
     "transformers",
     "bitsandbytes"


### PR DESCRIPTION
## Summary

- `bergson/utils/worker_utils.py` imports `fully_shard` from `torch.distributed.fsdp`. That symbol is part of the **FSDP2** API and is only available in **PyTorch ≥ 2.4**.
- `pyproject.toml` previously declared the dependency as `"torch"` with no lower bound, so fresh installs on environments with older torch wheels fail at first import:

  ```
  ImportError: cannot import name 'fully_shard' from 'torch.distributed.fsdp'
  ```

- This PR adds `"torch>=2.4"` to `[project].dependencies` so the requirement is enforced at install time instead of surfacing as a confusing import error the first time the CLI is invoked.

## Why a floor and not a guarded import

The `fully_shard` import is unconditional at module load, so any codepath that touches `worker_utils` (which includes `bergson` CLI startup) needs FSDP2. A guarded/lazy import would let `import bergson` succeed but defer the failure into runtime — that's strictly worse than a clear install-time error.