### PR TITLE
Add global-norm gradient clipping (max_grad_norm) to MAGIC trainer

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -346,6 +346,10 @@ class TrainingConfig(AttributionConfig, Serializable):
     weight_decay: float = 0.01
     """Weight decay coefficient for AdamW and Muon."""
 
+    max_grad_norm: float | None = None
+    """Clip gradients to this global norm before each optimizer step, matching
+    HuggingFace Trainer's ``max_grad_norm``. ``None`` or ``0`` disables clipping."""
+
     grad_checkpointing: bool = False
     """Whether to use gradient checkpointing during the forward pass."""
 

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -218,6 +218,7 @@ def worker(
         log_fn=log_fn,
         resume=resume,
         fsdp=run_cfg.fsdp,
+        max_grad_norm=run_cfg.max_grad_norm,
     )
     if getattr(run_cfg, "save_optimizer_state", False) and global_rank == 0:
         save_second_moments_as_optimizer_pt(
@@ -306,6 +307,7 @@ def worker(
             resume=run_cfg.resume,
             save_every=run_cfg.backward_save_every,
             save_mode=run_cfg.save_mode,
+            max_grad_norm=run_cfg.max_grad_norm,
         )
         if world_size > 1:
             dist.all_reduce(bwd_state.weight_grads, op=dist.ReduceOp.SUM)

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -21,7 +21,7 @@ from torch.distributed._functional_collectives import (
 from torch.distributed._functional_collectives import (
     wait_tensor,
 )
-from torch.distributed.tensor import init_device_mesh
+from torch.distributed.tensor import DTensor, Replicate, init_device_mesh
 from torchopt.pytree import tree_flatten_with_path, tree_iter, tree_map
 from torchopt.typing import GradientTransformation, OptState
 from tqdm.auto import tqdm
@@ -270,7 +270,11 @@ class Trainer:
         state = TrainerState(params, opt_state, buffers)
         return cls(model, optimizer), state
 
-    def __init__(self, model: nn.Module, optimizer: GradientTransformation):
+    def __init__(
+        self,
+        model: nn.Module,
+        optimizer: GradientTransformation,
+    ):
         # Move only trainable parameters to the meta device, leaving frozen params
         # on device so they don't need to be managed by TrainerState.
         for mod in model.modules():
@@ -291,6 +295,7 @@ class Trainer:
         inplace: bool = False,
         trace: bool = False,
         fsdp: bool = False,
+        max_grad_norm: float | None = None,
     ) -> TrainerState:
         """Perform a single training step on `state`, returning the new state.
 
@@ -308,6 +313,9 @@ class Trainer:
                 training is being used, the trainer will perform its own all-reduce of
                 gradients. If True, the trainer will assume that FSDP is handling
                 gradient synchronization, and will not perform any all-reduces itself.
+            max_grad_norm: Clip gradients to this global norm before the optimizer step,
+                matching HuggingFace Trainer's ``max_grad_norm``. ``None`` or ``0``
+                disables clipping.
         """
         torch.random.set_rng_state(state.cpu_rng_state)
 
@@ -349,6 +357,29 @@ class Trainer:
             else:
                 for g in grads.values():
                     dist.all_reduce(g, op=dist.ReduceOp.AVG)
+
+        # Clip by global norm over all params and ranks/FSDP shards.
+        if max_grad_norm:
+            # cast: sum()'s int start value widens the type to `Tensor | int`.
+            sq_norm = cast(torch.Tensor, sum(g.pow(2).sum() for g in grads.values()))
+            if fsdp:
+                # Sharded grads give a partial sum; redistribute (autograd-aware) to
+                # sum across the mesh. DDP grads are already all-reduced above.
+                assert isinstance(
+                    sq_norm, DTensor
+                ), "fsdp=True but grads aren't DTensors"
+                sq_norm = sq_norm.redistribute(placements=[Replicate()])
+            else:
+                assert not isinstance(
+                    sq_norm, DTensor
+                ), "DTensor grads require fsdp=True"
+            coef = (max_grad_norm / (sq_norm.sqrt() + 1e-6)).clamp(max=1.0)
+            if trace:
+                # Out-of-place to keep the clip in the autograd graph.
+                grads = {k: g * coef for k, g in grads.items()}
+            else:
+                for g in grads.values():
+                    g.mul_(coef)
 
         updates, new_state = self.optimizer.update(
             grads, state.opt_state, inplace=inplace, params=state.params
@@ -401,6 +432,7 @@ class Trainer:
         log_fn: Callable[[int, float], None] | None = None,
         resume: bool = False,
         fsdp: bool = False,
+        max_grad_norm: float | None = None,
     ) -> TrainerState:
         """Train the model on the given data stream, starting from the given state.
 
@@ -422,6 +454,8 @@ class Trainer:
                 loading the most recent checkpoint from `save_dir`.
             fsdp: Flag to pass to `Trainer.step`, indicating whether the model is
                 wrapped with FSDP.
+            max_grad_norm: Clip gradients to this global norm before each optimizer
+                step. Passed through to `Trainer.step`.
 
         Returns:
             The final trainer state after training.
@@ -478,7 +512,14 @@ class Trainer:
                         raise ValueError(f"Unsupported save mode: {other}")
 
             x = data[i]
-            state = self.step(state, x, inplace=inplace, trace=trace, fsdp=fsdp)
+            state = self.step(
+                state,
+                x,
+                inplace=inplace,
+                trace=trace,
+                fsdp=fsdp,
+                max_grad_norm=max_grad_norm,
+            )
 
             if log_fn is not None:
                 log_fn(i, self._last_loss)
@@ -549,6 +590,7 @@ class Trainer:
         resume: bool = False,
         save_every: int = 0,
         save_mode: MagicSaveMode = "sqrt",
+        max_grad_norm: float | None = None,
     ) -> BackwardState:
         """Run a backward pass through the training trajectory saved at `ckpt_dir`.
 
@@ -577,6 +619,10 @@ class Trainer:
             save_mode: The save mode that was used during the forward trajectory, which
                 determines how checkpoints are spaced and thus how the backward pass
                 should step forward through the trajectory when replaying.
+            max_grad_norm: Clip gradients to this global norm before each optimizer
+                step when replaying the forward trajectory. Must match the value used
+                during the forward pass for the replay to be faithful. Passed through
+                to `Trainer.step`.
 
         Returns:
             The final backward state after processing the entire trajectory.
@@ -663,6 +709,7 @@ class Trainer:
                     inplace=inplace,
                     trace=False,
                     fsdp=fsdp,
+                    max_grad_norm=max_grad_norm,
                 )
                 idx += 1
                 sub_pbar.update()
