### PR TITLE
CUDA isolation + upfront VRAM usage check

### DIFF
--- a/benchmarks/benchmark_bergson.py
+++ b/benchmarks/benchmark_bergson.py
@@ -29,7 +29,7 @@ from bergson.data import allocate_batches
 from bergson.gradients import GradientProcessor
 from bergson.score.score_writer import InMemorySequenceScoreWriter
 from bergson.score.scorer import Scorer
-from bergson.utils.auto_batch_size import determine_batch_size
+from bergson.utils.batch_size import determine_batch_size
 from bergson.utils.worker_utils import (
     setup_data_pipeline,
     setup_model_and_peft,

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -11,8 +11,13 @@ from bergson.collection import collect_gradients
 from bergson.config import HessianConfig, IndexConfig, PreprocessConfig
 from bergson.data import allocate_batches
 from bergson.distributed import launch_distributed_run
-from bergson.utils.auto_batch_size import maybe_auto_batch_size
-from bergson.utils.utils import assert_type, setup_reproducibility
+from bergson.utils.batch_size import maybe_auto_batch_size, test_fwd_bwd
+from bergson.utils.utils import (
+    assert_type,
+    get_device,
+    get_device_index,
+    setup_reproducibility,
+)
 from bergson.utils.worker_utils import (
     create_processor,
     setup_data_pipeline,
@@ -48,7 +53,7 @@ def build_worker(
     ds : Dataset | IterableDataset
         The entire dataset to be processed. A subset is assigned to each worker.
     """
-    torch.cuda.set_device(local_rank)
+    torch.cuda.set_device(get_device_index(local_rank))
 
     # These should be set by the main process
     if world_size > 1:
@@ -58,7 +63,7 @@ def build_worker(
         dist.init_process_group(
             "nccl",
             init_method=f"tcp://{addr}:{port}",
-            device_id=torch.device(f"cuda:{local_rank}"),
+            device_id=torch.device(get_device(local_rank)),
             rank=rank,
             timeout=timedelta(minutes=30),
             world_size=world_size,
@@ -68,6 +73,7 @@ def build_worker(
     processor = create_processor(model, index_cfg, target_modules)
 
     maybe_auto_batch_size(index_cfg, model, ds, processor, target_modules, rank)
+    test_fwd_bwd(model, index_cfg.token_batch_size)
 
     attention_cfgs = {
         module: index_cfg.attention for module in index_cfg.split_attention_modules

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -40,12 +40,22 @@ def grad_tree(
 
 def dist_worker(
     worker: Callable,
+    rank: int,
+    local_rank: int,
+    world_size: int,
+    master_addr: str,
+    master_port: str,
     *worker_args,
 ):
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = master_port
+
     try:
-        rank = int(os.environ.get("RANK", 0))
         with nullcontext() if rank == 0 else redirect_stdout(io.StringIO()):
-            worker(*worker_args)
+            worker(rank, local_rank, world_size, *worker_args)
     finally:
         if dist.is_initialized():
             try:
@@ -70,54 +80,72 @@ def launch_distributed_run(
     world_size = dist_config.world_size
     start_rank = dist_config.start_rank
 
-    # Multi-node environment
-    if dist_config.nnode > 1:
-        master_addr = os.environ.get("MASTER_ADDR", "localhost")
-        master_port = os.environ.get("MASTER_PORT", "29500")
-    else:
-        master_addr = "localhost"
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
-            _, master_port = s.getsockname()
-        master_port = str(master_port)
-
     if world_size <= 1:
         worker(0, 0, 1, *const_worker_args)
     else:
         mp.set_sharing_strategy("file_system")
 
-        ctx = None
-        try:
-            ctx = start_processes(
-                process_name,
-                dist_worker,
-                args={
-                    i: (worker, start_rank + i, i, world_size, *const_worker_args)
-                    for i in range(local_world_size)
-                },
-                envs={
-                    i: {
-                        "LOCAL_RANK": str(i),
-                        "RANK": str(start_rank + i),
-                        "WORLD_SIZE": str(world_size),
-                        "MASTER_ADDR": master_addr,
-                        "MASTER_PORT": master_port,
-                    }
-                    for i in range(local_world_size)
-                },
-                logs_specs=DefaultLogsSpecs(),
-            )
-            result = ctx.wait()
+        # Pin CUDA_VISIBLE_DEVICES per child so each only sees its assigned
+        # GPU. If the parent already had a CUDA_VISIBLE_DEVICES slice, index
+        # into that slice instead of overwriting it.
+        parent_cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+        parent_cvd = (
+            [d.strip() for d in parent_cuda_visible_devices.split(",") if d.strip()]
+            if parent_cuda_visible_devices
+            else [str(j) for j in range(local_world_size)]
+        )
+        assert len(parent_cvd) >= local_world_size, (
+            f"CUDA_VISIBLE_DEVICES has {len(parent_cvd)} entries "
+            f"({parent_cuda_visible_devices!r}) but nproc_per_node={local_world_size}"
+        )
 
-            if result is not None and hasattr(result, "failures") and result.failures:
-                newline = "\n"
-                raise RuntimeError(
-                    f"{process_name} failed with {len(result.failures)} process "
-                    f"failure(s): {newline.join([str(f) for f in result.failures])}"
+        # Multi-node environment
+        if dist_config.nnode > 1:
+            master_addr = os.environ.get("MASTER_ADDR", "localhost")
+            master_port = os.environ.get("MASTER_PORT", "29500")
+        else:
+            master_addr = "localhost"
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                _, master_port = s.getsockname()
+            master_port = str(master_port)
+
+        # Mutate CUDA_VISIBLE_DEVICES in the parent before each spawn so
+        # the child inherits it via execve, before any torch import. The
+        # other distributed env vars are set inside dist_worker once the
+        # child has started, since they're only read by Python code.
+        spawn_ctx = mp.get_context("spawn")
+        saved_cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+        children = []
+        try:
+            for i in range(local_world_size):
+                os.environ["CUDA_VISIBLE_DEVICES"] = parent_cvd[i]
+                p = spawn_ctx.Process(
+                    target=dist_worker,
+                    args=(
+                        worker,
+                        start_rank + i,
+                        i,
+                        world_size,
+                        master_addr,
+                        master_port,
+                        *const_worker_args,
+                    ),
                 )
+                p.start()
+                children.append(p)
         finally:
-            if ctx is not None:
-                ctx.close()  # Kill any processes that are still running
+            if saved_cvd is None:
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            else:
+                os.environ["CUDA_VISIBLE_DEVICES"] = saved_cvd
+
+        for p in children:
+            p.join()
+            if p.exitcode != 0:
+                raise RuntimeError(
+                    f"{process_name} child exited with code {p.exitcode}"
+                )
 
 
 Args = ParamSpec("Args")
@@ -156,6 +184,11 @@ def dist_main(dataset, worker: Worker):
                     "LOCAL_RANK": str(i),
                     "MASTER_ADDR": "localhost",
                     "MASTER_PORT": str(port),
+                    "CUDA_VISIBLE_DEVICES": (
+                        os.environ["CUDA_VISIBLE_DEVICES"].split(",")[i].strip()
+                        if os.environ.get("CUDA_VISIBLE_DEVICES")
+                        else str(i)
+                    ),
                 }
                 for i in range(world_size)
             },

--- a/bergson/hessians/apply_hessian.py
+++ b/bergson/hessians/apply_hessian.py
@@ -2,6 +2,7 @@ import gc
 import json
 import os
 from dataclasses import dataclass
+from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -14,6 +15,7 @@ from torch import Tensor
 from bergson.data import create_index, load_gradients
 from bergson.hessians.sharded_computation import ShardedMul
 from bergson.utils.logger import get_logger
+from bergson.utils.utils import get_device, get_device_index
 
 
 @dataclass
@@ -37,22 +39,22 @@ class EkfacApplicator:
 
         self.rank = dist.get_rank() if dist.is_initialized() else 0
         self.world_size = dist.get_world_size() if dist.is_initialized() else 1
-        self.device = f"cuda:{self.rank}"
+        self.device = get_device(self.rank)
 
         self.sharded_computer = ShardedMul()
 
     def compute_ivhp_sharded(self):
         eigen_a = load_file(
             self.path + f"/eigen_activation_sharded/shard_{self.rank}.safetensors",
-            device=f"cuda:{self.rank}",
+            device=self.device,
         )
         eigen_g = load_file(
             self.path + f"/eigen_gradient_sharded/shard_{self.rank}.safetensors",
-            device=f"cuda:{self.rank}",
+            device=self.device,
         )
         lambda_factor = load_file(
             self.path + f"/eigenvalue_correction_sharded/shard_{self.rank}.safetensors",
-            device=f"cuda:{self.rank}",
+            device=self.device,
         )
 
         for k, v in lambda_factor.items():
@@ -148,10 +150,8 @@ def apply_worker(
     cfg: EkfacConfig,
 ):
     """Worker function for distributed IVHP computation."""
-    from datetime import timedelta
-
     if torch.cuda.is_available():
-        torch.cuda.set_device(local_rank)
+        torch.cuda.set_device(get_device_index(local_rank))
 
     if world_size > 1:
         addr = os.environ.get("MASTER_ADDR", "localhost")
@@ -160,7 +160,7 @@ def apply_worker(
         dist.init_process_group(
             "nccl",
             init_method=f"tcp://{addr}:{port}",
-            device_id=torch.device(f"cuda:{local_rank}"),
+            device_id=torch.device(get_device(local_rank)),
             rank=rank,
             timeout=timedelta(hours=1),
             world_size=world_size,

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -20,6 +20,8 @@ from bergson.hessians.shampoo import ShampooCollector
 from bergson.hessians.tkfac import TraceCovarianceCollector
 from bergson.utils.utils import (
     convert_precision_to_torch,
+    get_device,
+    get_device_index,
     setup_reproducibility,
 )
 from bergson.utils.worker_utils import (
@@ -125,7 +127,7 @@ def hessian_worker(
         The entire dataset to be indexed. A subset is assigned to each worker.
     """
     if torch.cuda.is_available():
-        torch.cuda.set_device(local_rank)
+        torch.cuda.set_device(get_device_index(local_rank))
 
     # These should be set by the main process
     if world_size > 1:
@@ -135,7 +137,7 @@ def hessian_worker(
         dist.init_process_group(
             "nccl",
             init_method=f"tcp://{addr}:{port}",
-            device_id=torch.device(f"cuda:{local_rank}"),
+            device_id=torch.device(get_device(local_rank)),
             rank=rank,
             timeout=timedelta(hours=1),
             world_size=world_size,

--- a/bergson/hessians/sharded_computation.py
+++ b/bergson/hessians/sharded_computation.py
@@ -3,6 +3,8 @@ import torch.distributed as dist
 from jaxtyping import Float
 from torch import Tensor
 
+from bergson.utils.utils import get_device
+
 
 class ShardedMul:
     def __init__(
@@ -12,9 +14,7 @@ class ShardedMul:
 
         self.rank = dist.get_rank() if self.dist else 0
         self.world_size = dist.get_world_size() if self.dist else 1
-        self.device = torch.device(
-            f"cuda:{self.rank}" if torch.cuda.is_available() else "cpu"
-        )
+        self.device = torch.device(get_device(self.rank))
 
     def _init_covariance_dict(
         self,

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -22,6 +22,7 @@ from ..config import TrainingConfig, ValidationConfig
 from ..data import load_scores
 from ..distributed import grad_tree, launch_distributed_run
 from ..utils.logging import wandb_log_fn
+from ..utils.utils import get_device, get_device_index
 from ..utils.worker_utils import (
     setup_data_pipeline,
     setup_model_and_peft,
@@ -119,7 +120,7 @@ def prepare_trainer(
         attn_implementation="eager",
         apply_fsdp=False,
     )
-    model.to(f"cuda:{rank}")  # type: ignore[reportArgumentType]
+    model.to(get_device(rank))  # type: ignore[reportArgumentType]
 
     if target_modules:
         # Only train the PEFT adapter parameters
@@ -264,7 +265,7 @@ def worker(
     run_cfg: TrainingConfig,
     score_path: str = "",
 ):
-    torch.cuda.set_device(rank)
+    torch.cuda.set_device(get_device_index(rank))
 
     if world_size > 1:
         addr = os.environ.get("MASTER_ADDR", "localhost")
@@ -273,7 +274,7 @@ def worker(
         dist.init_process_group(
             "cpu:gloo,cuda:nccl",
             init_method=f"tcp://{addr}:{port}",
-            device_id=torch.device(f"cuda:{rank}"),
+            device_id=torch.device(get_device(rank)),
             rank=rank,
             world_size=world_size,
         )
@@ -304,7 +305,7 @@ def worker(
     stream = DataStream(
         train_dataset,
         run_cfg.batch_size,
-        device=f"cuda:{rank}",
+        device=get_device(rank),
         input_key=run_cfg.data.prompt_column,
         weight_shape=w_shape,
     )
@@ -377,7 +378,7 @@ def worker(
     query_stream = DataStream(
         query_dataset,
         run_cfg.batch_size,
-        device=f"cuda:{rank}",
+        device=get_device(rank),
         input_key=run_cfg.query.prompt_column,
         weight_shape=(num_query_docs,),
     )

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -26,9 +26,12 @@ from bergson.score.score_writer import (
     MemmapTokenScoreWriter,
 )
 from bergson.score.scorer import Scorer
+from bergson.utils.batch_size import test_fwd_bwd
 from bergson.utils.utils import (
     assert_type,
     convert_precision_to_torch,
+    get_device,
+    get_device_index,
     get_gradient_dtype,
 )
 from bergson.utils.worker_utils import (
@@ -246,7 +249,7 @@ def score_worker(
     ds : Dataset | IterableDataset
         The entire dataset to be indexed. A subset is assigned to each worker.
     """
-    torch.cuda.set_device(local_rank)
+    torch.cuda.set_device(get_device_index(local_rank))
 
     # These should be set by the main process
     if world_size > 1:
@@ -256,7 +259,7 @@ def score_worker(
         dist.init_process_group(
             "nccl",
             init_method=f"tcp://{addr}:{port}",
-            device_id=torch.device(f"cuda:{local_rank}"),
+            device_id=torch.device(get_device(local_rank)),
             rank=rank,
             timeout=timedelta(hours=1),
             world_size=world_size,
@@ -264,6 +267,7 @@ def score_worker(
 
     model, target_modules = setup_model_and_peft(index_cfg)
     processor = create_processor(model, index_cfg, target_modules)
+    test_fwd_bwd(model, index_cfg.token_batch_size)
 
     attention_cfgs = {
         module: index_cfg.attention for module in index_cfg.split_attention_modules
@@ -283,7 +287,7 @@ def score_worker(
         if score_cfg.precision != "auto"
         else get_gradient_dtype(model)
     )
-    score_device = torch.device(f"cuda:{rank}")
+    score_device = torch.device(get_device(local_rank))
 
     if isinstance(ds, Dataset):
         kwargs["batches"] = allocate_batches(

--- a/bergson/utils/batch_size.py
+++ b/bergson/utils/batch_size.py
@@ -19,6 +19,52 @@ if TYPE_CHECKING:
     )
 
 
+def test_fwd_bwd(
+    model: PreTrainedModel | PeftModel,
+    token_batch_size: int,
+) -> None:
+    """One worst-case fwd+bwd at ``token_batch_size``.
+
+    Raises if the configured batch size will not fit.
+    """
+    device = next(model.parameters()).device
+    if device.type != "cuda":
+        return
+
+    max_seq_len = (
+        getattr(model.config, "max_position_embeddings", 0) or token_batch_size
+    )
+    seq_len = min(token_batch_size, max_seq_len)
+    num_seqs = max(1, token_batch_size // seq_len)
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    try:
+        input_ids = torch.randint(
+            0, 10, (num_seqs, seq_len), device=device, dtype=torch.long
+        )
+        labels = torch.randint(
+            0, 10, (num_seqs, seq_len), device=device, dtype=torch.long
+        )
+        logits = model(input_ids).logits
+        loss = torch.nn.functional.cross_entropy(
+            logits[:, :-1].contiguous().view(-1, logits.size(-1)),
+            labels[:, 1:].contiguous().view(-1),
+        )
+        loss.backward()
+    except torch.cuda.OutOfMemoryError as e:
+        raise torch.cuda.OutOfMemoryError(
+            f"Pre-flight VRAM check failed for token_batch_size={token_batch_size} "
+            f"({num_seqs} x {seq_len}) on {device}. Lower --token_batch_size and "
+            f"retry. Underlying error: {e}"
+        ) from e
+    finally:
+        model.zero_grad(set_to_none=True)
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
 def maybe_auto_batch_size(
     cfg: IndexConfig,
     model: PreTrainedModel | PeftModel,

--- a/bergson/utils/utils.py
+++ b/bergson/utils/utils.py
@@ -219,9 +219,25 @@ def convert_precision_to_torch(
             return torch.float32
 
 
+def get_device_index(rank: int = 0) -> int:
+    """Return the CUDA device index for the given rank.
+
+    Returns 0 when only one GPU is visible to this process — workers
+    launched by ``launch_distributed_run`` get ``CUDA_VISIBLE_DEVICES``
+    pinned to a single GPU per process, so the only valid index is 0
+    regardless of the logical rank.
+    """
+    if torch.cuda.is_available() and torch.cuda.device_count() == 1:
+        return 0
+    return rank
+
+
 def get_device(rank: int = 0) -> str:
     """Get device string for the given rank.
 
-    Returns "cpu" if CUDA is not available.
+    Returns "cpu" if CUDA is not available, otherwise ``cuda:<index>``
+    where the index respects CVD pinning (see ``get_device_index``).
     """
-    return f"cuda:{rank}" if torch.cuda.is_available() else "cpu"
+    if not torch.cuda.is_available():
+        return "cpu"
+    return f"cuda:{get_device_index(rank)}"

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -35,7 +35,7 @@ from bergson.data import (
 from bergson.format import apply_format
 from bergson.gradients import GradientProcessor, Normalizer
 from bergson.utils import assert_type, get_layer_list, weighted_causal_lm_ce
-from bergson.utils.utils import simple_parse_kwargs_string
+from bergson.utils.utils import get_device, simple_parse_kwargs_string
 
 BIG_NUM = np.iinfo(np.int64).max
 
@@ -73,7 +73,7 @@ def create_processor(
 
         processor = GradientProcessor.load(
             processor_path,
-            map_location=f"cuda:{local_rank}",
+            map_location=get_device(local_rank),
             skip_hessians=cfg.skip_hessians,
         )
     else:
@@ -165,7 +165,7 @@ def setup_model_and_peft(
     elif cfg.fsdp or not torch.cuda.is_available():
         device_map = "cpu"
     else:
-        device_map = {"": f"cuda:{local_rank}"}
+        device_map = {"": get_device(local_rank)}
 
     quantization_config = None
     if cfg.precision in ("int4", "int8"):

--- a/tests/test_multinode.py
+++ b/tests/test_multinode.py
@@ -1,0 +1,111 @@
+"""Multi-node bergson build simulated on a single node.
+
+Spawns two ``python -m bergson build`` processes that pretend to be separate
+nodes. Each owns one physical GPU via outer CUDA_VISIBLE_DEVICES, and they
+rendezvous over loopback. Exercises the multi-node code path through
+``launch_distributed_run``: cross-node NCCL init, ``start_rank`` math
+(``rank = node_rank * nproc_per_node + local_rank``), and the rank-0-only
+partial-to-final move at the end.
+
+If multi-node rendezvous regresses (e.g. CUDA_VISIBLE_DEVICES pinning
+breaks the per-node NCCL handshake, or only one node's data ever reaches disk),
+this test either times out or fails the gradient-count assertion.
+"""
+
+import os
+import socket
+import subprocess
+from pathlib import Path
+
+import pytest
+import torch
+
+from bergson.data import load_gradients
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="Multi-node simulation needs >= 2 GPUs",
+)
+def test_multinode_build_two_nodes_one_gpu_each(tmp_path: Path):
+    run_path = tmp_path / "mn_run"
+    n_examples = 32
+    port = free_port()
+
+    common_args = [
+        "bergson",
+        "build",
+        str(run_path),
+        "--model",
+        "HuggingFaceTB/SmolLM2-135M",
+        "--dataset",
+        "NeelNanda/pile-10k",
+        "--split",
+        f"train[:{n_examples}]",
+        "--truncation",
+        "--projection_dim",
+        "8",
+        "--token_batch_size",
+        "256",
+        "--skip_hessians",
+        "--nnode",
+        "2",
+        "--nproc_per_node",
+        "1",
+        "--overwrite",
+    ]
+
+    base_env = {
+        **os.environ,
+        "MASTER_ADDR": "localhost",
+        "MASTER_PORT": str(port),
+    }
+
+    procs = []
+    for node_rank, gpu in [(1, "1"), (0, "0")]:
+        env = {**base_env, "CUDA_VISIBLE_DEVICES": gpu}
+        procs.append(
+            subprocess.Popen(
+                common_args + ["--node_rank", str(node_rank)],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        )
+
+    outputs = []
+    try:
+        for proc in procs:
+            out, _ = proc.communicate(timeout=600)
+            outputs.append(out)
+    except subprocess.TimeoutExpired:
+        for proc in procs:
+            proc.kill()
+        pytest.fail(
+            "Multi-node simulation timed out — likely a cross-node "
+            "rendezvous hang. Outputs so far:\n"
+            + "\n---\n".join(o or "<no output>" for o in outputs)
+        )
+
+    for i, proc in enumerate(procs):
+        assert proc.returncode == 0, (
+            f"Node {1 - i if i == 0 else 0} exited {proc.returncode}:\n" f"{outputs[i]}"
+        )
+
+    assert run_path.exists(), (
+        "Final run_path missing — rank 0's shutil.move from partial path "
+        "did not run, so the multi-node rank computation is wrong."
+    )
+
+    grads = load_gradients(run_path)
+    assert len(grads) == n_examples, (
+        f"Expected {n_examples} gradients across both nodes, got {len(grads)}. "
+        "One node's shard may not have been written."
+    )


### PR DESCRIPTION
I noticed GPU 0 had an extra .7 GB in VRAM usage per device. I've empirically observed this really adding up at scale.

dist.init_process_group("nccl", ...) is 260 MiB of it (NCCL  cuMemImportFromShareableHandle calls)

When the child process loads CUDA it stores some objects on the set GPU, or on the default GPU which is of course GPU 0. So we want to set CUDA_VISIBLE_DEVICES to the current device in each child process before it loads CUDA.

Unfortunately the child process loads CUDA right when it bootstraps the python interpreter, because python immediately imports bergson which uses torch.compile which immediately loads CUDA so it can understand the hardware characteristics for compilation.

So we mutate CUDA_VISIBLE_DEVICES in the parent process before we spawn the copy (this is safe because CUDA_VISIBLE_DEVICES is only read when CUDA is first loaded, so modiying it in the parent has no effect. This is also the reason why we need to absolutely ensure it's set up front in the child processes - we can't fix this in post).