### PR TITLE
Refactor skip hessians, remove processor_path

### DIFF
--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -8,7 +8,7 @@ from simple_parsing import ArgumentParser, ConflictResolution, Serializable
 from bergson.hessians.pipeline import hessian_pipeline
 
 from .approx_unrolling.pipeline import approx_unrolling_pipeline
-from .build import build
+from .build import build, BuildConfig
 from .config import (
     ApproxUnrollingConfig,
     HessianConfig,
@@ -61,21 +61,29 @@ class ApproxUnrolling(Serializable):
 @dataclass
 class Build(Serializable):
     """
-    Build a gradient index. Simultaneously approximates an autocorrelation Hessian
-    unless disabled with `--skip_hessians True`."""
+    Build a gradient index. Simultaneously approximate an autocorrelation Hessian
+    with `--skip_hessians False`."""
 
     index_cfg: IndexConfig
 
     preprocess_cfg: PreprocessConfig
 
+    build_cfg: BuildConfig
+
     def execute(self):
         """Build the gradient index."""
-        if self.index_cfg.skip_index and self.index_cfg.skip_hessians:
+        if self.index_cfg.skip_index and self.build_cfg.skip_hessians:
             raise ValueError("Either skip_index or skip_hessians must be False")
+        
+        hessian_cfg = (
+            None
+            if self.build_cfg.skip_hessians
+            else HessianConfig(method="autocorrelation")
+        )
 
         validate_run_path(self.index_cfg)
 
-        build(self.index_cfg, self.preprocess_cfg)
+        build(self.index_cfg, self.preprocess_cfg, hessian_cfg)
 
 
 @dataclass
@@ -116,8 +124,7 @@ class Hessian(Serializable):
 
         if self.hessian_cfg.method == "autocorrelation":
             self.index_cfg.skip_index = True
-            self.index_cfg.skip_hessians = False
-            build(self.index_cfg, PreprocessConfig())
+            build(self.index_cfg, PreprocessConfig(), self.hessian_cfg)
         else:
             approximate_hessians(self.index_cfg, self.hessian_cfg)
 

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Union, get_args
 
 from simple_parsing import ArgumentParser, ConflictResolution, Serializable
@@ -68,7 +68,7 @@ class Build(Serializable):
 
     preprocess_cfg: PreprocessConfig
 
-    build_cfg: BuildConfig
+    build_cfg: BuildConfig = field(default_factory=BuildConfig)
 
     def execute(self):
         """Build the gradient index."""

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -8,7 +8,7 @@ from simple_parsing import ArgumentParser, ConflictResolution, Serializable
 from bergson.hessians.pipeline import hessian_pipeline
 
 from .approx_unrolling.pipeline import approx_unrolling_pipeline
-from .build import build, BuildConfig
+from .build import BuildConfig, build
 from .config import (
     ApproxUnrollingConfig,
     HessianConfig,
@@ -74,7 +74,7 @@ class Build(Serializable):
         """Build the gradient index."""
         if self.index_cfg.skip_index and self.build_cfg.skip_hessians:
             raise ValueError("Either skip_index or skip_hessians must be False")
-        
+
         hessian_cfg = (
             None
             if self.build_cfg.skip_hessians

--- a/bergson/approx_unrolling/approx_unrolling_math.py
+++ b/bergson/approx_unrolling/approx_unrolling_math.py
@@ -240,7 +240,6 @@ def score_per_segment_and_aggregate(
         seg_index_cfg.model = final_checkpoint
         seg_index_cfg.run_path = str(scores_dir)
         seg_index_cfg.projection_dim = 0
-        seg_index_cfg.skip_hessians = True
         score_cfg = ScoreConfig(query_path=str(query_grad_segment_paths[l]))
         score_dataset(seg_index_cfg, score_cfg, PreprocessConfig())
         score_dirs.append(scores_dir)

--- a/bergson/approx_unrolling/pipeline.py
+++ b/bergson/approx_unrolling/pipeline.py
@@ -182,7 +182,6 @@ def approx_unrolling_pipeline(
         query_cfg.data = approx_unrolling_cfg.query
         query_cfg.run_path = str(query_path)
         query_cfg.projection_dim = 0
-        query_cfg.skip_hessians = True
         build(query_cfg, PreprocessConfig(aggregation="mean"))
 
     # ── Step 6: Phase 1 -- walk query backwards to get segment queries

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -81,9 +81,12 @@ def build_worker(
         )
 
     model, target_modules = setup_model_and_peft(index_cfg)
-    processor = create_processor(model, index_cfg, hessian_cfg is None, target_modules)
+    skip_hessians = hessian_cfg is None
+    processor = create_processor(model, index_cfg, target_modules)
 
-    maybe_auto_batch_size(index_cfg, model, ds, processor, target_modules, rank)
+    maybe_auto_batch_size(
+        index_cfg, model, ds, processor, target_modules, rank, skip_hessians
+    )
 
     attention_cfgs = {
         module: index_cfg.attention for module in index_cfg.split_attention_modules
@@ -97,6 +100,7 @@ def build_worker(
         "target_modules": target_modules,
         "attention_cfgs": attention_cfgs,
         "preprocess_cfg": preprocess_cfg,
+        "skip_hessians": skip_hessians,
     }
 
     if isinstance(ds, Dataset):

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from datetime import timedelta
+from dataclasses import dataclass
 
 import torch
 import torch.distributed as dist
@@ -28,6 +29,10 @@ from bergson.utils.worker_utils import (
     setup_model_and_peft,
 )
 
+@dataclass
+class BuildConfig:
+    skip_hessians: bool = True
+
 
 def build_worker(
     rank: int,  # global
@@ -35,6 +40,7 @@ def build_worker(
     world_size: int,
     index_cfg: IndexConfig,
     preprocess_cfg: PreprocessConfig,
+    hessian_cfg: HessianConfig | None,
     ds: Dataset | IterableDataset,
 ):
     """
@@ -74,7 +80,7 @@ def build_worker(
         )
 
     model, target_modules = setup_model_and_peft(index_cfg)
-    processor = create_processor(model, index_cfg, target_modules)
+    processor = create_processor(model, index_cfg, hessian_cfg is None, target_modules)
 
     maybe_auto_batch_size(index_cfg, model, ds, processor, target_modules, rank)
 
@@ -134,6 +140,7 @@ def build_worker(
 def build(
     index_cfg: IndexConfig,
     preprocess_cfg: PreprocessConfig,
+    hessian_cfg: HessianConfig | None = None,
 ):
     """
     Convert a dataset to an on-disk index.
@@ -153,8 +160,8 @@ def build(
     index_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
     index_cfg.save_yaml(index_cfg.partial_run_path / "index_config.yaml")
     preprocess_cfg.save_yaml(index_cfg.partial_run_path / "preprocess_config.yaml")
-    if not index_cfg.skip_hessians:
-        HessianConfig(method="autocorrelation").save_yaml(
+    if hessian_cfg:
+        hessian_cfg.save_yaml(
             index_cfg.partial_run_path / "hessian_config.yaml"
         )
 
@@ -170,7 +177,7 @@ def build(
     launch_distributed_run(
         "build",
         build_worker,
-        [index_cfg, preprocess_cfg, ds],
+        [index_cfg, preprocess_cfg, hessian_cfg, ds],
         dist_cfg,
     )
 

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -1,7 +1,7 @@
 import os
 import shutil
-from datetime import timedelta
 from dataclasses import dataclass
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
@@ -28,6 +28,7 @@ from bergson.utils.worker_utils import (
     setup_data_pipeline,
     setup_model_and_peft,
 )
+
 
 @dataclass
 class BuildConfig:
@@ -161,9 +162,7 @@ def build(
     index_cfg.save_yaml(index_cfg.partial_run_path / "index_config.yaml")
     preprocess_cfg.save_yaml(index_cfg.partial_run_path / "preprocess_config.yaml")
     if hessian_cfg:
-        hessian_cfg.save_yaml(
-            index_cfg.partial_run_path / "hessian_config.yaml"
-        )
+        hessian_cfg.save_yaml(index_cfg.partial_run_path / "hessian_config.yaml")
 
     ds, _ = setup_data_pipeline(index_cfg)
 

--- a/bergson/collection.py
+++ b/bergson/collection.py
@@ -14,6 +14,7 @@ def collect_gradients(
     processor: GradientProcessor,
     cfg: IndexConfig,
     *,
+    skip_hessians: bool = True,
     batches: list[list[int]] | None = None,
     target_modules: set[str] | None = None,
     attention_cfgs: dict[str, AttentionConfig] | None = None,
@@ -27,6 +28,7 @@ def collect_gradients(
         model=model.base_model,  # type: ignore
         cfg=cfg,
         processor=processor,
+        skip_hessians=skip_hessians,
         target_modules=target_modules,
         data=data,
         scorer=scorer,

--- a/bergson/collector/dist_autocorrelation_gradient_collector.py
+++ b/bergson/collector/dist_autocorrelation_gradient_collector.py
@@ -33,6 +33,9 @@ class GradientCollectorWithDistributedAutocorrelationMatrices(HookCollectorBase)
     cfg: IndexConfig
     """Configuration for gradient index."""
 
+    skip_hessians: bool = False
+    """This collector always estimates autocorrelation hessians."""
+
     mod_grads: dict = field(default_factory=dict)
     """Temporary storage for gradients during a batch, keyed by module name."""
 
@@ -40,7 +43,7 @@ class GradientCollectorWithDistributedAutocorrelationMatrices(HookCollectorBase)
         """
         Initialize collector state.
         """
-        assert not self.cfg.skip_hessians
+        assert not self.skip_hessians
 
         assert isinstance(
             self.model.device, torch.device

--- a/bergson/collector/gradient_collectors.py
+++ b/bergson/collector/gradient_collectors.py
@@ -33,6 +33,8 @@ class GradientCollector(HookCollectorBase):
     cfg: IndexConfig
     """Configuration for gradient index."""
 
+    skip_hessians: bool
+
     mod_grads: dict = field(default_factory=dict)
     """Temporary storage for gradients during a batch, keyed by module name."""
 
@@ -98,7 +100,7 @@ class GradientCollector(HookCollectorBase):
         global_proj = self.processor.projection_target == "global"
 
         # Collect per-module hessians when projection target is per_module
-        if not self.cfg.skip_hessians and not global_proj:
+        if not self.skip_hessians and not global_proj:
             P = P.float()
             if name in self.processor.hessians:
                 self.processor.hessians[name].addmm_(P.mT, P)

--- a/bergson/collector/gradient_collectors.py
+++ b/bergson/collector/gradient_collectors.py
@@ -33,7 +33,8 @@ class GradientCollector(HookCollectorBase):
     cfg: IndexConfig
     """Configuration for gradient index."""
 
-    skip_hessians: bool
+    skip_hessians: bool = True
+    """Whether to skip estimating autocorrelation hessian statistics."""
 
     mod_grads: dict = field(default_factory=dict)
     """Temporary storage for gradients during a batch, keyed by module name."""

--- a/bergson/collector/in_memory_collector.py
+++ b/bergson/collector/in_memory_collector.py
@@ -40,6 +40,8 @@ class InMemoryCollector(HookCollectorBase):
     cfg: IndexConfig
     """Configuration for gradient collection."""
 
+    skip_hessians: bool
+
     mod_grads: dict = dc_field(default_factory=dict)
     """Temporary per-batch gradients keyed by module name."""
 
@@ -138,7 +140,7 @@ class InMemoryCollector(HookCollectorBase):
         name: str = module._name  # type: ignore[assignment]
         P = self._compute_gradient(module, g)
 
-        if not self.cfg.skip_hessians:
+        if not self.skip_hessians:
             P = P.float()
             if name in self.processor.hessians:
                 self.processor.hessians[name].addmm_(P.mT, P)

--- a/bergson/collector/in_memory_collector.py
+++ b/bergson/collector/in_memory_collector.py
@@ -40,7 +40,8 @@ class InMemoryCollector(HookCollectorBase):
     cfg: IndexConfig
     """Configuration for gradient collection."""
 
-    skip_hessians: bool
+    skip_hessians: bool = True
+    """Whether to skip estimating autocorrelation hessian statistics."""
 
     mod_grads: dict = dc_field(default_factory=dict)
     """Temporary per-batch gradients keyed by module name."""

--- a/bergson/config.py
+++ b/bergson/config.py
@@ -394,17 +394,11 @@ class IndexConfig(AttributionConfig, Serializable):
     """Whether to automatically determine the optimal token batch size.
     Experimental feature only enabled for `build`."""
 
-    processor_path: str = ""
-    """Path to a precomputed processor."""
-
     optimizer_state: str = ""
     """Source for optimizer second moments used to normalize gradients.
     Either a local path (a checkpoint directory containing ``optimizer.pt``,
     or a path to an optimizer state file directly) or a Hugging Face URI
     ``hf://<repo>[@<revision>][/<path>]``."""
-
-    skip_hessians: bool = False
-    """Whether to skip estimating hessian statistics"""
 
     skip_index: bool = False
     """Whether to skip building the gradient index."""

--- a/bergson/gradients.py
+++ b/bergson/gradients.py
@@ -127,7 +127,7 @@ class GradientProcessor:
 
     def __post_init__(self):
         self._projection_matrices: dict[
-            tuple[str, Literal["left", "right"], torch.device], Tensor
+            tuple[str, Literal["left", "right", "single"], torch.device], Tensor
         ] = {}
 
     @classmethod

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -77,11 +77,10 @@ def hessian_pipeline(
             query_cfg.run_path = query_path
             query_cfg.data = hessian_pipeline_cfg.query
             query_cfg.projection_dim = 0
-            query_cfg.skip_hessians = True
             _validate(query_cfg)
 
             query_preprocess_cfg = PreprocessConfig(aggregation="mean")
-            build(query_cfg, query_preprocess_cfg)
+            build(query_cfg, query_preprocess_cfg, None)
 
     # ── Step 2: Fit Hessian factors on training data ──────────────────────
     print(f"Step 2/4: Fitting {method} factors on training data...")
@@ -117,7 +116,6 @@ def hessian_pipeline(
         score_index_cfg = deepcopy(index_cfg)
         score_index_cfg.run_path = scores_path
         score_index_cfg.projection_dim = 0
-        score_index_cfg.skip_hessians = True
         score_cfg.query_path = transformed_query_path
         score_cfg.higher_is_better = True
         _validate(score_index_cfg)

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -269,7 +269,7 @@ def score_worker(
         )
 
     model, target_modules = setup_model_and_peft(index_cfg)
-    processor = create_processor(model, index_cfg, target_modules)
+    processor = create_processor(model, index_cfg, True, target_modules)
 
     attention_cfgs = {
         module: index_cfg.attention for module in index_cfg.split_attention_modules

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -269,7 +269,7 @@ def score_worker(
         )
 
     model, target_modules = setup_model_and_peft(index_cfg)
-    processor = create_processor(model, index_cfg, True, target_modules)
+    processor = create_processor(model, index_cfg, target_modules)
 
     attention_cfgs = {
         module: index_cfg.attention for module in index_cfg.split_attention_modules
@@ -282,6 +282,7 @@ def score_worker(
         "cfg": index_cfg,
         "target_modules": target_modules,
         "attention_cfgs": attention_cfgs,
+        "skip_hessians": True,
     }
 
     score_dtype = (

--- a/bergson/trackstar.py
+++ b/bergson/trackstar.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from .build import build
 from .config import (
+    HessianConfig,
     IndexConfig,
     PreprocessConfig,
     TrackstarConfig,
@@ -48,6 +49,7 @@ def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
 
     # Steps 1-2 only compute hessians, so don't preprocess grads.
     hess_preprocess_cfg = PreprocessConfig()
+    hess_cfg = HessianConfig(method="autocorrelation")
 
     def _validate(cfg: IndexConfig):
         """Validate run path, skipping when resume would preserve partial output."""
@@ -61,11 +63,10 @@ def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
         value_hess_cfg = deepcopy(index_cfg)
         value_hess_cfg.run_path = value_hess_path
         value_hess_cfg.skip_index = True
-        value_hess_cfg.skip_hessians = False
         if trackstar_cfg.num_stats_sample_hessian:
             _limit_split_for_hess(value_hess_cfg)
         _validate(value_hess_cfg)
-        build(value_hess_cfg, hess_preprocess_cfg)
+        build(value_hess_cfg, hess_preprocess_cfg, hess_cfg)
 
     # Step 2: Compute hessians on query dataset
     print("Step 2/5: Computing hessians on query dataset...")
@@ -74,11 +75,10 @@ def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
         query_hess_cfg.run_path = query_hess_path
         query_hess_cfg.data = deepcopy(trackstar_cfg.query)
         query_hess_cfg.skip_index = True
-        query_hess_cfg.skip_hessians = False
         if trackstar_cfg.num_stats_sample_hessian:
             _limit_split_for_hess(query_hess_cfg)
         _validate(query_hess_cfg)
-        build(query_hess_cfg, hess_preprocess_cfg)
+        build(query_hess_cfg, hess_preprocess_cfg, hess_cfg)
 
     # Step 3: Mix query and value hessians
     print("Step 3/5: Mixing hessians...")
@@ -90,28 +90,25 @@ def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
             target_downweight_components=trackstar_cfg.target_downweight_components,
         )
 
-    # Step 4: Build query gradient index using query-specific normalizer.
-    # The mixed hessian is set here but only applied during build if the
+    # The mixed hessian is set here but only applied during step 4. if the
     # user is aggregating the query dataset (preprocess_cfg.aggregation != "none").
     # Otherwise, preconditioning will be deferred to score time in step 5.
-    print("Step 4/5: Building query gradient index...")
     trackstar_cfg.preprocess_cfg.hessian_path = mixed_hess_path
+
+    # Step 4: Build query gradient index using query-specific normalizer.
+    print("Step 4/5: Building query gradient index...")
     if not _step_complete(query_path, resume):
         query_cfg = deepcopy(index_cfg)
         query_cfg.run_path = query_path
         query_cfg.data = deepcopy(trackstar_cfg.query)
-        query_cfg.processor_path = query_hess_path
-        query_cfg.skip_hessians = True
         _validate(query_cfg)
-        build(query_cfg, trackstar_cfg.preprocess_cfg)
+        build(query_cfg, trackstar_cfg.preprocess_cfg, None)
 
     # Step 5: Score value dataset against query using mixed hessian
     print("Step 5/5: Scoring value dataset...")
     if not _step_complete(scores_path, resume):
         score_index_cfg = deepcopy(index_cfg)
         score_index_cfg.run_path = scores_path
-        score_index_cfg.processor_path = value_hess_path
-        score_index_cfg.skip_hessians = True
         trackstar_cfg.score_cfg.query_path = query_path
         trackstar_cfg.score_cfg.higher_is_better = True
         _validate(score_index_cfg)

--- a/bergson/utils/batch_size.py
+++ b/bergson/utils/batch_size.py
@@ -74,6 +74,7 @@ def maybe_auto_batch_size(
     processor: GradientProcessor,
     target_modules: set[str] | None,
     rank: int = 0,
+    skip_hessians: bool = True,
 ) -> None:
     """Run auto batch size determination if enabled.
 
@@ -109,6 +110,7 @@ def maybe_auto_batch_size(
                 model=model.base_model,
                 cfg=probe_cfg,
                 processor=processor,
+                skip_hessians=skip_hessians,
                 target_modules=target_modules,
                 data=ds,  # type: ignore
             ),

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -68,6 +68,7 @@ def create_processor(
     normalizers: dict[str, Normalizer] = {}
     if cfg.optimizer_state:
         from bergson.utils.load_from_optimizer import load_from_optimizer
+
         normalizers = load_from_optimizer(
             model,
             cfg.optimizer_state,

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -63,41 +63,28 @@ def create_processor(
     target_modules: set[str] | None = None,
 ) -> GradientProcessor:
     """Handle processor creation and normalizer loading."""
-    local_rank = cfg.distributed.local_rank
     rank = cfg.distributed.rank
 
-    processor_path = Path(cfg.processor_path)
-    if (processor_path / "processor_config.yaml").exists():
-        if local_rank == 0:
-            print(f"Loading processor from '{cfg.processor_path}'")
-
-        processor = GradientProcessor.load(
-            processor_path,
-            map_location=get_device(local_rank),
-            skip_hessians=cfg.skip_hessians,
-        )
-    else:
-        normalizers: dict[str, Normalizer] = {}
-        if cfg.optimizer_state:
-            from bergson.utils.load_from_optimizer import load_from_optimizer
-
-            normalizers = load_from_optimizer(
-                model,
-                cfg.optimizer_state,
-                include_bias=cfg.include_bias,
-                target_modules=target_modules,
-            )
-
-        processor = GradientProcessor(
-            normalizers,
-            projection_dim=cfg.projection_dim or None,
-            reshape_to_square=cfg.reshape_to_square,
-            projection_type=cfg.projection_type,
-            projection_target=cfg.projection_target,
+    normalizers: dict[str, Normalizer] = {}
+    if cfg.optimizer_state:
+        from bergson.utils.load_from_optimizer import load_from_optimizer
+        normalizers = load_from_optimizer(
+            model,
+            cfg.optimizer_state,
             include_bias=cfg.include_bias,
+            target_modules=target_modules,
         )
-        if rank == 0:
-            processor.save(cfg.partial_run_path)
+
+    processor = GradientProcessor(
+        normalizers,
+        projection_dim=cfg.projection_dim or None,
+        reshape_to_square=cfg.reshape_to_square,
+        projection_type=cfg.projection_type,
+        projection_target=cfg.projection_target,
+        include_bias=cfg.include_bias,
+    )
+    if rank == 0:
+        processor.save(cfg.partial_run_path)
 
     return processor
 

--- a/tests/test_attribute_tokens.py
+++ b/tests/test_attribute_tokens.py
@@ -242,9 +242,7 @@ def test_token_build_e2e(tmp_path: Path, model, dataset):
     """Build a token-attribution index and verify output shapes."""
     model = model.float()
     cfg = IndexConfig(
-        run_path=str(tmp_path),
-        skip_hessians=True,
-        token_batch_size=1024,
+        run_path=str(tmp_path),        token_batch_size=1024,
         attribute_tokens=True,
     )
     processor = GradientProcessor(projection_dim=16)
@@ -297,9 +295,7 @@ def test_token_build_with_labels(tmp_path: Path, model):
     )
 
     cfg = IndexConfig(
-        run_path=str(tmp_path),
-        skip_hessians=True,
-        token_batch_size=1024,
+        run_path=str(tmp_path),        token_batch_size=1024,
         attribute_tokens=True,
     )
     processor = GradientProcessor(projection_dim=16)
@@ -360,9 +356,7 @@ def test_token_score_e2e(tmp_path: Path, model, dataset):
     )
 
     cfg = IndexConfig(
-        run_path=str(tmp_path / "run"),
-        skip_hessians=True,
-        token_batch_size=1024,
+        run_path=str(tmp_path / "run"),        token_batch_size=1024,
         attribute_tokens=True,
         skip_index=True,
     )
@@ -407,9 +401,7 @@ def test_token_build_adam_e2e(tmp_path: Path, model, dataset):
     dataset = dataset.repeat(10)
 
     cfg = IndexConfig(
-        run_path=str(tmp_path),
-        skip_hessians=True,
-        token_batch_size=1024,
+        run_path=str(tmp_path),        token_batch_size=1024,
         attribute_tokens=True,
     )
 
@@ -473,9 +465,7 @@ def _collect_in_memory(
 ):
     """Run InMemoryCollector and return the collector for inspection."""
     cfg = IndexConfig(
-        run_path=run_path,
-        skip_hessians=True,
-        token_batch_size=1024,
+        run_path=run_path,        token_batch_size=1024,
         attribute_tokens=attribute_tokens,
         loss_reduction="sum",
         skip_index=True,

--- a/tests/test_attribute_tokens.py
+++ b/tests/test_attribute_tokens.py
@@ -242,7 +242,8 @@ def test_token_build_e2e(tmp_path: Path, model, dataset):
     """Build a token-attribution index and verify output shapes."""
     model = model.float()
     cfg = IndexConfig(
-        run_path=str(tmp_path),        token_batch_size=1024,
+        run_path=str(tmp_path),
+        token_batch_size=1024,
         attribute_tokens=True,
     )
     processor = GradientProcessor(projection_dim=16)
@@ -295,7 +296,8 @@ def test_token_build_with_labels(tmp_path: Path, model):
     )
 
     cfg = IndexConfig(
-        run_path=str(tmp_path),        token_batch_size=1024,
+        run_path=str(tmp_path),
+        token_batch_size=1024,
         attribute_tokens=True,
     )
     processor = GradientProcessor(projection_dim=16)
@@ -356,7 +358,8 @@ def test_token_score_e2e(tmp_path: Path, model, dataset):
     )
 
     cfg = IndexConfig(
-        run_path=str(tmp_path / "run"),        token_batch_size=1024,
+        run_path=str(tmp_path / "run"),
+        token_batch_size=1024,
         attribute_tokens=True,
         skip_index=True,
     )
@@ -401,7 +404,8 @@ def test_token_build_adam_e2e(tmp_path: Path, model, dataset):
     dataset = dataset.repeat(10)
 
     cfg = IndexConfig(
-        run_path=str(tmp_path),        token_batch_size=1024,
+        run_path=str(tmp_path),
+        token_batch_size=1024,
         attribute_tokens=True,
     )
 
@@ -465,7 +469,8 @@ def _collect_in_memory(
 ):
     """Run InMemoryCollector and return the collector for inspection."""
     cfg = IndexConfig(
-        run_path=run_path,        token_batch_size=1024,
+        run_path=run_path,
+        token_batch_size=1024,
         attribute_tokens=attribute_tokens,
         loss_reduction="sum",
         skip_index=True,

--- a/tests/test_attributor.py
+++ b/tests/test_attributor.py
@@ -26,7 +26,6 @@ requires_faiss_gpu = pytest.mark.skipif(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_attributor(tmp_path: Path, model, dataset):
     cfg = IndexConfig(run_path=str(tmp_path), token_batch_size=1024)
-    cfg.skip_hessians = True
 
     collect_gradients(
         model=model,
@@ -138,7 +137,6 @@ def test_attributor_precondition_one_sided(tmp_path: Path, model, dataset):
 def test_attributor_reverse(tmp_path: Path, model, dataset):
     """Test that reverse mode returns lowest influence examples."""
     cfg = IndexConfig(run_path=str(tmp_path), token_batch_size=1024)
-    cfg.skip_hessians = True
 
     collect_gradients(
         model=model,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -33,6 +33,8 @@ def test_build_e2e(tmp_path: Path):
             "1024",
             "--precision",
             "bf16",
+            "--skip_hessians",
+            "False",
         ],
         cwd=tmp_path,
         capture_output=True,  # Add this
@@ -56,7 +58,6 @@ def test_build_consistency(tmp_path: Path, model, dataset):
 
     cfg = IndexConfig(
         run_path=str(tmp_path),
-        skip_hessians=True,
         token_batch_size=1024,
         loss_reduction="mean",
     )
@@ -128,9 +129,6 @@ def test_conv1d_build(tmp_path: Path, dataset):
 
     cfg = IndexConfig(
         run_path=str(tmp_path),
-        # This build hangs in pytest with hessians enabled.
-        # It works when run directly so it may be a pytest issue.
-        skip_hessians=True,
         # GPT-2 model_max_length is 1024
         token_batch_size=1024,
     )

--- a/tests/test_force_math_sdp.py
+++ b/tests/test_force_math_sdp.py
@@ -69,7 +69,6 @@ def test_force_math_sdp_persists_through_collect(
 
     cfg = IndexConfig(
         run_path=str(tmp_path / "run"),
-        skip_hessians=True,
         token_batch_size=1024,
         force_math_sdp=True,
         projection_dim=0,
@@ -100,7 +99,6 @@ def test_force_math_sdp_persists_through_collect(
     # Now collect with only the short doc
     cfg_alone = IndexConfig(
         run_path=str(tmp_path / "run_alone"),
-        skip_hessians=True,
         token_batch_size=1024,
         force_math_sdp=True,
         projection_dim=0,

--- a/tests/test_global_projection.py
+++ b/tests/test_global_projection.py
@@ -134,7 +134,6 @@ def test_global_projector_e2e(tmp_path: Path, model, dataset):
     proj_dim = 512
     cfg = IndexConfig(
         run_path=str(tmp_path),
-        skip_hessians=True,
         token_batch_size=64,
         projection_dim=proj_dim,
         projection_target="global",
@@ -186,7 +185,7 @@ def test_global_project_values_cpu(tmp_path: Path, model, dataset):
     """
     proj_dim = 16
     tokens = torch.tensor([dataset[0]["input_ids"]])
-    cfg = IndexConfig(run_path=str(tmp_path), skip_index=True, skip_hessians=True)
+    cfg = IndexConfig(run_path=str(tmp_path), skip_index=True)
 
     # First pass: capture raw per-module gradients (no projection)
     raw_collector = GradientCollector(
@@ -251,7 +250,6 @@ def test_global_projector_e2e_cpu(tmp_path: Path, model, dataset):
     capturer = _Capturer()
     cfg = IndexConfig(
         run_path=str(tmp_path),
-        skip_hessians=True,
         token_batch_size=64,
         projection_dim=proj_dim,
         projection_target="global",

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -165,7 +165,6 @@ def test_gradient_collector_proj_norm():
         cfg = IndexConfig(
             run_path=str(temp_dir / "run"),
             skip_index=True,
-            skip_hessians=p is None,
         )
         processor = GradientProcessor(projection_dim=p)
         collector = GradientCollector(
@@ -173,6 +172,7 @@ def test_gradient_collector_proj_norm():
             cfg=cfg,
             data=data,
             processor=processor,
+            skip_hessians=p is None,
         )
         with collector:
             model.zero_grad()

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -63,7 +63,8 @@ def test_programmatic_reduce(tmp_path: Path):
     index_cfg = IndexConfig(
         run_path=str(tmp_path / "reduction"),
         data=DataConfig(truncation=True, split="train[:100]"),
-        model="EleutherAI/pythia-14m",        token_batch_size=1024,
+        model="EleutherAI/pythia-14m",
+        token_batch_size=1024,
     )
 
     build(index_cfg, PreprocessConfig(aggregation="mean"))
@@ -113,7 +114,8 @@ def test_reduce_with_preconditioning(tmp_path: Path, model, dataset):
 def test_in_memory_reduce(tmp_path: Path, model, dataset):
     model.cuda()
     cfg = IndexConfig(
-        run_path=str(tmp_path / "reduction"),        token_batch_size=1024,
+        run_path=str(tmp_path / "reduction"),
+        token_batch_size=1024,
     )
     cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -36,7 +36,6 @@ def test_reduce_cli(tmp_path: Path):
             "--aggregation",
             "mean",
             "--unit_normalize",
-            "--skip_hessians",
             "--token_batch_size",
             "1024",
         ],
@@ -64,9 +63,7 @@ def test_programmatic_reduce(tmp_path: Path):
     index_cfg = IndexConfig(
         run_path=str(tmp_path / "reduction"),
         data=DataConfig(truncation=True, split="train[:100]"),
-        model="EleutherAI/pythia-14m",
-        skip_hessians=True,
-        token_batch_size=1024,
+        model="EleutherAI/pythia-14m",        token_batch_size=1024,
     )
 
     build(index_cfg, PreprocessConfig(aggregation="mean"))
@@ -86,6 +83,7 @@ def test_reduce_with_preconditioning(tmp_path: Path, model, dataset):
         data=dataset,
         processor=GradientProcessor(),
         cfg=build_cfg,
+        skip_hessians=False,
     )
 
     # Step 2: reduce with preconditioning pointing at the built index
@@ -95,7 +93,6 @@ def test_reduce_with_preconditioning(tmp_path: Path, model, dataset):
     reduce_index_cfg = IndexConfig(
         run_path=str(tmp_path / "reduce_hess"),
         token_batch_size=1024,
-        skip_hessians=True,
     )
 
     collect_gradients(
@@ -116,9 +113,7 @@ def test_reduce_with_preconditioning(tmp_path: Path, model, dataset):
 def test_in_memory_reduce(tmp_path: Path, model, dataset):
     model.cuda()
     cfg = IndexConfig(
-        run_path=str(tmp_path / "reduction"),
-        skip_hessians=True,
-        token_batch_size=1024,
+        run_path=str(tmp_path / "reduction"),        token_batch_size=1024,
     )
     cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -71,7 +71,6 @@ def test_large_gradients_query(tmp_path: Path, dataset):
             "--truncation",
             "--token_batch_size",
             "256",
-            "--skip_hessians",
         ],
         cwd=tmp_path,
         capture_output=True,
@@ -167,6 +166,7 @@ def test_precondition_ds(tmp_path: Path, model, dataset):
         data=dataset,
         cfg=build_cfg,
         processor=processor,
+        skip_hessians=False,
     )
 
     computer = CollectorComputer(

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -42,7 +42,6 @@ def run_pipeline(tmp_path, model_name, token_batch_size, doc_tokens, truncation)
         run_path=str(tmp_path / "run"),
         model=model_name,
         token_batch_size=token_batch_size,
-        skip_hessians=True,
         data=DataConfig(dataset=documents_file, truncation=truncation),
     )
     ds, _ = setup_data_pipeline(cfg)


### PR DESCRIPTION
This PR is to simplify the library before release.


Problem 1: We have been using a flag in `IndexConfig` to enable autocorrelation Hessian estimation simultaneously with an index build. We also now have a standalone tool, `bergson hessian`, to enable estimation of many types of Hessians.  We have also begun to use the `IndexConfig` for all config related to gradient collection, including in contexts where Hessians are always estimated (`bergson hessian`) or never estimated (`bergson reduce`). This is convoluted and confusing.

Solution 1: Move this flag into a new `BuildConfig` CLI config class, unavailable to other CLI tools. Set it manually in contexts where the value is constant, e.g. Hessians are always enabled in `bergson hessian` code. This will prevent users from seeing config options that don't make sense.

Problem 2: `processor_path` is confusing and not useful. The original idea was that Hessians and normalizers could be pre-computed and then loaded in and applied at build time, but when the processor path is present it's actually used to compute _new_ Hessians, which is very confusing. We also don't like that this class couples loading normalizers and loading Hessian approximations. We have partially fixed this by adding a standalone `hessian_path` field in PreprocessConfig to apply a precomputed Hessian, and a standalone `optimizer_state` field in IndexConfig to apply a precomputed Adam state buffer. 

Solution 2: Finish the job by removing the processor_path field.

Solution 2 (follow-up PR): Migrate the `optimizer_state` field in IndexConfig to the PreprocessConfig.