### PR TITLE
Refactor load_from_optimizer

### DIFF
--- a/bergson/utils/load_from_optimizer.py
+++ b/bergson/utils/load_from_optimizer.py
@@ -9,12 +9,12 @@ from bergson.gradients import AdafactorNormalizer, AdamNormalizer, Normalizer
 
 
 class OptimizerStateFormat(Enum):
-    """Optimizer state format for a single module - Adafactor for factored
-    optimizer states (e.g. 2D+ modules in Adafactor optimizers), and Adam
-    for unfactored states."""
+    """Optimizer state format for a single module - Adafactor-style factored
+    optimizer states (e.g. 2D+ modules in Adafactor optimizers), or Adam-style
+    unfactored states."""
 
-    ADAM = 1
-    ADAFACTOR = 2
+    UNFACTORED = 1
+    FACTORED = 2
 
 
 def get_optimizer_state_format(param_state) -> OptimizerStateFormat | None:
@@ -22,15 +22,15 @@ def get_optimizer_state_format(param_state) -> OptimizerStateFormat | None:
         return None
 
     if "exp_avg_sq" in param_state:
-        return OptimizerStateFormat.ADAM
+        return OptimizerStateFormat.UNFACTORED
 
     if "exp_avg_sq_row" in param_state:
-        return OptimizerStateFormat.ADAFACTOR
+        return OptimizerStateFormat.FACTORED
 
     bnb_state = param_state.get("__bnb_optimizer_quant_state__")
     if isinstance(bnb_state, dict) and "state2" in bnb_state:
         # 8-bit Adam
-        return OptimizerStateFormat.ADAM
+        return OptimizerStateFormat.UNFACTORED
 
     return None
 
@@ -53,8 +53,8 @@ def get_normalizers(
     target_modules,
     adapter_suffix,
     include_bias,
+    device,
 ):
-    # Extract second moments per layer
     normalizers: dict[str, Normalizer] = {}
     for param_idx, state in optimizer_state["state"].items():
         param_idx = int(param_idx)
