### PR TITLE
Add build → score pipeline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Many workflows chain several Bergson commands together. Rather than running each
 bergson pipeline <path_to_yaml>
 ```
 
-The YAML is a list of single-key entries, one per step, each holding that command's full config. See [`examples/pipelines/hessian_then_build.yaml`](examples/pipelines/hessian_then_build.yaml) for a runnable Hessian → build example.
+The YAML is a list of single-key entries, one per step, each holding that command's full config. See [`examples/pipelines/hessian_then_build.yaml`](examples/pipelines/hessian_then_build.yaml) for a runnable Hessian → build example, or [`examples/pipelines/build_then_score.yaml`](examples/pipelines/build_then_score.yaml) for a build → score example using the no-compression scoring path (`projection_dim: 0`).
 
 ## Query an On-Disk Gradient Index
 

--- a/examples/pipelines/build_then_score.yaml
+++ b/examples/pipelines/build_then_score.yaml
@@ -1,0 +1,38 @@
+# Build a one-gradient query index, then score a dataset against it.
+#
+# This pipeline demonstrates the no-compression scoring path: gradients
+# are kept at full model dimensionality (`projection_dim: 0`) and
+# influence is computed as a raw dot product between the query gradient
+# and each training gradient.
+#
+# Run with:
+#     bergson pipeline examples/pipelines/build_then_score.yaml
+
+- build:
+    index_cfg:
+      run_path: runs/example_query
+      model: gpt2
+      projection_dim: 0
+      token_batch_size: 1024
+      data:
+        dataset: NeelNanda/pile-10k
+        split: "train[:20]"
+        chunk_length: 1024
+    preprocess_cfg:
+      aggregation: mean
+
+- score:
+    score_cfg:
+      query_path: runs/example_query
+      score: individual
+    index_cfg:
+      run_path: runs/example_scores
+      model: gpt2
+      projection_dim: 0
+      token_batch_size: 1024
+      data:
+        dataset: NeelNanda/pile-10k
+        split: "train[:100]"
+        chunk_length: 1024
+    preprocess_cfg:
+      aggregation: mean

--- a/examples/pipelines/build_then_score.yaml
+++ b/examples/pipelines/build_then_score.yaml
@@ -34,6 +34,7 @@
       run_path: runs/example_scores
       model: gpt2
       projection_dim: 0
+      skip_preconditioners: true
       token_batch_size: 1024
       data:
         dataset: NeelNanda/pile-10k

--- a/examples/pipelines/build_then_score.yaml
+++ b/examples/pipelines/build_then_score.yaml
@@ -13,6 +13,11 @@
       run_path: runs/example_query
       model: gpt2
       projection_dim: 0
+      # With projection_dim=0 the full per-token gradient is kept, so the
+      # default Adafactor-style P.mT @ P preconditioner would be a
+      # (full_grad_dim x full_grad_dim) matrix — multi-TB even for GPT-2.
+      # No-compression scoring uses raw dot products, not preconditioned ones.
+      skip_preconditioners: true
       token_batch_size: 1024
       data:
         dataset: NeelNanda/pile-10k

--- a/tests/test_yaml_pipeline.py
+++ b/tests/test_yaml_pipeline.py
@@ -4,13 +4,16 @@ These tests exercise parsing only — they never call `.execute()`, so they
 need no GPU and no model downloads.
 """
 
+from pathlib import Path
 from typing import get_args
 
 import pytest
 
-from bergson.__main__ import Build, Hessian, Main
-from bergson.config import HessianConfig, IndexConfig, PreprocessConfig
+from bergson.__main__ import Build, Hessian, Main, Score
+from bergson.config import HessianConfig, IndexConfig, PreprocessConfig, ScoreConfig
 from bergson.yaml_pipeline import parse_pipeline
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples" / "pipelines"
 
 
 @pytest.fixture
@@ -114,6 +117,34 @@ def test_unknown_command_raises(tmp_path, registry):
     )
     with pytest.raises(ValueError, match="unknown command 'not_a_real_command'"):
         parse_pipeline(yaml_path, registry)
+
+
+def test_build_then_score_example_parses(registry):
+    """The shipped build->score example YAML hydrates into the right commands."""
+    steps = parse_pipeline(str(EXAMPLES_DIR / "build_then_score.yaml"), registry)
+
+    assert [name for name, _ in steps] == ["build", "score"]
+
+    _, build_cmd = steps[0]
+    assert isinstance(build_cmd, Build)
+    assert isinstance(build_cmd.index_cfg, IndexConfig)
+    assert build_cmd.index_cfg.run_path == "runs/example_query"
+    assert build_cmd.index_cfg.model == "gpt2"
+    assert build_cmd.index_cfg.projection_dim == 0
+    assert build_cmd.index_cfg.data.split == "train[:20]"
+    assert isinstance(build_cmd.preprocess_cfg, PreprocessConfig)
+    assert build_cmd.preprocess_cfg.aggregation == "mean"
+
+    _, score_cmd = steps[1]
+    assert isinstance(score_cmd, Score)
+    assert isinstance(score_cmd.score_cfg, ScoreConfig)
+    assert score_cmd.score_cfg.query_path == "runs/example_query"
+    assert score_cmd.score_cfg.score == "individual"
+    assert isinstance(score_cmd.index_cfg, IndexConfig)
+    assert score_cmd.index_cfg.run_path == "runs/example_scores"
+    assert score_cmd.index_cfg.projection_dim == 0
+    assert isinstance(score_cmd.preprocess_cfg, PreprocessConfig)
+    assert score_cmd.preprocess_cfg.aggregation == "mean"
 
 
 def test_empty_step_body_uses_dataclass_defaults(tmp_path, registry):


### PR DESCRIPTION
## Summary

Adds a runnable two-step pipeline example demonstrating the no-compression scoring path:

```bash
bergson pipeline examples/pipelines/build_then_score.yaml
```

Step 1 (`build`) creates a one-gradient on-disk query index with `projection_dim: 0` and `aggregation: mean`. Step 2 (`score`) loads that query into memory and dot-products it against each item in a small slice of `NeelNanda/pile-10k`, producing per-item influence scores. Until now, this required two CLI invocations — this single YAML now drives the whole flow through `bergson pipeline`.

## Why

1. **Showcase the YAML pipeline functionality** introduced in #246 with a real, useful example.
2. **Demonstrate a feature that previously required multiple commands** (`bergson build` + `bergson score`) — now reducible to a single `bergson pipeline` invocation.
3. **Lay groundwork for EK-FAC support in `score`** — having an end-to-end no-compression scoring pipeline in YAML form is a prerequisite for then layering Hessian application onto the uncompressed gradients (Lewis's worker has the existing reference for that), without entangling Hessian work with the rest of the codebase.

## Files

- `examples/pipelines/build_then_score.yaml` — the example pipeline (small model: `gpt2`, small dataset: `NeelNanda/pile-10k` with `train[:20]` for the query and `train[:100]` for scoring, `chunk_length: 1024`).
- `README.md` — extends the "Run a Multi-Step Pipeline" section introduced in #246 with a one-sentence reference to `build_then_score.yaml` as a second example covering the no-compression scoring path. (The section itself, the description of `bergson pipeline`, and the link to `hessian_then_build.yaml` all live in #246.)
- `tests/test_yaml_pipeline.py` — `test_build_then_score_example_parses` asserts the shipped YAML hydrates into the right `Build`/`Score` commands with the expected configs (parse-only, no GPU needed).

## Configuration notes

- **`skip_preconditioners: true`** is set on both build and score steps. With `projection_dim: 0` the per-token gradient `P` retains the full flattened module-gradient dimension; the default per-module Adafactor preconditioner update `P.mT @ P` would otherwise materialize a `(full_grad_dim × full_grad_dim)` matrix — multi-TB even for GPT-2's `c_attn` — and OOM immediately. The no-compression scoring path uses raw dot products of full gradients, so preconditioners aren't needed here. See issue #255 for a suggested follow-up to make this implicit.
- **`unit_normalize` and `--preconditioner_path`** from the CLI command in the Linear task aren't replicated here. Those belong to the compressed/preconditioned path. This example is deliberately the no-compression demo.

## Dependencies

- **Stacked on #246** (`add_yaml-mediated_search_pipeline`) — this branch sits on top of the YAML pipeline runner introduced there. The PR base reflects that.
- **Requires #252** (`Add length column to tokenize_and_chunk output`) to run successfully. Without it the build step crashes at `ValueError: Column 'length' doesn't exist.` because `tokenize_and_chunk` (triggered by `chunk_length: 1024`) doesn't add the column expected by the build/score workers. Please merge #252 before this.
- **Requires #251** (`torch>=2.4`) — the CLI fails to import on torch < 2.4 due to FSDP2 `fully_shard`. Not blocking for review but blocks running the example on stale environments.