@@ -709,6 +756,7 @@ class Trainer:
                 data[fwd_state.batch_index],
                 trace=True,
                 fsdp=fsdp,
+                max_grad_norm=max_grad_norm,
             )
             main_pbar.update()
 

--- a/tests/test_distributed_magic.py
+++ b/tests/test_distributed_magic.py
@@ -84,5 +84,74 @@ def test_fsdp_ddp_scores_match():
         )
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="Requires at least 2 CUDA devices",
+)
+def test_fsdp_ddp_scores_match_with_grad_clipping():
+    """Gradient clipping is consistent across FSDP shards and DDP replicas.
+
+    The global norm is reduced differently in each mode (FSDP sums partial squared
+    norms across shards; DDP computes it from replicated grads), so matching scores
+    confirm the cross-shard reduction is correct. The unclipped DDP run is the
+    control that the chosen threshold actually clips.
+
+    Scores here are tiny (~1e-6), so the checks are scale-free: clipping must change
+    the scores by an O(1) fraction, while FSDP and DDP must agree to far tighter than
+    that change — a broken cross-shard reduction would move scores by ~their own size.
+    """
+    world_size = min(torch.cuda.device_count(), 4)
+    # tiny-Phi3 grad norms on this data are ~0.35, so 0.2 clips on every step.
+    max_grad_norm = 0.2
+
+    data = DataConfig(
+        dataset="Salesforce/wikitext",
+        subset="wikitext-2-raw-v1",
+        split="train[:512]",
+        chunk_length=32,
+    )
+    dist_cfg = DistributedConfig(nproc_per_node=world_size)
+
+    def cfg(name, *, fsdp, clip):
+        return MagicConfig(
+            run_path=f"{tmpdir}/{name}",
+            model="trl-internal-testing/tiny-Phi3ForCausalLM",
+            fsdp=fsdp,
+            data=data,
+            query=data,
+            batch_size=8,
+            num_epochs=1,
+            overwrite=True,
+            num_subsets=2,
+            max_grad_norm=max_grad_norm if clip else None,
+            distributed=dist_cfg,
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_magic(cfg("ddp_noclip", fsdp=False, clip=False))
+        run_magic(cfg("ddp", fsdp=False, clip=True))
+        run_magic(cfg("fsdp", fsdp=True, clip=True))
+
+        ddp_noclip = torch.load(f"{tmpdir}/ddp_noclip/scores.pt", weights_only=True)
+        ddp_scores = torch.load(f"{tmpdir}/ddp/scores.pt", weights_only=True)
+        fsdp_scores = torch.load(f"{tmpdir}/fsdp/scores.pt", weights_only=True)
+
+    assert fsdp_scores.shape == ddp_scores.shape
+
+    scale = ddp_noclip.abs().max()
+    clip_effect = (ddp_scores - ddp_noclip).abs().max()
+    fsdp_ddp_diff = (fsdp_scores - ddp_scores).abs().max()
+
+    assert clip_effect > 0.1 * scale, (
+        f"clip barely changed the scores ({clip_effect:.2e} vs scale {scale:.2e}); "
+        "lower max_grad_norm so it bites"
+    )
+    assert fsdp_ddp_diff < 0.05 * clip_effect, (
+        f"clipped FSDP and DDP scores differ too much: {fsdp_ddp_diff:.2e} "
+        f"(clip effect {clip_effect:.2e}) — cross-shard norm reduction is likely wrong"
+    )
+
+
 if __name__ == "__main__":
     test_fsdp_ddp_scores_match()
+    test_fsdp_ddp_scores_match_with_grad_clipping()

--- a/tests/test_grad_clipping.py
+++ b/tests/test_grad_clipping.py
@@ -1,0 +1,205 @@
+"""Tests for global-norm gradient clipping (``max_grad_norm``) in the MAGIC trainer.
+
+Clipping must (a) match the standard clip-by-global-norm formula, (b) be a true
+no-op when disabled or when the threshold doesn't bite, and (c) stay inside the
+autograd graph so MAGIC influence scores remain correct — the same failure class
+as the historical non-differentiable all-reduce bug.
+"""
+
+import tempfile
+
+import pytest
+import torch
+import torchopt
+from datasets import Dataset
+from torchopt.pytree import tree_iter
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from bergson.distributed import grad_tree
+from bergson.magic import BackwardState, DataStream, Trainer
+from bergson.utils.math import weighted_causal_lm_ce
+
+MODEL_NAME = "EleutherAI/pythia-14m"
+
+
+@pytest.fixture
+def clip_dataset():
+    # Four single-doc rows. With batch_size=2 each step's gradient is a weighted
+    # sum of two examples, so clipping couples (rather than cancels) the per-doc
+    # weights — necessary for a non-degenerate influence/finite-difference check.
+    rows = [
+        [1, 2, 3, 4, 5],
+        [6, 7, 8, 9, 10],
+        [11, 12, 13, 14, 15],
+        [16, 17, 18, 19, 20],
+    ]
+    return Dataset.from_dict(
+        {"input_ids": rows, "labels": rows, "attention_mask": [[1] * 5] * 4}
+    )
+
+
+def _build_model():
+    torch.manual_seed(42)
+    config = AutoConfig.from_pretrained(MODEL_NAME)
+    model = AutoModelForCausalLM.from_config(
+        config, dtype=torch.float32, attn_implementation="eager"
+    )
+    model.loss_function = weighted_causal_lm_ce
+    model.requires_grad_(True)
+    return model
+
+
+def test_clip_scales_update_by_coef(clip_dataset):
+    """A biting ``max_grad_norm`` scales an SGD update by exactly the clip coef.
+
+    With plain SGD the update is ``-lr * grad``, so clipping by ``coef`` must scale
+    the whole update by ``coef`` (the optimizer is linear in the gradient here).
+    """
+    lr = 0.05
+
+    def run(max_grad_norm):
+        model = _build_model()
+        trainer, state = Trainer.initialize(model, torchopt.sgd(lr))
+        stream = DataStream(clip_dataset, batch_size=len(clip_dataset), device="cpu")
+        new = trainer.step(
+            state, stream[0], inplace=False, trace=False, max_grad_norm=max_grad_norm
+        )
+        return {k: (new.params[k] - state.params[k]).detach() for k in state.params}
+
+    full = run(None)
+    # ||grad|| recovered from the unclipped update: delta = -lr * grad.
+    sq = torch.stack([(d / lr).pow(2).sum() for d in full.values()]).sum()
+    global_norm = sq.sqrt()
+    max_grad_norm = float(global_norm) * 0.2  # well below the norm, so it bites
+    coef = min(1.0, max_grad_norm / (float(global_norm) + 1e-6))
+    assert coef < 1.0, "test misconfigured: clip does not bite"
+
+    clipped = run(max_grad_norm)
+    for k in full:
+        torch.testing.assert_close(clipped[k], coef * full[k], atol=1e-6, rtol=1e-5)
+
+
+def test_no_clip_is_bit_identical(clip_dataset):
+    """``None`` and a non-biting threshold reproduce the unclipped trajectory."""
+
+    def run(max_grad_norm):
+        model = _build_model()
+        opt = torchopt.adamw(1e-3, betas=(0.95, 0.975), eps_root=1e-2)
+        trainer, state = Trainer.initialize(model, opt)
+        stream = DataStream(clip_dataset, batch_size=2, device="cpu")
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            return trainer.train(
+                state,
+                stream,
+                inplace=True,
+                save_dir=ckpt_dir,
+                max_grad_norm=max_grad_norm,
+            )
+
+    baseline = run(None)
+    huge = run(1e30)  # far above any real grad norm, so coef == 1 every step
+    for k in baseline.params:
+        assert torch.equal(baseline.params[k], huge.params[k])
+
+
+def _query_batch(dataset):
+    qs = DataStream(dataset, batch_size=len(dataset), device="cpu")
+    batch = qs[0]
+    del batch["example_weight"]
+    return batch
+
+
+def _magic_scores(dataset, max_grad_norm, weights=None):
+    """Train + MAGIC backward, returning per-doc influence scores for the query batch.
+
+    Mirrors the train→query-grad→backward flow exercised by ``test_magic``.
+    """
+    query = _query_batch(dataset)
+    model = _build_model()
+    opt = torchopt.sgd(0.05)
+    trainer, fwd_state = Trainer.initialize(model, opt)
+    stream = DataStream(dataset, batch_size=2, device="cpu")
+    if weights is not None:
+        stream.weights.data.copy_(weights)
+
+    with tempfile.TemporaryDirectory() as ckpt_dir:
+        fwd_state = trainer.train(
+            fwd_state,
+            stream,
+            inplace=True,
+            save_dir=ckpt_dir,
+            max_grad_norm=max_grad_norm,
+        )
+        with fwd_state.activate(model) as params:
+            loss = model(**query).loss
+            query_grads = {
+                k: g.detach().clone() for k, g in grad_tree(loss, params).items()
+            }
+            opt_grads = [
+                torch.zeros_like(buf)
+                for buf in tree_iter(fwd_state.opt_state)
+                if isinstance(buf, torch.Tensor) and buf.is_floating_point()
+            ]
+            bwd_state = BackwardState(
+                query_grads, opt_grads, torch.zeros_like(stream.weights)
+            )
+        stream.requires_grad = True
+        bwd_state = trainer.backward(
+            ckpt_dir,
+            stream,
+            bwd_state,
+            fwd_state,
+            inplace=True,
+            cleanup=True,
+            max_grad_norm=max_grad_norm,
+        )
+    return bwd_state.weight_grads.detach().cpu()
+
+
+def _final_query_loss(dataset, max_grad_norm, weights):
+    query = _query_batch(dataset)
+    model = _build_model()
+    opt = torchopt.sgd(0.05)
+    trainer, state = Trainer.initialize(model, opt)
+    stream = DataStream(dataset, batch_size=2, device="cpu")
+    stream.weights.data.copy_(weights)
+    with tempfile.TemporaryDirectory() as ckpt_dir:
+        state = trainer.train(
+            state, stream, inplace=True, save_dir=ckpt_dir, max_grad_norm=max_grad_norm
+        )
+        with state.activate(model), torch.no_grad():
+            return model(**query).loss.item()
+
+
+def test_clipped_scores_finite_and_change_trajectory(clip_dataset):
+    """A biting clip yields finite, nonzero scores differing from the unclipped run."""
+    unclipped = _magic_scores(clip_dataset, None)
+    clipped = _magic_scores(clip_dataset, 2.0)
+
+    assert torch.isfinite(clipped).all()
+    assert clipped.abs().sum() > 0, "clipped scores are all zero"
+    assert not torch.allclose(clipped, unclipped), "clip had no effect"
+
+
+def test_clip_is_differentiable_finite_difference(clip_dataset):
+    """MAGIC influence through the clip matches a finite-difference estimate.
+
+    This is the core correctness check: if the clip left the autograd graph (e.g. an
+    in-place update under ``trace=True``), the scores would silently disagree with the
+    finite-difference gradient of the query loss w.r.t. the per-doc weights.
+    """
+    max_grad_norm = 2.0  # bites on every step for this model/data/lr
+    scores = _magic_scores(clip_dataset, max_grad_norm)
+
+    w0 = torch.ones(len(clip_dataset))
+    eps = 1e-2
+    for i in range(len(clip_dataset)):
+        wp = w0.clone()
+        wp[i] += eps
+        wm = w0.clone()
+        wm[i] -= eps
+        fd = (
+            _final_query_loss(clip_dataset, max_grad_norm, wp)
+            - _final_query_loss(clip_dataset, max_grad_norm, wm)
+        ) / (2 * eps)
+        torch.testing.assert_close(scores[i], torch.tensor(fd), atol=1e-4, rtol=0.05)


### PR DESCRIPTION
## Add global-norm gradient clipping (`max_grad_norm`) to the MAGIC trainer

**Written by Claude.**

### What

Adds an optional `max_grad_norm: float | None = None` to `TrainingConfig`. When
set, gradients are clipped to that global norm before each optimizer step, matching
HuggingFace `Trainer`'s `max_grad_norm`. `None`/`0` disables clipping and preserves
the current behavior exactly.

This lets a MAGIC replay faithfully match training runs that clip — previously the
MAGIC trainer had no clipping and no way to enable it.

### How

One config field, one clip step in `Trainer.step()` (applied between the cross-rank
gradient reduce and `self.optimizer.update`), and the value threaded from config
into the trainer constructor.

```python
sq_norm = sum(g.pow(2).sum() for g in grads.values())
# ... reduce across FSDP shards if needed ...
coef = (self.max_grad_norm / (sq_norm.sqrt() + 1e-6)).clamp(max=1.0)
grads = {k: g * coef for k, g in grads.items()}   # out-of-place under trace
```

### MAGIC-specific subtleties

MAGIC differentiates the training trajectory w.r.t. implicit per-token data weights,
so the clip must stay inside the autograd graph or influence scores silently become
approximate (the same failure class as the historical non-differentiable all-reduce
bug). Two points:

- **Out-of-place under `trace=True`.** The clip uses `g * coef`, not `g.mul_(coef)`,
  because an in-place update breaks the graph MAGIC backprops through. The non-traced
  forward replay still clips in-place to save memory.
- **Global norm across all params *and* all ranks/FSDP shards.** Under FSDP the grads
  are sharded `DTensor`s, so the squared norm is a partial sum over each rank's shard;
  it's redistributed to `Replicate` (an autograd-aware all-reduce) rather than a plain
  `dist.all_reduce`, which raises on `DTensor`s. In the DDP path the grads are already
  replicated by the all-reduce above, so the local sum is already global.

### Tests

- `tests/test_grad_clipping.py`
  - a biting `max_grad_norm` scales an SGD update by exactly the clip coef;
  - `None` and a non-biting threshold reproduce the unclipped trajectory bit-for-bit;
  - clipped MAGIC scores are finite, nonzero, and change the trajectory;
  - **MAGIC influence through the clip matches a finite-difference gradient** of the
    query loss w.r.t. the per-doc weights — the check that fails if the clip ever
    leaves the autograd graph.
- `tests/test_distributed_magic.py::test_fsdp_ddp_scores_match_with_grad_clipping`
  (2 GPUs): FSDP and DDP produce matching clipped scores, exercising the cross-shard
  norm reduction. The unclipped run is the control that the threshold actually bites;
  checks are scale-free since scores are ~1e-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
