### PR TITLE
Decouple MAGIC batch padding quirks from other algorithms

### DIFF
--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -707,10 +707,14 @@ class CollectorComputer:
 
                 # Compute padded tensors and valid_mask before entering context
                 # TODO check if valid_mask has bug
+                # Local padding only: bin-packer enforces a per-rank
+                # ``max_len × batch_size ≤ N`` budget that a global-max
+                # all-reduce would silently violate.
                 x, y, valid_mask = pad_and_tensor(
                     batch["input_ids"],
                     labels=batch.get("labels"),
                     device=self.device,
+                    sync_max_len=False,
                 )
                 total_processed += valid_mask.sum()
 

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -595,19 +595,32 @@ def pad_and_tensor(
     padding_value: int = 0,
     dtype: torch.dtype | None = torch.long,
     device: torch.device | None = None,
+    sync_max_len: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Pad a list of sequences to the same length and convert them to tensors.
     Returns a tuple of padded sequences and labels. The labels are the same as the
     sequences, but with -100 for the padding positions, which is useful for ignoring
     padding in loss calculations.
+
+    When ``sync_max_len`` is True (default) and a process group is
+    initialized, the padding length is reduced to the global max across
+    ranks via an ``all_reduce``. This is required by callers that need
+    matching activation shapes across ranks (MAGIC, see PR #227). The
+    build-time gradient collector passes ``sync_max_len=False`` because
+    its bin-packer enforces a per-rank token budget
+    (``max_len × batch_size ≤ N``) that the global all-reduce silently
+    violates when ranks are assigned batches with very different
+    max_lens — a single long-example batch on one rank forces every
+    short-example batch on its peers to pad up to the long length,
+    blowing the budget by orders of magnitude.
     """
     if labels is None:
         labels = sequences
 
     # find max length
     max_len = max(len(seq) for seq in sequences)
-    if dist.is_initialized():
+    if sync_max_len and dist.is_initialized():
         max_len_tensor = torch.tensor(max_len, device=device)
         dist.all_reduce(max_len_tensor, op=dist.ReduceOp.MAX)
         max_len = int(max_len_tensor)

--- a/tests/test_distributed_batch_budget.py
+++ b/tests/test_distributed_batch_budget.py
@@ -1,0 +1,98 @@
+"""Distributed bin-packing + pad must not exceed the per-rank token budget.
+
+Regression test for a NCCL-collective-shaped deadlock observed in the LESS
+pipeline FSDP train builds: ``pad_and_tensor`` does an ``all_reduce(MAX)``
+on sequence length and pads every rank's batch to the global max.
+Combined with bergson's bin-packing (which only enforces the budget per
+batch *in isolation*), a rank that gets a single long-example batch can
+force every other rank at the same iteration index to pad many short
+examples up to that long length, blowing the per-batch token budget by
+~40× and OOM-thrashing the GPU.
+
+This test runs on CPU via gloo so it doesn't need a multi-GPU node.
+"""
+
+import socket
+
+import pytest
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from bergson.data import allocate_batches, pad_and_tensor
+
+
+# Bimodal length distribution: 80 very short examples plus one long one.
+# At token_batch_size=2048 the bin-packer produces one (80 × short) batch
+# and one (1 × long) batch; round-robin distribution puts them on
+# different ranks at iteration 0. The all_reduce(MAX) in pad_and_tensor
+# then pads the (80 × short) batch to the long length on its rank.
+SHORT_LEN = 25
+LONG_LEN = 1000
+N_SHORT = 80
+TOKEN_BUDGET = 2048
+
+
+def _doc_lengths() -> list[int]:
+    return [SHORT_LEN] * N_SHORT + [LONG_LEN]
+
+
+def _worker(rank: int, world_size: int, port: int, results) -> None:
+    try:
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"tcp://localhost:{port}",
+            rank=rank,
+            world_size=world_size,
+        )
+
+        lengths = _doc_lengths()
+        my_batches = allocate_batches(lengths, TOKEN_BUDGET, seed=42)
+
+        # Pad every batch this rank owns and record the worst budget breach.
+        worst = 0
+        for batch in my_batches:
+            input_ids = [[1] * lengths[i] for i in batch]
+            # Match the build-path call: local-only padding so the
+            # bin-packer's per-rank budget invariant is preserved. The
+            # MAGIC path (default sync_max_len=True) still globally
+            # syncs and is expected to over-pad in this scenario.
+            padded, _, _ = pad_and_tensor(input_ids, sync_max_len=False)
+            cost = padded.shape[0] * padded.shape[1]
+            worst = max(worst, cost)
+        results[rank] = worst
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def test_pad_respects_per_rank_budget_under_bimodal_lengths():
+    """Each rank's post-pad batch should stay within the bin-packer's budget."""
+    world_size = 2
+
+    with socket.socket() as s:
+        s.bind(("", 0))
+        port = s.getsockname()[1]
+
+    manager = mp.Manager()
+    results = manager.dict()
+
+    mp.spawn(
+        _worker,
+        args=(world_size, port, results),
+        nprocs=world_size,
+        join=True,
+    )
+
+    for rank in range(world_size):
+        cost = results.get(rank)
+        assert cost is not None, f"rank {rank} did not report"
+        # Allow a small slack but blowups (e.g. 80 × 1000 = 80,000) must fail.
+        assert cost <= TOKEN_BUDGET * 2, (
+            f"rank {rank} padded to {cost} tokens, "
+            f"exceeds bin-packer budget {TOKEN_BUDGET}. "
+            "pad_and_tensor's global-max all_reduce broke the per-rank invariant."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_distributed_batch_budget.py
+++ b/tests/test_distributed_batch_budget.py
@@ -20,7 +20,6 @@ import torch.multiprocessing as mp
 
 from bergson.data import allocate_batches, pad_and_tensor
 
-
 # Bimodal length distribution: 80 very short examples plus one long one.
 # At token_batch_size=2048 the bin-packer produces one (80 × short) batch
 # and one (1 × long) batch; round-robin distribution puts them on


### PR DESCRIPTION
bergson's bin-packer enforces a per-rank token budget max_len * batch_size <= N. 

[PR #227](https://github.com/EleutherAI/bergson/pull/227) added an all_reduce(MAX) on max_len in pad_and_tensor to make activation shapes identical across ranks for the MAGIC trainer. But build index also calls pad_and_tensor. 

If there is a large variance in sequence length so there are some 2-token items and some long ones you can get one device that's like [1, 2048] and another that's like [1024, 2] and then when you pad everything to the max length you get a batch that's like [1024, 2048] and everything hangs (crashes on one rank). I'm making this flag-controlled so we can keep your MAGIC fix and turn it off for everything else. But this isn't a great long term solution (due to my limited understanding of the relevant factors).

Adds a CPU test that fails on the pre-fix code path (rank 1 padded to 79,000 tokens vs. 2048 budget).


I don't love this solution - MAGIC will also OOM in scenarios with high sequence length variance. But apparently without it we get hangs? hoping for some more info from @norabelrose 