### PR TITLE
Fix tokenization edge case and test more edge cases

### DIFF
--- a/bergson/data.py
+++ b/bergson/data.py
@@ -662,24 +662,31 @@ def tokenize(
         return tokenizer(batch[args.prompt_column], **kwargs)
 
     # Make sure we only compute loss on the assistant's responses
-    # Chat templates already include special tokens (BOS/EOS) in the rendered
-    # string, so we must disable add_special_tokens to avoid duplicates.
     strings = tokenizer.apply_chat_template(convos, tokenize=False)
-    encodings = tokenizer(strings, add_special_tokens=False, **kwargs)
+    encodings = tokenizer(strings, **kwargs)
     labels_list: list[list[int]] = []
 
     for i, convo in enumerate(convos):
-        # Find the spans of the assistant's responses in the tokenized output
-        pos = 0
+        # Find the spans (start, end) of the assistant's responses in the tokens
         spans: list[tuple[int, int]] = []
 
-        for msg in convo:
+        # We use rfind to find the last match in the string so if the answer is
+        # duplicated in the user prompt we don't select that.
+
+        # We work backwards through the messages and restrict the search to not
+        # use previously matching substrings so if two assistant messages
+        # have the same content they won't both match the right-most substring.
+        search_end = len(strings[i])
+
+        for msg in reversed(convo):
             if msg["role"] != "assistant":
                 continue
 
             ans = msg["content"]
-            start = strings[i].rfind(ans, pos)
+            start = strings[i].rfind(ans, 0, search_end)
             if start < 0:
+                print("String under test: ", strings[i])
+                print("Substring search: ", ans)
                 raise RuntimeError(
                     "Failed to find completion in the chat-formatted conversation. "
                     "Make sure the chat template does not alter the completion, e.g. "
@@ -687,18 +694,35 @@ def tokenize(
                 )
 
             # move past this match
-            pos = start + len(ans)
+            end = start + len(ans)
 
-            start_token = encodings.char_to_token(i, start)
-            end_token = encodings.char_to_token(i, pos)
-            spans.append((start_token, end_token))
+            start_token_idx = encodings.char_to_token(i, start)
+            end_token_idx = encodings.char_to_token(i, end)
+            # When end falls on the last char, char_to_token returns None;
+            # look up the token for the previous char and advance by one.
+            if end_token_idx is None and end > 0:
+                prev = encodings.char_to_token(i, end - 1)
+                if prev is not None:
+                    end_token_idx = prev + 1
+            spans.append((start_token_idx, end_token_idx))
+
+            # Update the boundary; the next message must be found before this one
+            search_end = start
+
+        spans = list(reversed(spans))
 
         # Labels are -100 everywhere except where the assistant's response is
         tokens = encodings["input_ids"][i]
         labels = [-100] * len(tokens)
         for start, end in spans:
-            if start is not None and end is not None:
-                labels[start:end] = tokens[start:end]
+            if start is None:
+                # Entire span is beyond the truncation boundary, so we skip.
+                continue
+            if end is None:
+                # Span starts in-bounds but extends past truncation, so we
+                # label up to the end of the truncated sequence
+                end = len(tokens)
+            labels[start:end] = tokens[start:end]
 
         labels_list.append(labels)
 

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -113,3 +113,34 @@ def test_fully_truncated_span_skipped(tokenizer):
     labels = result["labels"][0]
     assert len(labels) == max_length
     # Should not raise, and should still have some labels from the first turn
+
+
+def test_assistant_content_repeated_in_later_turn(tokenizer):
+    earlier = "bin boot dev etc home lib"
+    later = "~ % " + earlier
+    batch = _make_batch(
+        [
+            [
+                {"role": "user", "content": "`ls`"},
+                {"role": "assistant", "content": earlier},
+                {"role": "user", "content": "`mkdir x`\n`ls`"},
+                {"role": "assistant", "content": later},
+            ]
+        ]
+    )
+    cfg = DataConfig(conversation_column="conversation")
+    result = tokenize(batch, args=cfg, tokenizer=tokenizer)
+
+    labels = result["labels"][0]
+    tokens = result["input_ids"][0]
+    rendered = tokenizer.decode(tokens)
+
+    earlier_start = rendered.find(earlier)
+    later_start = rendered.find(later)
+    assert earlier_start >= 0 and later_start > earlier_start
+
+    earlier_token = next(
+        i for i, t in enumerate(tokens) if labels[i] == t and labels[i] != -100
+    )
+    last_active = max(i for i, l in enumerate(labels) if l != -100)
+    assert last_active > earlier_token + len(tokenizer.encode(earlier))

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -146,6 +146,11 @@ def test_assistant_content_repeated_in_later_turn(tokenizer):
     assert last_active > earlier_token + len(tokenizer.encode(earlier))
 
 
+@pytest.mark.xfail(
+    reason="rfind-based span lookup can't distinguish a user echo of an "
+    "earlier assistant turn from the assistant turn itself when both "
+    "occurrences sit before the next assistant turn."
+)
 def test_user_quotes_previous_assistant(tokenizer):
     ans1 = "alpha bravo charlie delta echo"
     ans2 = "Yes, confirmed."

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -170,7 +170,9 @@ def test_user_quotes_previous_assistant(tokenizer):
     asst1_char = rendered.find(ans1)
     user_quote_char = rendered.find(ans1, asst1_char + 1)
     ans2_char = rendered.find(ans2)
-    assert asst1_char >= 0 and user_quote_char > asst1_char and ans2_char > user_quote_char
+    assert (
+        asst1_char >= 0 and user_quote_char > asst1_char and ans2_char > user_quote_char
+    )
 
     asst1_token = encodings.char_to_token(asst1_char)
     user_quote_token = encodings.char_to_token(user_quote_char)
@@ -206,7 +208,5 @@ def test_identical_assistant_turns(tokenizer):
     assert labels[first_token] != -100
     assert labels[second_token] != -100
 
-    gap = [
-        i for i in range(first_token, second_token) if labels[i] == -100
-    ]
+    gap = [i for i in range(first_token, second_token) if labels[i] == -100]
     assert gap, "Expected -100 region between the two identical assistant turns"

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -144,3 +144,64 @@ def test_assistant_content_repeated_in_later_turn(tokenizer):
     )
     last_active = max(i for i, l in enumerate(labels) if l != -100)
     assert last_active > earlier_token + len(tokenizer.encode(earlier))
+
+
+def test_user_quotes_previous_assistant(tokenizer):
+    ans1 = "alpha bravo charlie delta echo"
+    ans2 = "Yes, confirmed."
+    convo = [
+        {"role": "user", "content": "Pick five NATO words."},
+        {"role": "assistant", "content": ans1},
+        {"role": "user", "content": f"Earlier you said '{ans1}'. Right?"},
+        {"role": "assistant", "content": ans2},
+    ]
+    cfg = DataConfig(conversation_column="conversation")
+    result = tokenize(_make_batch([convo]), args=cfg, tokenizer=tokenizer)
+    labels = result["labels"][0]
+
+    rendered = tokenizer.apply_chat_template(convo, tokenize=False)
+    encodings = tokenizer(rendered, add_special_tokens=False)
+
+    asst1_char = rendered.find(ans1)
+    user_quote_char = rendered.find(ans1, asst1_char + 1)
+    ans2_char = rendered.find(ans2)
+    assert asst1_char >= 0 and user_quote_char > asst1_char and ans2_char > user_quote_char
+
+    asst1_token = encodings.char_to_token(asst1_char)
+    user_quote_token = encodings.char_to_token(user_quote_char)
+    ans2_token = encodings.char_to_token(ans2_char)
+
+    assert labels[asst1_token] != -100
+    assert labels[user_quote_token] == -100
+    assert labels[ans2_token] != -100
+
+
+def test_identical_assistant_turns(tokenizer):
+    repeated = "alpha bravo charlie delta echo"
+    convo = [
+        {"role": "user", "content": "Say it."},
+        {"role": "assistant", "content": repeated},
+        {"role": "user", "content": "Say it again."},
+        {"role": "assistant", "content": repeated},
+    ]
+    cfg = DataConfig(conversation_column="conversation")
+    result = tokenize(_make_batch([convo]), args=cfg, tokenizer=tokenizer)
+    labels = result["labels"][0]
+
+    rendered = tokenizer.apply_chat_template(convo, tokenize=False)
+    encodings = tokenizer(rendered, add_special_tokens=False)
+
+    first_char = rendered.find(repeated)
+    second_char = rendered.find(repeated, first_char + 1)
+    assert first_char >= 0 and second_char > first_char
+
+    first_token = encodings.char_to_token(first_char)
+    second_token = encodings.char_to_token(second_char)
+
+    assert labels[first_token] != -100
+    assert labels[second_token] != -100
+
+    gap = [
+        i for i in range(first_token, second_token) if labels[i] == -100
+    ]
+    assert gap, "Expected -100 region between the two identical assistant turns"


### PR DESCRIPTION
During the LESS replication I had some tokenization fail in oasst1 due to repeated messages. here's some Claude slop with more "detail":

> bergson/data.py:681 uses rfind to locate each assistant turn in the templated string. 94 oasst1 rows are multi-turn shell/Q&A conversations where an  early assistant reply is contained verbatim inside a later assistant reply (e.g., row 498: turn 1 is bin boot dev …, turn 3 is ~ % bin boot dev …). rfind locks onto the later occurrence for turn 1, advances pos past it, and then turn 3's search returns -1.

I added edge cases to the tests (test_assistant_content_repeated_in_later_turn, test_user_quotes_previous_assistant, test_identical_assistant_turns), and an algorithm of my own design based on iterating backwards through the messages. This fixed two tests. The third (test_user_quotes_previous_assistant) is not fixed. I can't see a way to fix it without spending more effort so I skipped it. More claude slop:

>  this case is the most ambiguous of the three — there's no general way to tell from string-matching alone whether the canonical  match is the earliest or latest occurrence inside the same [0, search_end) window. Real fixes need template-level structure (e.g., asking the chat template for assistant-turn offsets via return_assistant_tokens_mask=True, which HF tokenizers support when the template has {% generation %}/{%endgeneration %} markers).