@@ -77,37 +77,30 @@ def get_normalizers(
             print("Unrecognized format, skipping normalizer for param_idx", param_idx)
             continue
 
-        if optimizer_format == OptimizerStateFormat.ADAM:
-            # Adam or 8-bit Adam checkpoint
-            exp_avg_sq = get_unfactored_second_moment(state)
+        bias_exp_avg_sq = _get_bias_second_moment(
+            layer_name, target_param_index_to_name, optimizer_state, include_bias
+        )
+        bias_on_device = (
+            bias_exp_avg_sq.to(device) if bias_exp_avg_sq is not None else None
+        )
 
+        if optimizer_format == OptimizerStateFormat.UNFACTORED:
+            exp_avg_sq = get_unfactored_second_moment(state)
             if exp_avg_sq.ndim != 2:
                 continue
-
-            bias_exp_avg_sq = _get_bias_second_moment(
-                layer_name, target_param_index_to_name, optimizer_state, include_bias
-            )
-
             normalizers[module_name] = AdamNormalizer(
-                weight_avg_sq=exp_avg_sq,
-                bias_avg_sq=bias_exp_avg_sq,
+                weight_avg_sq=exp_avg_sq.to(device),
+                bias_avg_sq=bias_on_device,
             )
-        elif optimizer_format == OptimizerStateFormat.ADAFACTOR:
-            # Native Adafactor checkpoint
+        elif optimizer_format == OptimizerStateFormat.FACTORED:
             row = state["exp_avg_sq_row"]
             col = state.get("exp_avg_sq_col")
-
             if row.ndim != 1:
                 continue
-
-            bias_exp_avg_sq = _get_bias_second_moment(
-                layer_name, target_param_index_to_name, optimizer_state, include_bias
-            )
-
             normalizers[module_name] = AdafactorNormalizer(
-                row=row,
-                col=col,
-                bias_avg_sq=bias_exp_avg_sq,
+                row=row.to(device),
+                col=col.to(device) if col is not None else None,
+                bias_avg_sq=bias_on_device,
             )
 
     return normalizers
@@ -166,7 +159,6 @@ def load_from_optimizer(
     for idx, (name, _param) in enumerate(params_for_index):
         target_param_index_to_name[idx] = name
 
-    # Extract per-module normalizers
     device = next(model.parameters()).device
 
     normalizers = get_normalizers(
@@ -175,27 +167,13 @@ def load_from_optimizer(
         target_modules,
         adapter_suffix,
         include_bias,
-        # device=device
+        device,
     )
     assert normalizers, (
         f"No optimizer second moments found in '{optimizer_state_path}'. "
         "Ensure the checkpoint was saved from an Adam-family or Adafactor optimizer."
     )
 
-    # Move normalizer tensors to the model's device
-    device = next(model.parameters()).device
-    for norm in normalizers.values():
-        if isinstance(norm, AdamNormalizer):
-            norm.weight_avg_sq = norm.weight_avg_sq.to(device)
-            if norm.bias_avg_sq is not None:
-                norm.bias_avg_sq = norm.bias_avg_sq.to(device)
-        elif isinstance(norm, AdafactorNormalizer):
-            norm.row = norm.row.to(device)
-            norm.col = norm.col.to(device)
-            if norm.bias_avg_sq is not None:
-                norm.bias_avg_sq = norm.bias_avg_sq.to(device)
-
-    # Report what we loaded
     types = {type(n).__name__ for n in normalizers.values()}
     print(
         f"Loaded {len(normalizers)} normalizers ({', '.join(types)}) "
@@ -219,7 +197,7 @@ def _get_bias_second_moment(
         if name == bias_name:
             bias_state = optimizer_state["state"].get(idx)
             optimizer_format = get_optimizer_state_format(bias_state)
-            if optimizer_format == OptimizerStateFormat.ADAM:
+            if optimizer_format == OptimizerStateFormat.UNFACTORED:
                 return get_unfactored_second_moment(bias_state)
             return None
 

--- a/bergson/utils/load_from_optimizer.py
+++ b/bergson/utils/load_from_optimizer.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
 
 import torch
 from peft import PeftModel, get_peft_model_state_dict
@@ -9,9 +9,10 @@ from bergson.gradients import AdafactorNormalizer, AdamNormalizer, Normalizer
 
 
 class OptimizerStateFormat(Enum):
-    """Optimizer state format for a single module - Adafactor for factored 
-    optimizer states (e.g. 2D+ modules in Adafactor optimizers), and Adam 
+    """Optimizer state format for a single module - Adafactor for factored
+    optimizer states (e.g. 2D+ modules in Adafactor optimizers), and Adam
     for unfactored states."""
+
     ADAM = 1
     ADAFACTOR = 2
 
@@ -37,7 +38,7 @@ def get_optimizer_state_format(param_state) -> OptimizerStateFormat | None:
 def get_unfactored_second_moment(state: dict) -> torch.Tensor:
     """Return the second moment tensor for an unfactored optimizer state.
 
-    Adam and 8-bit Adam always use unfactored tensors. 
+    Adam and 8-bit Adam always use unfactored tensors.
     Adafactor has multiple factored moment tensors for 2D+ parameters,
     and unfactored tensors for 1D parameters.
     """
@@ -71,7 +72,7 @@ def get_normalizers(
             continue
 
         optimizer_format = get_optimizer_state_format(state)
-        
+
         if optimizer_format is None:
             print("Unrecognized format, skipping normalizer for param_idx", param_idx)
             continue
@@ -95,7 +96,7 @@ def get_normalizers(
             # Native Adafactor checkpoint
             row = state["exp_avg_sq_row"]
             col = state.get("exp_avg_sq_col")
-            
+
             if row.ndim != 1:
                 continue
 

--- a/bergson/utils/load_from_optimizer.py
+++ b/bergson/utils/load_from_optimizer.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from enum import Enum
 
 import torch
 from peft import PeftModel, get_peft_model_state_dict
@@ -7,34 +8,108 @@ from transformers import PreTrainedModel
 from bergson.gradients import AdafactorNormalizer, AdamNormalizer, Normalizer
 
 
-def _extract_second_moments(
-    state: dict,
-) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
-    """Extract second moment tensors from a single parameter's optimizer state.
+class OptimizerStateFormat(Enum):
+    """Optimizer state format for a single module - Adafactor for factored 
+    optimizer states (e.g. 2D+ modules in Adafactor optimizers), and Adam 
+    for unfactored states."""
+    ADAM = 1
+    ADAFACTOR = 2
 
-    Supports three optimizer formats:
-    - Adam (``exp_avg_sq``): full second moment matrix
-    - Adafactor (``exp_avg_sq_row`` + ``exp_avg_sq_col``): factored row/col
-    - 8-bit Adam (``__bnb_optimizer_quant_state__["state2"]``): quantized second moments
 
-    Returns:
-        ``(exp_avg_sq, exp_avg_sq_row, exp_avg_sq_col)`` — whichever fields are
-        present; the rest are ``None``.
-    """
-    # Standard Adam
-    if "exp_avg_sq" in state:
-        return state["exp_avg_sq"], None, None
+def get_optimizer_state_format(param_state) -> OptimizerStateFormat | None:
+    if not isinstance(param_state, dict):
+        return None
 
-    # Native Adafactor
-    if "exp_avg_sq_row" in state:
-        return None, state["exp_avg_sq_row"], state.get("exp_avg_sq_col")
+    if "exp_avg_sq" in param_state:
+        return OptimizerStateFormat.ADAM
 
-    # 8-bit Adam (bitsandbytes)
-    bnb_state = state.get("__bnb_optimizer_quant_state__")
+    if "exp_avg_sq_row" in param_state:
+        return OptimizerStateFormat.ADAFACTOR
+
+    bnb_state = param_state.get("__bnb_optimizer_quant_state__")
     if isinstance(bnb_state, dict) and "state2" in bnb_state:
-        return bnb_state["state2"], None, None
+        # 8-bit Adam
+        return OptimizerStateFormat.ADAM
 
-    return None, None, None
+    return None
+
+
+def get_unfactored_second_moment(state: dict) -> torch.Tensor:
+    """Return the second moment tensor for an unfactored optimizer state.
+
+    Adam and 8-bit Adam always use unfactored tensors. 
+    Adafactor has multiple factored moment tensors for 2D+ parameters,
+    and unfactored tensors for 1D parameters.
+    """
+    if "exp_avg_sq" in state:
+        return state["exp_avg_sq"]
+    return state["__bnb_optimizer_quant_state__"]["state2"]
+
+
+def get_normalizers(
+    optimizer_state,
+    target_param_index_to_name,
+    target_modules,
+    adapter_suffix,
+    include_bias,
+):
+    # Extract second moments per layer
+    normalizers: dict[str, Normalizer] = {}
+    for param_idx, state in optimizer_state["state"].items():
+        param_idx = int(param_idx)
+        if param_idx not in target_param_index_to_name:
+            continue
+
+        param_name = target_param_index_to_name[param_idx]
+        if not param_name.endswith(".weight"):
+            continue
+
+        layer_name = param_name.removesuffix(".weight")
+        module_name = layer_name.removeprefix("base_model.") + adapter_suffix
+
+        if target_modules is not None and module_name not in target_modules:
+            continue
+
+        optimizer_format = get_optimizer_state_format(state)
+        
+        if optimizer_format is None:
+            print("Unrecognized format, skipping normalizer for param_idx", param_idx)
+            continue
+
+        if optimizer_format == OptimizerStateFormat.ADAM:
+            # Adam or 8-bit Adam checkpoint
+            exp_avg_sq = get_unfactored_second_moment(state)
+
+            if exp_avg_sq.ndim != 2:
+                continue
+
+            bias_exp_avg_sq = _get_bias_second_moment(
+                layer_name, target_param_index_to_name, optimizer_state, include_bias
+            )
+
+            normalizers[module_name] = AdamNormalizer(
+                weight_avg_sq=exp_avg_sq,
+                bias_avg_sq=bias_exp_avg_sq,
+            )
+        elif optimizer_format == OptimizerStateFormat.ADAFACTOR:
+            # Native Adafactor checkpoint
+            row = state["exp_avg_sq_row"]
+            col = state.get("exp_avg_sq_col")
+            
+            if row.ndim != 1:
+                continue
+
+            bias_exp_avg_sq = _get_bias_second_moment(
+                layer_name, target_param_index_to_name, optimizer_state, include_bias
+            )
+
+            normalizers[module_name] = AdafactorNormalizer(
+                row=row,
+                col=col,
+                bias_avg_sq=bias_exp_avg_sq,
+            )
+
+    return normalizers
 
 
 def load_from_optimizer(
@@ -50,7 +125,7 @@ def load_from_optimizer(
 
     - Adam/AdamW: ``exp_avg_sq`` -> AdamNormalizer
     - Adafactor: ``exp_avg_sq_row``/``exp_avg_sq_col`` -> AdafactorNormalizer
-    - 8-bit Adam (bnb): ``state2`` -> AdamNormalizer
+    - 8-bit Adam (BitsAndBytes): ``state2`` -> AdamNormalizer
 
     Args:
         model: The model whose parameter names are used to map optimizer
@@ -64,17 +139,25 @@ def load_from_optimizer(
     Returns:
         Dictionary mapping layer names to normalizer instances.
     """
-    state_path = Path(optimizer_state_path)
-    if state_path.is_dir():
-        state_path = state_path / "optimizer.pt"
+    optimizer_path = Path(optimizer_state_path)
+    if optimizer_path.is_dir():
+        optimizer_path = optimizer_path / "optimizer.pt"
 
-    optimizer_state = torch.load(state_path, map_location="cpu", weights_only=False)
+    optimizer_state = torch.load(optimizer_path, map_location="cpu", weights_only=False)
 
     # The optimizer state is keyed by position in the trainable parameter list.
     # For PEFT checkpoints, only include PEFT params.
+    adapter_suffix = ""
     if isinstance(model, PeftModel):
         st = get_peft_model_state_dict(model)
         params_for_index = list(st.items())
+        # peft serializes LoRA keys without the active adapter name (e.g.
+        # ``...lora_A.weight``), but extract_peft_target_modules and the
+        # actual submodule paths include it (``...lora_A.default``). Append
+        # the adapter name so module_name lookups match target_modules.
+        adapters = list(model.peft_config.keys())
+        if len(adapters) == 1:
+            adapter_suffix = "." + adapters[0]
     else:
         params_for_index = list(model.named_parameters())
 
@@ -82,60 +165,17 @@ def load_from_optimizer(
     for idx, (name, _param) in enumerate(params_for_index):
         target_param_index_to_name[idx] = name
 
-    # Extract second moments per layer
-    normalizers: dict[str, Normalizer] = {}
-    for param_idx, state in optimizer_state["state"].items():
-        param_idx = int(param_idx)
-        if param_idx not in target_param_index_to_name:
-            continue
+    # Extract per-module normalizers
+    device = next(model.parameters()).device
 
-        param_name = target_param_index_to_name[param_idx]
-
-        if not param_name.endswith(".weight"):
-            continue
-
-        exp_avg_sq, row, col = _extract_second_moments(state)
-
-        if row is not None and col is not None:
-            # Native Adafactor checkpoint
-            if row.ndim != 1:
-                continue
-
-            layer_name = param_name.removesuffix(".weight")
-            module_name = layer_name.removeprefix("base_model.")
-
-            if target_modules is not None and module_name not in target_modules:
-                continue
-
-            bias_exp_avg_sq = _get_bias_second_moment(
-                layer_name, target_param_index_to_name, optimizer_state, include_bias
-            )
-
-            normalizers[module_name] = AdafactorNormalizer(
-                row=row,
-                col=col,
-                bias_avg_sq=bias_exp_avg_sq,
-            )
-        elif exp_avg_sq is not None:
-            # Adam or 8-bit Adam checkpoint
-            if exp_avg_sq.ndim != 2:
-                continue
-
-            layer_name = param_name.removesuffix(".weight")
-            module_name = layer_name.removeprefix("base_model.")
-
-            if target_modules is not None and module_name not in target_modules:
-                continue
-
-            bias_exp_avg_sq = _get_bias_second_moment(
-                layer_name, target_param_index_to_name, optimizer_state, include_bias
-            )
-
-            normalizers[module_name] = AdamNormalizer(
-                weight_avg_sq=exp_avg_sq,
-                bias_avg_sq=bias_exp_avg_sq,
-            )
-
+    normalizers = get_normalizers(
+        optimizer_state,
+        target_param_index_to_name,
+        target_modules,
+        adapter_suffix,
+        include_bias,
+        # device=device
+    )
     assert normalizers, (
         f"No optimizer second moments found in '{optimizer_state_path}'. "
         "Ensure the checkpoint was saved from an Adam-family or Adafactor optimizer."
@@ -177,9 +217,9 @@ def _get_bias_second_moment(
     for idx, name in param_index_to_name.items():
         if name == bias_name:
             bias_state = optimizer_state["state"].get(idx)
-            if bias_state is not None:
-                exp_avg_sq, _, _ = _extract_second_moments(bias_state)
-                return exp_avg_sq
-            break
+            optimizer_format = get_optimizer_state_format(bias_state)
+            if optimizer_format == OptimizerStateFormat.ADAM:
+                return get_unfactored_second_moment(bias_state)
+            return None
 
     return None

--- a/bergson/utils/load_from_optimizer.py
+++ b/bergson/utils/load_from_optimizer.py
@@ -95,11 +95,11 @@ def get_normalizers(
         elif optimizer_format == OptimizerStateFormat.FACTORED:
             row = state["exp_avg_sq_row"]
             col = state.get("exp_avg_sq_col")
-            if row.ndim != 1:
+            if row.ndim != 1 or col is None:
                 continue
             normalizers[module_name] = AdafactorNormalizer(
                 row=row.to(device),
-                col=col.to(device) if col is not None else None,
+                col=col.to(device),
                 bias_avg_sq=bias_on_device,
             )
 

--- a/tests/test_adam_state_loading.py
+++ b/tests/test_adam_state_loading.py
@@ -144,17 +144,17 @@ def test_missing_optimizer_file(tmp_path):
 
 def test_get_optimizer_state_format_adam():
     state = {"exp_avg_sq": torch.zeros(2, 3), "step": torch.tensor(1)}
-    assert get_optimizer_state_format(state) == OptimizerStateFormat.ADAM
+    assert get_optimizer_state_format(state) == OptimizerStateFormat.UNFACTORED
 
 
 def test_get_optimizer_state_format_adafactor():
     state = {"exp_avg_sq_row": torch.zeros(2), "exp_avg_sq_col": torch.zeros(3)}
-    assert get_optimizer_state_format(state) == OptimizerStateFormat.ADAFACTOR
+    assert get_optimizer_state_format(state) == OptimizerStateFormat.FACTORED
 
 
 def test_get_optimizer_state_format_bnb_8bit_adam():
     state = {"__bnb_optimizer_quant_state__": {"state2": torch.zeros(8)}}
-    assert get_optimizer_state_format(state) == OptimizerStateFormat.ADAM
+    assert get_optimizer_state_format(state) == OptimizerStateFormat.UNFACTORED
 
 
 def test_get_optimizer_state_format_empty_or_unknown_returns_none():
@@ -163,6 +163,13 @@ def test_get_optimizer_state_format_empty_or_unknown_returns_none():
     assert get_optimizer_state_format({}) is None
     assert get_optimizer_state_format({"step": torch.tensor(1)}) is None
     assert get_optimizer_state_format({"square_avg": torch.zeros(2)}) is None
+
+
+def test_get_optimizer_state_format_non_dict_returns_none():
+    # The isinstance guard means None / non-dicts return None instead of
+    # raising "argument of type 'NoneType' is not iterable" on the `in` check.
+    assert get_optimizer_state_format(None) is None
+    assert get_optimizer_state_format("not a dict") is None
 
 
 def test_get_unfactored_second_moment_adam_and_bnb():

--- a/tests/test_adam_state_loading.py
+++ b/tests/test_adam_state_loading.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 import torch.nn as nn
 from datasets import Dataset
+from peft import LoraConfig, get_peft_model, get_peft_model_state_dict
 from transformers import (
     AutoConfig,
     AutoModelForCausalLM,
@@ -14,7 +15,13 @@ from transformers import (
 )
 
 from bergson.gradients import AdafactorNormalizer, AdamNormalizer
-from bergson.utils.load_from_optimizer import load_from_optimizer
+from bergson.utils.load_from_optimizer import (
+    OptimizerStateFormat,
+    get_optimizer_state_format,
+    get_unfactored_second_moment,
+    load_from_optimizer,
+)
+from bergson.utils.worker_utils import extract_peft_target_modules
 
 
 def _create_model():
@@ -128,6 +135,236 @@ def test_missing_optimizer_file(tmp_path):
 
     with pytest.raises(FileNotFoundError):
         load_from_optimizer(model, str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# get_optimizer_state_format / get_unfactored_second_moment unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_optimizer_state_format_adam():
+    state = {"exp_avg_sq": torch.zeros(2, 3), "step": torch.tensor(1)}
+    assert get_optimizer_state_format(state) == OptimizerStateFormat.ADAM
+
+
+def test_get_optimizer_state_format_adafactor():
+    state = {"exp_avg_sq_row": torch.zeros(2), "exp_avg_sq_col": torch.zeros(3)}
+    assert get_optimizer_state_format(state) == OptimizerStateFormat.ADAFACTOR
+
+
+def test_get_optimizer_state_format_bnb_8bit_adam():
+    state = {"__bnb_optimizer_quant_state__": {"state2": torch.zeros(8)}}
+    assert get_optimizer_state_format(state) == OptimizerStateFormat.ADAM
+
+
+def test_get_optimizer_state_format_empty_or_unknown_returns_none():
+    # Empty (param registered but never stepped) and unknown formats both
+    # return None so the main loop can skip without crashing.
+    assert get_optimizer_state_format({}) is None
+    assert get_optimizer_state_format({"step": torch.tensor(1)}) is None
+    assert get_optimizer_state_format({"square_avg": torch.zeros(2)}) is None
+
+
+def test_get_unfactored_second_moment_adam_and_bnb():
+    sq = torch.rand(2, 3)
+    assert torch.equal(get_unfactored_second_moment({"exp_avg_sq": sq}), sq)
+
+    bnb_sq = torch.rand(8)
+    state = {"__bnb_optimizer_quant_state__": {"state2": bnb_sq}}
+    assert torch.equal(get_unfactored_second_moment(state), bnb_sq)
+
+
+# ---------------------------------------------------------------------------
+# Bad / empty target_modules paths
+# ---------------------------------------------------------------------------
+
+
+def test_target_modules_no_overlap_raises(tmp_path):
+    """If target_modules names don't match any param, no normalizers loaded."""
+    model = _create_model()
+    opt_state = _create_fake_optimizer_state(model)
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    with pytest.raises(AssertionError, match="No optimizer second moments"):
+        load_from_optimizer(
+            model, str(opt_path), target_modules={"definitely.not.a.real.module"}
+        )
+
+
+def test_target_modules_empty_set_raises(tmp_path):
+    """An empty target_modules set rejects everything → assertion."""
+    model = _create_model()
+    opt_state = _create_fake_optimizer_state(model)
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    with pytest.raises(AssertionError, match="No optimizer second moments"):
+        load_from_optimizer(model, str(opt_path), target_modules=set())
+
+
+# ---------------------------------------------------------------------------
+# Unrecognized / mixed-format states
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognized_state_skipped_others_loaded(tmp_path):
+    """A state entry with no recognised keys is skipped; the rest still load."""
+    model = _create_model()
+    opt_state = _create_fake_optimizer_state(model)
+
+    # Replace the first param's state with an unknown-format dict.
+    first_idx = next(iter(opt_state["state"]))
+    opt_state["state"][first_idx] = {"step": torch.tensor(1)}
+
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    normalizers = load_from_optimizer(model, str(opt_path))
+
+    # Some normalizers loaded — the unrecognised one was simply skipped.
+    assert len(normalizers) > 0
+
+
+# ---------------------------------------------------------------------------
+# include_bias path
+# ---------------------------------------------------------------------------
+
+
+def test_include_bias_loads_bias_normalizer(tmp_path):
+    """Bias second moments are attached when include_bias=True."""
+    # Build a minimal model with a bias and craft optimizer state for both
+    # weight and bias of the same Linear.
+    model = nn.Sequential(nn.Linear(3, 4, bias=True))
+    state: dict = {}
+    param_groups = [{"lr": 1e-3, "params": []}]
+    for idx, (_name, param) in enumerate(model.named_parameters()):
+        param_groups[0]["params"].append(idx)
+        state[idx] = {
+            "step": torch.tensor(1),
+            "exp_avg": torch.zeros_like(param),
+            "exp_avg_sq": torch.rand_like(param) * 0.01,
+        }
+    opt_state = {"state": state, "param_groups": param_groups}
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    normalizers = load_from_optimizer(model, str(opt_path), include_bias=True)
+    assert len(normalizers) == 1
+    norm = next(iter(normalizers.values()))
+    assert isinstance(norm, AdamNormalizer)
+    assert norm.bias_avg_sq is not None
+    assert norm.bias_avg_sq.shape == (4,)
+
+
+def test_include_bias_false_leaves_bias_unset(tmp_path):
+    model = nn.Sequential(nn.Linear(3, 4, bias=True))
+    state: dict = {}
+    param_groups = [{"lr": 1e-3, "params": []}]
+    for idx, (_name, param) in enumerate(model.named_parameters()):
+        param_groups[0]["params"].append(idx)
+        state[idx] = {
+            "step": torch.tensor(1),
+            "exp_avg": torch.zeros_like(param),
+            "exp_avg_sq": torch.rand_like(param) * 0.01,
+        }
+    opt_state = {"state": state, "param_groups": param_groups}
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    normalizers = load_from_optimizer(model, str(opt_path), include_bias=False)
+    assert len(normalizers) == 1
+    norm = next(iter(normalizers.values()))
+    assert norm.bias_avg_sq is None
+
+
+# ---------------------------------------------------------------------------
+# PEFT path: adapter-suffixed target_modules must match
+# ---------------------------------------------------------------------------
+
+
+def _create_peft_model():
+    config = AutoConfig.from_pretrained("trl-internal-testing/tiny-Phi3ForCausalLM")
+    base = AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
+    return get_peft_model(
+        base,
+        LoraConfig(
+            r=4,
+            lora_alpha=8,
+            target_modules=["qkv_proj", "o_proj"],
+            bias="none",
+            task_type="CAUSAL_LM",
+        ),
+    )
+
+
+def _fake_optimizer_state_for_peft(peft_model):
+    """Build optimizer state keyed by index, matching get_peft_model_state_dict
+    order (which is what load_from_optimizer uses for PEFT models)."""
+    state: dict = {}
+    param_groups = [{"lr": 1e-3, "params": []}]
+    psd = get_peft_model_state_dict(peft_model)
+    for idx, (_name, param) in enumerate(psd.items()):
+        param_groups[0]["params"].append(idx)
+        state[idx] = {
+            "step": torch.tensor(1),
+            "exp_avg": torch.zeros_like(param),
+            "exp_avg_sq": torch.rand_like(param) * 0.01,
+        }
+    return {"state": state, "param_groups": param_groups}
+
+
+def test_load_from_peft_model_with_adapter_suffix(tmp_path):
+    """Regression: PEFT module names from extract_peft_target_modules include
+    the adapter suffix (``.default``); load_from_optimizer must produce
+    matching keys, otherwise the target_modules filter rejects everything."""
+    model = _create_peft_model()
+    opt_state = _fake_optimizer_state_for_peft(model)
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    target_modules = extract_peft_target_modules(model)
+    assert any(name.endswith(".default") for name in target_modules)
+
+    normalizers = load_from_optimizer(
+        model, str(opt_path), target_modules=target_modules
+    )
+
+    # Every adapter-suffixed module should have a normalizer.
+    assert set(normalizers.keys()) == target_modules
+    for norm in normalizers.values():
+        assert isinstance(norm, AdamNormalizer)
+        assert norm.weight_avg_sq.ndim == 2
+
+
+def test_load_from_peft_model_without_target_modules(tmp_path):
+    """target_modules=None on a PEFT model still loads every LoRA weight."""
+    model = _create_peft_model()
+    opt_state = _fake_optimizer_state_for_peft(model)
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    normalizers = load_from_optimizer(model, str(opt_path))
+    # Every LoRA weight produces one normalizer; names carry the adapter
+    # suffix because adapter_suffix is appended unconditionally for PEFT.
+    assert len(normalizers) > 0
+    for name in normalizers:
+        assert name.endswith(".default")
+
+
+def test_load_from_peft_strip_adapter_target_modules_misses(tmp_path):
+    """If a caller passes target_modules WITHOUT the adapter suffix (the bug
+    we just fixed), nothing matches and the assertion fires."""
+    model = _create_peft_model()
+    opt_state = _fake_optimizer_state_for_peft(model)
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    target_modules = extract_peft_target_modules(model)
+    stripped = {name.removesuffix(".default") for name in target_modules}
+
+    with pytest.raises(AssertionError, match="No optimizer second moments"):
+        load_from_optimizer(model, str(opt_path), target_modules=stripped)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Changes**
- Use enum for optimizer format switching
- Claude-suggested bug fix: manually append the active adapter name in `load_from_optimizer`. Details:

Our function `extract_peft_target_modules` produces module names with the suffix (`...lora_A.default`).

`load_from_optimizer` uses `peft.get_peft_model_state_dict` to get module names. This function returns LoRA keys without the suffix that's like `...lora_A.weight`.

Then every module is filtered in the normalizer loading loop:

```
if target_modules is not None and module_name not in target_modules:                                               
      continue  
```

and `load_from_optimizer` raises a "no second moments" assertion. 

**New tests**
- Test the regression (PEFT with adapter-suffixed target_modules loads, stripped target_modules raises)
- Test a few details like bad/empty target_modules, unrecognised state entries, include_bias on Adam, and unit tests for the new format helpers.