### PR TITLE
Declare torch as build dep for fast-jl in uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ reportPrivateImportUsage = false
 [tool.setuptools.packages.find]
 include = ["bergson*"]
 
+[tool.uv.extra-build-dependencies]
+fast-jl = ["torch>=2.4,<2.10"]
+
 [tool.black]
 target-version = ["py310", "py311", "py312"]
 


### PR DESCRIPTION
Allows `uv sync --extra fast-jl` to succeed on a fresh repo by giving fast-jl's setup.py access to torch at build time. Pip users still need the documented `--no-build-isolation` workaround.