### PR TITLE
Separate train and validate commands

### DIFF
--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -16,6 +16,8 @@ from .config import (
     QueryConfig,
     ScoreConfig,
     TrackstarConfig,
+    TrainingConfig,
+    ValidationConfig,
 )
 from .diagnose import DiagnoseConfig, diagnose
 from .hessians.hessian_approximations import approximate_hessians
@@ -162,6 +164,15 @@ class Trackstar(Serializable):
 
 
 @dataclass
+class Train(TrainingConfig):
+    """Train a model with the MAGIC trainer, but don't actually run MAGIC."""
+
+    def execute(self):
+        """Train the model."""
+        run_magic(self)
+
+
+@dataclass
 class Test_Model_Configuration:
     """Test gradient consistency across padding and batch composition.
 
@@ -174,6 +185,19 @@ class Test_Model_Configuration:
     def execute(self):
         """Run the diagnostic."""
         diagnose(self.diagnose_cfg)
+
+
+@dataclass
+class Validate(ValidationConfig):
+    """Run leave-k-out validation of attribution scores."""
+
+    scores: str = ""
+    """Path to saved attribution scores for validation."""
+
+    def execute(self):
+        """Run the validation."""
+        assert self.scores, "Path to attribution scores must be provided."
+        run_magic(self, score_path=self.scores)
 
 
 @dataclass
@@ -190,7 +214,9 @@ class Main:
         Reduce,
         Score,
         Trackstar,
+        Train,
         Test_Model_Configuration,
+        Validate,
     ]
 
     def execute(self):

--- a/bergson/config.py
+++ b/bergson/config.py
@@ -121,6 +121,9 @@ class ModelConfig(ABC):
     run_path: str = field(positional=True)
     """Directory to save results."""
 
+    overwrite: bool = False
+    """Whether to overwrite any existing index in the run path."""
+
     model: str = "EleutherAI/pythia-160m"
     """Name of the model to load."""
 
@@ -250,7 +253,36 @@ class LRScheduleConfig(Serializable):
 
 
 @dataclass
-class TrainingConfig(ModelConfig, Serializable):
+class AttributionConfig(ModelConfig, ABC):
+    """Base config for attribution methods."""
+
+    data: DataConfig = field(default_factory=DataConfig)
+    """Specification of the data on which to build the index."""
+
+    tokenizer: str = ""
+    """Name of the tokenizer to use. If not set the model tokenizer is used."""
+
+    drop_columns: bool = True
+    """Only save the new dataset columns. If false, the original dataset
+    columns will be saved as well."""
+
+    max_tokens: int | None = None
+    """Max tokens to process. If None, all tokens processed. Dataset only.
+    This experimental feature may be removed in the future."""
+
+    use_tf32_matmuls: bool = False
+    """Set matmul precision to 'high'."""
+
+    debug: bool = False
+    """Whether to enable debug mode with additional logging."""
+
+    def __post_init__(self):
+        if self.use_tf32_matmuls:
+            torch.set_float32_matmul_precision("high")
+
+
+@dataclass
+class TrainingConfig(AttributionConfig, Serializable):
     """Configuration for the MAGIC trainer."""
 
     lr_schedule: LRScheduleConfig = field(default_factory=LRScheduleConfig)
@@ -262,6 +294,9 @@ class TrainingConfig(ModelConfig, Serializable):
 
     num_epochs: int = 1
     """Number of full passes over the training data."""
+
+    seed: int = 42
+    """Random seed for dataset shuffling."""
 
     adam_beta1: float = 0.95
     """Beta1 for AdamW optimizer."""
@@ -282,37 +317,31 @@ class TrainingConfig(ModelConfig, Serializable):
     grad_checkpointing: bool = False
     """Whether to use gradient checkpointing during the forward pass."""
 
+    resume: bool = False
+    """Resume a previously interrupted run from the last checkpoint."""
+
+    wandb_project: str = ""
+    """Weights & Biases project name. If set, logs training loss to W&B."""
+
 
 @dataclass
-class AttributionConfig(ModelConfig, ABC):
-    """Base config for attribution methods."""
+class ValidationConfig(TrainingConfig, ABC):
+    """Config for leave-k-out validation of attribution scores."""
 
-    data: DataConfig = field(default_factory=DataConfig)
-    """Specification of the data on which to build the index."""
+    query: DataConfig = field(
+        default_factory=lambda: DataConfig(split="train"),
+    )
+    """Query/eval dataset for computing attribution target gradients.
+    If not specified, defaults to the training dataset."""
 
-    tokenizer: str = ""
-    """Name of the tokenizer to use. If not set the model tokenizer is used."""
+    query_method: Literal["mean", "sum"] = "mean"
+    """Method for reducing query gradients across batches."""
 
-    drop_columns: bool = True
-    """Only save the new dataset columns. If false, the original dataset
-    columns will be saved as well."""
+    num_subsets: int = 100
+    """Number of leave-k-out subsets for Spearman correlation."""
 
-    max_tokens: int | None = None
-    """Max tokens to process. If None, all tokens processed. Dataset only.
-    This experimental feature may be removed in the future."""
-
-    overwrite: bool = False
-    """Whether to overwrite any existing index in the run path."""
-
-    use_tf32_matmuls: bool = False
-    """Set matmul precision to 'high'."""
-
-    debug: bool = False
-    """Whether to enable debug mode with additional logging."""
-
-    def __post_init__(self):
-        if self.use_tf32_matmuls:
-            torch.set_float32_matmul_precision("high")
+    subset_strategy: Literal["random", "sorted"] = "sorted"
+    """Strategy for selecting leave-k-out subsets for validation."""
 
 
 @dataclass

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -21,7 +21,7 @@ from datasets import (
     load_from_disk,
 )
 from numpy.lib.recfunctions import structured_to_unstructured
-from numpy.typing import DTypeLike
+from numpy.typing import DTypeLike, NDArray
 from transformers import PreTrainedTokenizerFast, logging
 
 from .config import DataConfig
@@ -538,11 +538,11 @@ class Scores:
     def __len__(self) -> int:
         return len(self.mmap)
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: Any) -> NDArray:
         items = self.mmap[key]
         return structured_to_unstructured(items[self._score_fields])
 
-    def get(self, key: Any, score_idx: int = 0) -> Any:
+    def get(self, key: Any, score_idx: int = 0) -> NDArray:
         """Get scores for a specific score index."""
         return self.mmap[key][f"score_{score_idx}"]
 
@@ -552,9 +552,7 @@ class Scores:
         return all(np.all(self.mmap[f"written_{i}"]) for i in range(self.num_scores))
 
 
-def load_scores(
-    path: Path,
-) -> Scores:
+def load_scores(path: Path) -> Scores:
     bin_path = path / "scores.bin"
     info_path = path / "info.json"
 

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -18,7 +18,8 @@ from torch.distributed.tensor import init_device_mesh
 from torchopt.pytree import tree_iter
 from tqdm import tqdm
 
-from ..config import TrainingConfig
+from ..config import TrainingConfig, ValidationConfig
+from ..data import load_scores
 from ..distributed import grad_tree, launch_distributed_run
 from ..utils.logging import wandb_log_fn
 from ..utils.worker_utils import (
@@ -257,10 +258,11 @@ def worker(
     rank: int,
     world_size: int,
     train_dataset: Dataset,
-    query_dataset: Dataset,
+    query_dataset: Dataset | None,
     num_train_docs: int,
     num_query_docs: int,
-    run_cfg: MagicConfig,
+    run_cfg: TrainingConfig,
+    score_path: str = "",
 ):
     torch.cuda.set_device(rank)
 
@@ -289,7 +291,7 @@ def worker(
         )
     )
 
-    if run_cfg.per_token:
+    if getattr(run_cfg, "per_token", False):
         seq_len = run_cfg.data.chunk_length
         if seq_len <= 0:
             seq_len = max(train_dataset["length"])
@@ -338,7 +340,7 @@ def worker(
         debug=run_cfg.debug,
         inplace=True,
         save_dir=ckpts_path,
-        save_mode=run_cfg.save_mode,
+        save_mode=getattr(run_cfg, "save_mode", "sqrt"),
         log_fn=log_fn,
         resume=resume,
         fsdp=run_cfg.fsdp,
@@ -346,6 +348,14 @@ def worker(
 
     if save_fut is not None:
         save_fut.result()  # ensure state0 is saved before validation loads it
+
+    # If no query dataset is provided, skip backward and validation entirely
+    if query_dataset is None:
+        return
+    elif not isinstance(run_cfg, ValidationConfig):
+        raise RuntimeError(
+            "run_cfg must be a ValidationConfig if query_dataset is provided"
+        )
 
     # Pad query dataset to be divisible by batch_size (weight=0 for padding)
     query_dataset, num_query_docs, query_pad_count, query_weight_pad_count = (
@@ -376,44 +386,58 @@ def worker(
         fwd_state, model, query_stream, run_cfg.query_method, run_cfg.fsdp
     )
 
-    stream.requires_grad = True
-    opt_grads = [
-        torch.zeros_like(buf)
-        for buf in tree_iter(fwd_state.opt_state)
-        if isinstance(buf, torch.Tensor) and buf.is_floating_point()
-    ]
-    bwd_state = BackwardState(query_grads, opt_grads, torch.zeros_like(stream.weights))
+    if not score_path:
+        # Sanity check
+        if not isinstance(run_cfg, MagicConfig):
+            raise RuntimeError("run_cfg must be a MagicConfig to compute scores")
 
-    bwd_state = trainer.backward(
-        ckpts_path,
-        stream,
-        bwd_state,
-        fwd_state,
-        debug=run_cfg.debug,
-        inplace=True,
-        fsdp=run_cfg.fsdp,
-        resume=run_cfg.resume,
-        save_every=run_cfg.backward_save_every,
-        save_mode=run_cfg.save_mode,
-    )
-    if world_size > 1:
-        dist.all_reduce(bwd_state.weight_grads, op=dist.ReduceOp.SUM)
+        stream.requires_grad = True
+        opt_grads = [
+            torch.zeros_like(buf)
+            for buf in tree_iter(fwd_state.opt_state)
+            if isinstance(buf, torch.Tensor) and buf.is_floating_point()
+        ]
+        bwd_state = BackwardState(
+            query_grads,
+            opt_grads,
+            torch.zeros_like(stream.weights),
+        )
 
-    scores = bwd_state.weight_grads.cpu()
-    if pad_count:
-        if scores.ndim == 1:
-            scores = scores[:-weight_pad_count]
-        else:
-            scores = scores[:-pad_count]
-    if global_rank == 0:
-        print(f"Baseline loss: {baseline}")
+        bwd_state = trainer.backward(
+            ckpts_path,
+            stream,
+            bwd_state,
+            fwd_state,
+            debug=run_cfg.debug,
+            inplace=True,
+            fsdp=run_cfg.fsdp,
+            resume=run_cfg.resume,
+            save_every=run_cfg.backward_save_every,
+            save_mode=run_cfg.save_mode,
+        )
+        if world_size > 1:
+            dist.all_reduce(bwd_state.weight_grads, op=dist.ReduceOp.SUM)
 
-        summ = describe(scores.flatten())
-        print(f"Score summary: {summ}")
+        scores = bwd_state.weight_grads.cpu()
+        if pad_count:
+            if scores.ndim == 1:
+                scores = scores[:-weight_pad_count]
+            else:
+                scores = scores[:-pad_count]
 
-        score_path = os.path.join(run_cfg.run_path, "scores.pt")
-        torch.save(scores, score_path)
-        print(f"Saved attribution scores to {score_path}")
+        if global_rank == 0:
+            print(f"Baseline loss: {baseline}")
+
+            summ = describe(scores.flatten())
+            print(f"Score summary: {summ}")
+
+            score_path = os.path.join(run_cfg.run_path, "scores.pt")
+            torch.save(scores, score_path)
+            print(f"Saved attribution scores to {score_path}")
+    elif os.path.isdir(score_path):
+        scores = torch.from_numpy(load_scores(Path(score_path))[:])
+    else:
+        scores = torch.load(score_path, map_location="cpu")
 
         # Per-token scores are indexed by (shuffled_chunk_idx, token_idx).
         # Save doc_ids alongside so downstream can aggregate per-doc with
@@ -520,7 +544,7 @@ def worker(
         )
 
 
-def run_magic(run_cfg: MagicConfig):
+def run_magic(run_cfg: TrainingConfig, *, score_path: str = ""):
     run_path = Path(run_cfg.run_path)
     is_main_node = int(os.environ.get("SLURM_PROCID", 0)) == 0
     multi_node = run_cfg.distributed.nnode > 1
@@ -552,7 +576,10 @@ def run_magic(run_cfg: MagicConfig):
     # Shuffle the train_ds with the seed.
     train_ds = train_ds.shuffle(seed=run_cfg.seed)
 
-    query_ds, query_n = setup_data_pipeline(run_cfg, run_cfg.query)
+    if isinstance(run_cfg, ValidationConfig):
+        query_ds, query_n = setup_data_pipeline(run_cfg, run_cfg.query)
+    else:
+        query_ds, query_n = None, 0
 
     if barrier is not None and is_main_node:
         barrier.touch()
@@ -560,7 +587,7 @@ def run_magic(run_cfg: MagicConfig):
     launch_distributed_run(
         "run_magic",
         worker,
-        [train_ds, query_ds, train_n, query_n, run_cfg],
+        [train_ds, query_ds, train_n, query_n, run_cfg, score_path],
         run_cfg.distributed,
     )
 

--- a/bergson/magic/config.py
+++ b/bergson/magic/config.py
@@ -1,24 +1,14 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal
 
-from ..config import AttributionConfig, DataConfig, TrainingConfig
+from ..config import ValidationConfig
 
-MagicQueryMethod = Literal["mean", "sum"]
 MagicSaveMode = Literal["all", "sqrt", "log"]
 
 
 @dataclass
-class MagicConfig(AttributionConfig, TrainingConfig):
+class MagicConfig(ValidationConfig):
     """Special config for MAGIC attribution."""
-
-    query: DataConfig = field(
-        default_factory=lambda: DataConfig(split="train"),
-    )
-    """Query/eval dataset for computing attribution target gradients.
-    If not specified, defaults to the training dataset."""
-
-    query_method: MagicQueryMethod = "mean"
-    """Method for reducing query gradients across batches."""
 
     save_mode: MagicSaveMode = "sqrt"
     """Checkpoint saving mode.
@@ -33,21 +23,6 @@ class MagicConfig(AttributionConfig, TrainingConfig):
     The original MAGIC paper used 'log', but 'sqrt' is often a better choice when disk
     space is not a concern.
     """
-
-    subset_strategy: Literal["random", "sorted"] = "sorted"
-    """Strategy for selecting leave-k-out subsets for validation."""
-
-    num_subsets: int = 100
-    """Number of leave-k-out subsets for Spearman correlation."""
-
-    seed: int = 42
-    """Random seed for subset permutation."""
-
-    wandb_project: str = ""
-    """Weights & Biases project name. If set, logs training loss to W&B."""
-
-    resume: bool = False
-    """Resume a previously interrupted run from the last checkpoint."""
 
     backward_save_every: int = 0
     """How often (in steps) to save backward state for resume."""


### PR DESCRIPTION
Adds `bergson train` which just runs the Trainer without running MAGIC afterward, and `bergson validate` with a `--scores` argument that allows you to do leave-k-out validation on arbitrary attribution scores.