### PR TITLE
Allow multiple backwards for a single forward

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -22,6 +22,12 @@ from torch.distributed._functional_collectives import (
 from torch.distributed.tensor import init_device_mesh
 from torchopt.pytree import tree_iter
 from tqdm import tqdm
+from transformers.utils.logging import (
+    disable_progress_bar as hf_disable_pbar,
+)
+from transformers.utils.logging import (
+    set_verbosity_error as hf_set_verbosity_error,
+)
 
 from ..config import TrainingConfig, ValidationConfig
 from ..data import load_scores
@@ -52,12 +58,18 @@ def compute_query_gradients(
     Iterates over the query stream, computing per-batch parameter gradients
     and reducing them (mean or sum) into a single gradient dict.
     """
+    denom = len(query_stream)
     grad_accum: dict[str, torch.Tensor] | None = None
     loss_accum = 0.0
-    denom = len(query_stream) * (dist.get_world_size() if dist.is_initialized() else 1)
+
+    if dist.is_initialized():
+        denom *= dist.get_world_size()
+        main = dist.get_rank() == 0
+    else:
+        main = True
 
     with fwd_state.activate(model) as params:
-        for batch in tqdm(query_stream, desc="Query"):
+        for batch in tqdm(query_stream, desc="Query", disable=not main):
             del batch["example_weight"]
             loss = model(**batch).loss
             grads = grad_tree(loss, params)
@@ -121,11 +133,7 @@ class CSVWriter:
             self._file.close()
 
 
-def prepare_trainer(
-    cfg: TrainingConfig,
-    rank: int,
-    schedule: Callable,
-):
+def prepare_trainer(cfg: TrainingConfig, rank: int, schedule: Callable):
     """Prepare the model, optimizer, and trainer for training."""
     model, target_modules = setup_model_and_peft(
         cfg,
@@ -279,6 +287,11 @@ def worker(
 ):
     torch.cuda.set_device(get_device_index(rank))
 
+    # For each non-main local rank, suppress HF info and warning messages
+    if rank != 0:
+        hf_disable_pbar()
+        hf_set_verbosity_error()
+
     if world_size > 1:
         addr = os.environ.get("MASTER_ADDR", "localhost")
         port = os.environ.get("MASTER_PORT", "29500")
@@ -335,20 +348,10 @@ def worker(
         dist.barrier()
 
     schedule = run_cfg.lr_schedule.get_schedule(len(stream))
-    trainer, fwd_state, model = prepare_trainer(
-        run_cfg,
-        rank,
-        schedule,
-    )
+    trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
 
     ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")
-    path0 = os.path.join(ckpts_path, "state0.pt")
-
-    resume = run_cfg.resume and os.path.exists(path0)
-
-    save_fut = None
-    if not resume:
-        save_fut = fwd_state.save(path0)
+    resume = run_cfg.resume
 
     fwd_state = trainer.train(
         fwd_state,
@@ -361,9 +364,6 @@ def worker(
         resume=resume,
         fsdp=run_cfg.fsdp,
     )
-
-    if save_fut is not None:
-        save_fut.result()  # ensure state0 is saved before validation loads it
 
     # If no query dataset is provided, skip backward and validation entirely
     if query_dataset is None:
@@ -424,6 +424,7 @@ def worker(
             stream,
             bwd_state,
             fwd_state,
+            cleanup=run_cfg.cleanup_ckpts,
             debug=run_cfg.debug,
             inplace=True,
             fsdp=run_cfg.fsdp,
@@ -495,9 +496,13 @@ def worker(
         enabled=global_rank == 0,
     )
 
+    # Disable annoying repetitive model loading messages, even on rank 0
+    hf_disable_pbar()
+    hf_set_verbosity_error()
+
     pbar = tqdm(subsets, desc="Validating", disable=global_rank != 0)
     for i, subset in enumerate(pbar):
-        fwd_state.load(path0)
+        trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
         fwd_state.detach_()
 
         stream.weights.fill_(1.0)

--- a/bergson/magic/config.py
+++ b/bergson/magic/config.py
@@ -27,5 +27,8 @@ class MagicConfig(ValidationConfig):
     backward_save_every: int = 0
     """How often (in steps) to save backward state for resume."""
 
+    cleanup_ckpts: bool = True
+    """Whether to delete all but the last checkpoint during the backward pass."""
+
     per_token: bool = False
     """Whether to compute attribution scores per token (instead of per sequence)."""

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -6,7 +6,7 @@ from concurrent.futures import Future
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from shutil import rmtree
-from typing import cast
+from typing import Any, cast
 
 import psutil
 import torch
@@ -280,12 +280,29 @@ class Trainer:
     def step(
         self,
         state: TrainerState,
-        inputs: dict,
+        inputs: dict[str, Any],
         *,
         inplace: bool = False,
         trace: bool = False,
         fsdp: bool = False,
     ) -> TrainerState:
+        """Perform a single training step on `state`, returning the new state.
+
+        Args:
+            state: The current trainer state, containing model parameters, optimizer
+                state, and RNG states.
+            inputs: A batch of training data to use for this step. It will be unpacked
+                as keyword arguments to the model's forward method.
+            inplace: Whether to perform in-place updates during this step. In-place
+                updates can reduce memory usage but can cause problems with autograd.
+            trace: Whether to trace this step with autograd to allow for a backward
+                pass later. Tracing can add overhead, so it should only be enabled if
+                backward passes will be needed.
+            fsdp: Whether the model is wrapped with FSDP. If False and distributed
+                training is being used, the trainer will perform its own all-reduce of
+                gradients. If True, the trainer will assume that FSDP is handling
+                gradient synchronization, and will not perform any all-reduces itself.
+        """
         torch.random.set_rng_state(state.cpu_rng_state)
 
         # Trainable params live on the meta device and are swapped in from state.
@@ -339,7 +356,12 @@ class Trainer:
         )
         return state
 
-    def resume(self, state: TrainerState, save_dir: str):
+    def resume(self, state: TrainerState, save_dir: str) -> TrainerState:
+        """Resume training from the most recent checkpoint in `save_dir`.
+
+        This method modifies `state` in-place to load the most recent checkpoint, and
+        returns it for convenience.
+        """
         ckpt_list = sorted_checkpoints(save_dir)
 
         # Filter out incomplete checkpoints (missing .metadata) and clean them up
@@ -352,10 +374,11 @@ class Trainer:
                 rmtree(path) if os.path.isdir(path) else os.remove(path)
 
         # Load the most recent trainer state
-        last_idx, last_path = valid_ckpts[-1]
-        state.batch_index = last_idx
-        state.load(last_path)
-        state.detach_()
+        if valid_ckpts:
+            last_idx, last_path = valid_ckpts[-1]
+            state.batch_index = last_idx
+            state.load(last_path)
+            state.detach_()
 
         return state
 
@@ -373,6 +396,30 @@ class Trainer:
         resume: bool = False,
         fsdp: bool = False,
     ) -> TrainerState:
+        """Train the model on the given data stream, starting from the given state.
+
+        Args:
+            state: The initial trainer state to start training from.
+            data: The training data stream to iterate over.
+            debug: Whether to print debug information about checkpoint loading times.
+            inplace: Whether to perform in-place updates during training. In-place
+                updates can reduce memory usage but may cause issues with some
+                optimizers or models.
+            save_dir: The directory in which to save checkpoints during training.
+            save_mode: The strategy for how often to save checkpoints.
+            trace: Whether to trace the training step with autograd to allow for
+                backward passes. Tracing can add overhead, so it should only be enabled
+                if backward passes will be needed.
+            log_fn: An optional function to call after each training step with the step
+                index and the most recent loss value, for logging purposes.
+            resume: Whether to resume from a previously interrupted training run by
+                loading the most recent checkpoint from `save_dir`.
+            fsdp: Flag to pass to `Trainer.step`, indicating whether the model is
+                wrapped with FSDP.
+
+        Returns:
+            The final trainer state after training.
+        """
         # Make sure the save directory exists
         if save_dir is not None:
             os.makedirs(save_dir, exist_ok=True)
@@ -385,6 +432,13 @@ class Trainer:
         if resume and save_dir is not None:
             state = self.resume(state, save_dir)
             start = state.batch_index
+
+            # It's possible that training is already finished, and this is a no-op. In
+            # that case, don't bother creating the progress bar.
+            # Note that we actually skip training if start == n - 1, not start == n,
+            # because Trainer.backward will redo the last training step no matter what.
+            if start >= n - 1:
+                return state
 
         pending_save: SaveFuture | None = None
 
@@ -497,10 +551,42 @@ class Trainer:
         save_every: int = 0,
         save_mode: MagicSaveMode = "sqrt",
     ) -> BackwardState:
-        ckpt_list = cast(
-            list[tuple[int, str | TrainerState]],
-            sorted_checkpoints(ckpt_dir),
-        )
+        """Run a backward pass through the training trajectory saved at `ckpt_dir`.
+
+        Args:
+            ckpt_dir: Directory containing checkpoints saved during the forward pass.
+            data: The training data stream, needed to replay forward steps.
+            bwd_state: The initial backward state, containing gradients for the query
+                loss function.
+            fwd_state: Forward state containing the model parameters and optimizer
+                state from the end of the forward trajectory.
+            cleanup: Whether to delete checkpoints in `ckpt_dir` as soon as they are
+                no longer needed. If False, only the temporary checkpoints created
+                during the backward pass will be deleted, and all original checkpoints
+                will be preserved.
+            debug: Whether to print debug information about checkpoint loading times.
+            inplace: Whether to perform in-place updates during forward and backward
+                steps. In-place updates can reduce memory usage but may cause issues
+                with some optimizers or models.
+            fsdp: The `fsdp` flag that will be passed to the trainer's `step` method.
+            resume: Whether to resume from a previously interrupted backward pass by
+                loading the backward state and skipping checkpoints that have already
+                been processed.
+            save_every: If > 0, save the backward state every N steps to allow resuming
+                from interruptions. Backward checkpoints are saved in `ckpt_dir` with
+                the name `backward_rank{rank}.pt`.
+            save_mode: The save mode that was used during the forward trajectory, which
+                determines how checkpoints are spaced and thus how the backward pass
+                should step forward through the trajectory when replaying.
+
+        Returns:
+            The final backward state after processing the entire trajectory.
+        """
+        ckpts = sorted_checkpoints(ckpt_dir)
+        ckpt_paths = [path for _, path in ckpts]
+        preserve_paths = {ckpt_paths[-1]} if cleanup else set(ckpt_paths)
+
+        ckpt_list = cast(list[tuple[int, str | TrainerState]], ckpts)
         state_size = fwd_state.size_in_bytes()
 
         main = not dist.is_initialized() or dist.get_rank() == 0
@@ -552,7 +638,7 @@ class Trainer:
                 del ckpt_list[-1]
 
                 # Only delete on the main rank
-                if cleanup and isinstance(ckpt, str) and main and idx != last_idx:
+                if isinstance(ckpt, str) and main and ckpt not in preserve_paths:
                     rmtree(ckpt) if os.path.isdir(ckpt) else os.remove(ckpt)
 
             # Step forward in training if needed

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -433,13 +433,6 @@ class Trainer:
             state = self.resume(state, save_dir)
             start = state.batch_index
 
-            # It's possible that training is already finished, and this is a no-op. In
-            # that case, don't bother creating the progress bar.
-            # Note that we actually skip training if start == n - 1, not start == n,
-            # because Trainer.backward will redo the last training step no matter what.
-            if start >= n - 1:
-                return state
-
         pending_save: SaveFuture | None = None
 
         main = not dist.is_initialized() or dist.get_rank() == 0

--- a/examples/magic/gpt2_wikitext.yaml
+++ b/examples/magic/gpt2_wikitext.yaml
@@ -1,6 +1,7 @@
 run_path: runs/gpt2_wikitext
 model: gpt2
 overwrite: true
+cleanup_ckpts: false
 
 data:
   dataset: Salesforce/wikitext


### PR DESCRIPTION
The `cleanup_ckpts` flag now exists, and can be set to `False`. When turned off, the `Trainer.backward` method does not delete the checkpoints created by `Trainer.train`, so these can be reused in a future `backward` call.

To perform multiple backward passes for a single forward pass, just set `cleanup_ckpts: false` in the config for `bergson magic`, then use `resume: true` on subsequent backward passes. This will cause `Trainer.train` to be a no-op, and it'll jump straight to `Trainer.backward`.

This PR also suppresses some annoying warning and info messages created by HuggingFace on ranks other than rank 0, for a better user experience. It also adds some extra docstrings.