### PR TITLE
Pin transformers>=5.0 and bump torch>=2.5 lower bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ dependencies = [
     "pyyaml",
     "simple-parsing",
     "torch>=2.5,<2.10",
+    # torchvision/torchaudio aren't used by bergson directly, but transformers'
+    # image_utils does an unconditional `from torchvision.io import ...` at
+    # import time when torchvision is present. RunPod (and most CUDA base
+    # images) ship a torchvision built against torch 2.4; once we bump torch
+    # to >=2.5, the stale torchvision crashes at import. Pin both to a range
+    # compatible with the torch bound above.
+    "torchvision>=0.20,<0.25",
+    "torchaudio>=2.5,<2.10",
     "torchopt",
     "transformers>=5.0",
     "bitsandbytes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
     "pyarrow",
     "pyyaml",
     "simple-parsing",
-    "torch>=2.4,<2.10",
+    "torch>=2.5,<2.10",
     "torchopt",
-    "transformers",
+    "transformers>=5.0",
     "bitsandbytes",
     "traker",
     "huggingface-hub>=1.13.0",
@@ -73,7 +73,7 @@ faiss = [
 bergson = "bergson.__main__:main"
 
 [tool.uv.extra-build-dependencies]
-fast-jl = ["torch>=2.4,<2.10"]
+fast-jl = ["torch>=2.5,<2.10"]
 
 [tool.pyright]
 include = ["bergson*"]


### PR DESCRIPTION
(Maybe no one else was having this issue? @luciaquirke @LouisYRYJ?)

## Summary

Make `pip install -e .` actually work on a stock CUDA base image (RunPod and similar). Three pin changes:

- **`torch>=2.4,<2.10` → `torch>=2.5,<2.10`** — transformers 5.x imports `torch.distributed.tensor.device_mesh`, only present from torch 2.5. With torch 2.4 a fresh install can't even `import transformers`.
- **`transformers` → `transformers>=5.0`** — currently unpinned. The existing `huggingface-hub>=1.13.0` already implicitly forces this (transformers 4.x wants `hf_hub<1.0`, which collides with our pin for `parse_hf_uri`), but making it explicit prevents a resolver from picking a 4.x and ending up in an unrunnable state.
- **Add `torchvision>=0.20,<0.25` and `torchaudio>=2.5,<2.10`** — bergson never imports either, but transformers' `image_utils.py` does an unconditional `from torchvision.io import ImageReadMode, decode_image` at import time. Stock CUDA images ship a torchvision built for torch 2.4; bumping torch to 2.5 without bumping torchvision leaves a landmine that crashes `bergson --help` with `RuntimeError: operator torchvision::nms does not exist`. Adding ranged pins lets pip resolve the matching upgrade.

The minimum consistent set is **torch ≥ 2.5 + transformers ≥ 5 + hf_hub ≥ 1.13 + matching torchvision/torchaudio**. All four are now pinned explicitly.

## Why?

Hit this debugging the P-SIFT branch on a fresh RunPod box. `pip install -e .` left torch 2.4 + transformers 5.9, which crashed at import time. Working backwards through downgrades produced an `hf_hub`/`transformers` conflict. Bumping torch revealed the torchvision landmine. Took about two hours of dependency triangulation across two RunPod boxes; pinning explicitly saves the next person from re-running that.

## Trade-off

The torchvision/torchaudio pins add ~1 GB of wheels for a user who happens to have neither installed. The alternative (document-the-manual-fix in README) keeps installs lean but means every new contributor hits the same wall. I went with pinning since the goal is to make `pip install -e .` just work on a stock GPU image.