### PR TITLE
Add test coverage - trackstar token scores sum to sequence scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+logs/
+
 
 ablations/
 archive/

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -10,7 +10,11 @@ from tqdm.auto import tqdm
 from bergson.collection import collect_gradients
 from bergson.config import HessianConfig, IndexConfig, PreprocessConfig
 from bergson.data import allocate_batches
-from bergson.distributed import cap_world_size_to_dataset, launch_distributed_run
+from bergson.distributed import (
+    cap_world_size_to_dataset,
+    launch_distributed_run,
+    parent_barrier,
+)
 from bergson.utils.batch_size import maybe_auto_batch_size
 from bergson.utils.utils import (
     assert_type,
@@ -172,3 +176,6 @@ def build(
 
     if dist_cfg.rank == 0:
         shutil.move(index_cfg.partial_run_path, index_cfg.run_path)
+
+    if dist_cfg.world_size < index_cfg.distributed.world_size:
+        parent_barrier(index_cfg.distributed)

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -110,6 +110,8 @@ def launch_distributed_run(
     start_rank = dist_config.start_rank
 
     if world_size <= 1:
+        # Handle multi-node pipelines with single-process steps
+        # Other nodes proceed to next step's NCCL rendezvous
         if dist_config._node_rank == 0:
             worker(0, 0, 1, *const_worker_args)
     else:

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -26,6 +26,21 @@ def cap_world_size_to_dataset(
     return capped_cfg
 
 
+def parent_barrier(dist_config: DistributedConfig) -> None:
+    if dist_config.nnode <= 1:
+        return
+    master_addr = os.environ.get("MASTER_ADDR", "localhost")
+    master_port = str(int(os.environ.get("MASTER_PORT", "29500")) + 1)
+    dist.init_process_group(
+        "gloo",
+        init_method=f"tcp://{master_addr}:{master_port}",
+        rank=dist_config._node_rank,
+        world_size=dist_config.nnode,
+    )
+    dist.barrier()
+    dist.destroy_process_group()
+
+
 def grad_tree(
     outputs: torch.Tensor,
     inputs: Mapping[str, torch.Tensor],
@@ -95,8 +110,6 @@ def launch_distributed_run(
     start_rank = dist_config.start_rank
 
     if world_size <= 1:
-        # Handle multi-node pipelines with single-process steps
-        # Other nodes proceed to next step's NCCL rendezvous
         if dist_config._node_rank == 0:
             worker(0, 0, 1, *const_worker_args)
     else:

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -16,7 +16,11 @@ from bergson.data import (
     allocate_batches,
     load_gradients,
 )
-from bergson.distributed import cap_world_size_to_dataset, launch_distributed_run
+from bergson.distributed import (
+    cap_world_size_to_dataset,
+    launch_distributed_run,
+    parent_barrier,
+)
 from bergson.process_grads import (
     get_trackstar_hessian,
     normalize_and_aggregate_grads,
@@ -387,3 +391,6 @@ def score_dataset(
 
     if dist_cfg.rank == 0:
         shutil.move(index_cfg.partial_run_path, index_cfg.run_path)
+
+    if dist_cfg.world_size < index_cfg.distributed.world_size:
+        parent_barrier(index_cfg.distributed)

--- a/tests/test_attribute_tokens.py
+++ b/tests/test_attribute_tokens.py
@@ -607,3 +607,229 @@ def test_token_sum_equals_sequence(
                 msg=f"Module {name}, example {i}: "
                 f"token sum and sequence grad diverge",
             )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("projection_dim", [None, 8])
+def test_trackstar_token_scores_sum_to_sequence_scores(
+    tmp_path, model, dataset, projection_dim
+):
+    """Per-token TrackStar scores summed within a doc equal the per-doc score.
+
+    TrackStar's score is ``s(d) = <q, H^-1, grad(d)>`` — a linear function of
+    the index gradient. With ``loss_reduction='sum'`` the per-token gradients
+    ``g_{d,t}`` satisfy ``sum_t g_{d,t} = grad(d)`` (see
+    ``test_token_sum_equals_sequence``); composing with the linear scoring
+    operator gives ``sum_t s(d, t) = s(d)`` for every doc d.
+
+    This is the score-level analog of the gradient-level test above, and
+    the trackstar analog of ``test_magic_per_token_sums_to_per_doc``.
+    """
+    from bergson.score.score_writer import InMemorySequenceScoreWriter
+    from bergson.score.scorer import Scorer
+
+    model = model.float()
+    dataset = dataset.repeat(10)
+
+    target_modules = {
+        name
+        for name, module in model.base_model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+    }
+
+    processor = GradientProcessor(projection_dim=projection_dim)
+
+    seq_collector = _collect_in_memory(
+        model,
+        dataset,
+        processor,
+        target_modules,
+        attribute_tokens=False,
+        run_path=str(tmp_path / "seq"),
+    )
+    tok_collector = _collect_in_memory(
+        model,
+        dataset,
+        processor,
+        target_modules,
+        attribute_tokens=True,
+        run_path=str(tmp_path / "tok"),
+    )
+
+    sorted_modules = sorted(seq_collector.gradients.keys())
+    torch.manual_seed(0)
+    query_grads = {
+        m: torch.randn(1, seq_collector.gradients[m].shape[-1]) for m in sorted_modules
+    }
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    seq_scorer = Scorer(
+        query_grads=query_grads,
+        modules=sorted_modules,
+        writer=InMemorySequenceScoreWriter(len(dataset), 1, dtype=dtype),
+        device=device,
+        dtype=dtype,
+    )
+    seq_scores = seq_scorer.score(seq_collector.gradients).float().cpu().squeeze(-1)
+
+    n_tokens = tok_collector.gradients[sorted_modules[0]].shape[0]
+    tok_scorer = Scorer(
+        query_grads=query_grads,
+        modules=sorted_modules,
+        writer=InMemorySequenceScoreWriter(n_tokens, 1, dtype=dtype),
+        device=device,
+        dtype=dtype,
+    )
+    tok_scores = tok_scorer.score(tok_collector.gradients).float().cpu().squeeze(-1)
+
+    assert tok_collector.builder is not None
+    offsets = tok_collector.builder.offsets
+
+    for i in range(len(dataset)):
+        start, end = int(offsets[i]), int(offsets[i + 1])
+        tok_sum = tok_scores[start:end].sum()
+        torch.testing.assert_close(
+            tok_sum,
+            seq_scores[i],
+            atol=1e-2,
+            rtol=1e-2,
+            msg=(
+                f"Example {i}: per-token score sum {tok_sum:.6e} != "
+                f"per-doc score {seq_scores[i]:.6e}"
+            ),
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("projection_dim", [None, 8])
+def test_trackstar_token_scores_sum_to_sequence_scores_on_disk(
+    tmp_path, model, dataset, projection_dim
+):
+    """On-disk per-token scores summed within a doc equal on-disk per-doc scores.
+
+    Same property as ``test_trackstar_token_scores_sum_to_sequence_scores``,
+    routed through ``MemmapSequenceScoreWriter`` /
+    ``MemmapTokenScoreWriter`` so the disk write + read-back paths
+    (info.json, structured scores.bin, token_scores.bin, offsets.npy)
+    are exercised end-to-end.
+    """
+    from bergson.score.score_writer import (
+        MemmapSequenceScoreWriter,
+        MemmapTokenScoreWriter,
+    )
+    from bergson.score.scorer import Scorer
+
+    model = model.float()
+    dataset = dataset.repeat(10)
+
+    target_modules = {
+        name
+        for name, module in model.base_model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+    }
+
+    processor = GradientProcessor(projection_dim=projection_dim)
+
+    seq_collector = _collect_in_memory(
+        model,
+        dataset,
+        processor,
+        target_modules,
+        attribute_tokens=False,
+        run_path=str(tmp_path / "seq"),
+    )
+    tok_collector = _collect_in_memory(
+        model,
+        dataset,
+        processor,
+        target_modules,
+        attribute_tokens=True,
+        run_path=str(tmp_path / "tok"),
+    )
+
+    sorted_modules = sorted(seq_collector.gradients.keys())
+    torch.manual_seed(0)
+    query_grads = {
+        m: torch.randn(1, seq_collector.gradients[m].shape[-1]) for m in sorted_modules
+    }
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+    indices = list(range(len(dataset)))
+
+    # --- Per-doc scores via MemmapSequenceScoreWriter ---
+    seq_path = tmp_path / "seq_scores"
+    seq_writer = MemmapSequenceScoreWriter(seq_path, len(dataset), 1, dtype=dtype)
+    seq_scorer = Scorer(
+        query_grads=query_grads,
+        modules=sorted_modules,
+        writer=seq_writer,
+        device=device,
+        dtype=dtype,
+    )
+    seq_scorer(indices, seq_collector.gradients)
+    seq_writer.flush()
+
+    # --- Per-token scores via MemmapTokenScoreWriter ---
+    tok_path = tmp_path / "tok_scores"
+    tok_writer = MemmapTokenScoreWriter(tok_path, dataset, 1, dtype=dtype)
+    tok_scorer = Scorer(
+        query_grads=query_grads,
+        modules=sorted_modules,
+        writer=tok_writer,
+        device=device,
+        dtype=dtype,
+        attribute_tokens=True,
+    )
+    # Per-token Scorer expects already-flat per-token gradients of shape
+    # [total_valid_tokens, grad_dim] per module, which is exactly what the
+    # InMemoryCollector populated with attribute_tokens=True produces.
+    tok_scorer(indices, tok_collector.gradients)
+    tok_writer.flush()
+
+    # --- Read back from disk ---
+    with open(seq_path / "info.json") as f:
+        seq_info = json.load(f)
+    seq_dtype = np.dtype(
+        {
+            "names": seq_info["dtype"]["names"],
+            "formats": seq_info["dtype"]["formats"],
+            "offsets": seq_info["dtype"]["offsets"],
+            "itemsize": seq_info["dtype"]["itemsize"],
+        }
+    )
+    seq_mmap = np.memmap(
+        seq_path / "scores.bin",
+        dtype=seq_dtype,
+        mode="r",
+        shape=(seq_info["num_items"],),
+    )
+    seq_scores = torch.from_numpy(seq_mmap["score_0"].copy())
+
+    with open(tok_path / "info.json") as f:
+        tok_info = json.load(f)
+    tok_np_dtype = np.dtype(tok_info["dtype"])
+    tok_mmap = np.memmap(
+        tok_path / "token_scores.bin",
+        dtype=tok_np_dtype,
+        mode="r",
+        shape=(tok_info["total_tokens"], tok_info["num_scores"]),
+    )
+    tok_scores = torch.from_numpy(tok_mmap[:, 0].copy())
+    offsets = np.load(tok_path / "offsets.npy")
+
+    for i in range(len(dataset)):
+        start, end = int(offsets[i]), int(offsets[i + 1])
+        tok_sum = tok_scores[start:end].sum()
+        torch.testing.assert_close(
+            tok_sum,
+            seq_scores[i],
+            atol=1e-2,
+            rtol=1e-2,
+            msg=(
+                f"Example {i}: on-disk token sum {tok_sum:.6e} != "
+                f"on-disk per-doc score {seq_scores[i]:.6e}"
+            ),
+        )

--- a/tests/test_distributed_cap.py
+++ b/tests/test_distributed_cap.py
@@ -1,0 +1,84 @@
+"""Tests for capping world_size to dataset size in build/score paths.
+
+When a dataset has fewer docs than the configured world_size, the build
+path used to pad the dataset and truncate the resulting index. The new
+behavior reduces world_size to ``len(dataset)`` instead — no padding,
+no truncation, no duplicate gradient computation across ranks.
+"""
+
+from bergson.config import DistributedConfig
+from bergson.distributed import cap_world_size_to_dataset
+
+
+def test_cap_to_dataset_size_when_smaller():
+    """Tiny dataset → capped to single node, nproc_per_node = dataset size."""
+    cfg = DistributedConfig(nnode=4, nproc_per_node=4)
+    assert cfg.world_size == 16
+    capped = cap_world_size_to_dataset(cfg, dataset_size=1)
+    assert capped.world_size == 1
+    assert capped.nnode == 1
+    assert capped.nproc_per_node == 1
+
+
+def test_cap_to_intermediate_dataset_size():
+    """Dataset between 1 and original world_size → single node, fitting nproc."""
+    cfg = DistributedConfig(nnode=4, nproc_per_node=4)
+    capped = cap_world_size_to_dataset(cfg, dataset_size=3)
+    assert capped.world_size == 3
+    assert capped.nnode == 1
+    assert capped.nproc_per_node == 3
+
+
+def test_unchanged_when_dataset_at_least_world_size():
+    """Dataset with >= world_size docs → cfg returned unchanged."""
+    cfg = DistributedConfig(nnode=4, nproc_per_node=4)
+    capped = cap_world_size_to_dataset(cfg, dataset_size=100)
+    assert capped.world_size == 16
+    assert capped.nnode == 4
+    assert capped.nproc_per_node == 4
+
+
+def test_caps_to_one_node_when_dataset_exceeds_nproc_per_node():
+    """Dataset between nproc_per_node and world_size → 1 node, full nproc_per_node."""
+    cfg = DistributedConfig(nnode=4, nproc_per_node=4)
+    # 5 docs: too many for 1 GPU, too few for the full 16-GPU world.
+    capped = cap_world_size_to_dataset(cfg, dataset_size=5)
+    assert capped.world_size == 4
+    assert capped.nnode == 1
+    assert capped.nproc_per_node == 4
+
+
+def test_unchanged_when_dataset_exactly_world_size():
+    """Boundary: dataset == world_size leaves cfg unchanged (cap on strict-less)."""
+    cfg = DistributedConfig(nnode=4, nproc_per_node=4)
+    capped = cap_world_size_to_dataset(cfg, dataset_size=16)
+    assert capped.world_size == 16
+    assert capped.nnode == 4
+    assert capped.nproc_per_node == 4
+
+
+def test_does_not_mutate_input():
+    """Capping returns a new cfg; the original is untouched."""
+    cfg = DistributedConfig(nnode=4, nproc_per_node=4)
+    cap_world_size_to_dataset(cfg, dataset_size=1)
+    assert cfg.nnode == 4
+    assert cfg.nproc_per_node == 4
+    assert cfg.world_size == 16
+
+
+def test_zero_dataset_size_caps_to_one_worker():
+    """Dataset with zero docs caps to a single worker (downstream raises)."""
+    cfg = DistributedConfig(nnode=4, nproc_per_node=4)
+    capped = cap_world_size_to_dataset(cfg, dataset_size=0)
+    assert capped.world_size == 1
+    assert capped.nnode == 1
+    assert capped.nproc_per_node == 1
+
+
+def test_single_node_unchanged_when_already_small():
+    """Single-node config with dataset >= existing world_size is unchanged."""
+    cfg = DistributedConfig(nnode=1, nproc_per_node=2)
+    capped = cap_world_size_to_dataset(cfg, dataset_size=10)
+    assert capped.world_size == 2
+    assert capped.nnode == 1
+    assert capped.nproc_per_node == 2


### PR DESCRIPTION
cc: @SrGonao for SOAR team

- Add test coverage - trackstar token scores sum to sequence scores
- Fix unrelated bug in pipeline context when using different numbers of nodes for each step that I introduced ten minutes ago