### PR TITLE
Fix approx-unrolling checkpoint-step parsing

### DIFF
--- a/bergson/approx_unrolling/approx_unrolling_math.py
+++ b/bergson/approx_unrolling/approx_unrolling_math.py
@@ -24,6 +24,29 @@ from bergson.hessians.apply_hessian import EkfacApplicator, EkfacConfig
 from bergson.score.score import score_dataset
 
 
+def _checkpoint_step(p: str) -> int:
+    """Extract the training step index for a checkpoint.
+
+    Accepts a path whose final component is a ``checkpoint-<N>`` directory
+    (what HF Trainer writes natively) or a bare ``<N>`` step directory.
+    """
+    # TODO: Inferring the step from a checkpoint name via regex is brittle.
+    # For now, we raise an error
+    name = Path(p).name
+    m = re.match(r"checkpoint-(\d+)$", name)
+    if m:
+        return int(m.group(1))
+    if name.isdigit():
+        return int(name)
+    raise ValueError(
+        f"Cannot infer a training step from checkpoint {p!r}: expected a path "
+        "ending in 'checkpoint-<N>' or a bare '<N>' step directory. Set both "
+        "`lr_list` and `step_size_list` on ApproxUnrollingConfig to specify "
+        "the per-segment learning rate and step counts explicitly instead of "
+        "inferring them from checkpoint names."
+    )
+
+
 def compute_lr_times_steps_per_segment(
     approx_unrolling_cfg: ApproxUnrollingConfig,
 ) -> list[float]:
@@ -34,12 +57,8 @@ def compute_lr_times_steps_per_segment(
     if cfg.lr_list and cfg.step_size_list:
         return [lr * k for lr, k in zip(cfg.lr_list, cfg.step_size_list)]
 
-    # TODO: parsing 'checkpoint-N' from dir name is fragile.
     per_segment = len(cfg.checkpoints) // L
-    ckpt_steps = [
-        int(re.match(r"checkpoint-(\d+)$", Path(str(p)).name).group(1))  # type: ignore
-        for p in cfg.checkpoints
-    ]
+    ckpt_steps = [_checkpoint_step(p) for p in cfg.checkpoints]
     boundaries = [0] + [ckpt_steps[(l + 1) * per_segment - 1] for l in range(L)]
     # Prefer log_history.json if dumped at the parent dir; otherwise pull
     # log_history out of the final checkpoint's trainer_state.json (what HF

--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -40,8 +40,8 @@ from ..utils.worker_utils import validate_run_path
 class ApproxUnrolling(Serializable):
     """Run the SOURCE (approximate unrolling) training-data attribution pipeline.
 
-    Currently only step 1 (per-checkpoint Hessian precompute) is wired up;
-    later steps land incrementally. See
+    Runs from per-checkpoint Hessian precompute through per-segment scoring and
+    aggregation into ``<run>/scores.npy``. See
     :mod:`bergson.approx_unrolling.pipeline` for the step list.
     """
 

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -646,12 +646,12 @@ class ScoreConfig(Serializable):
 class ApproxUnrollingConfig(Serializable):
     """Config for approximate unrolling of the influence function."""
 
-    checkpoints: list[int | str] = field(default_factory=list)
-    """List of training checkpoints (by step or path) to use for approximating"""
+    checkpoints: list[str] = field(default_factory=list)
+    """List of training checkpoint paths (HF model ids or local dirs) to use for
+    approximating."""
 
     model_path: str | None = None
-    """Path to the model used for the training checkpoints. Required if checkpoint
-    paths are integers."""
+    """Path to the model used for the training checkpoints."""
 
     segments: int = 3
     """Number of segments to split the training trajectory into for approximation.

--- a/examples/pipelines/approx_unrolling_pythia.yaml
+++ b/examples/pipelines/approx_unrolling_pythia.yaml
@@ -30,6 +30,13 @@ steps:
           - EleutherAI/pythia-14m
           - EleutherAI/pythia-14m
         segments: 3
+        # Per-segment average LR and optimizer step count (one entry per
+        # segment). Required here because the checkpoint names are HF ids, not
+        # `.../checkpoint-<N>` dirs, so the step counts can't be inferred from
+        # names. For a real run over `checkpoint-<N>` snapshots these may be
+        # omitted and are inferred from the training run's log_history.json.
+        lr_list: [1.0e-5, 1.0e-5, 1.0e-5]
+        step_size_list: [1, 1, 1]
         query:
           dataset: NeelNanda/pile-10k
           split: train[:8]

--- a/tests/test_approx_unrolling_checkpoint_parse.py
+++ b/tests/test_approx_unrolling_checkpoint_parse.py
@@ -1,0 +1,52 @@
+"""Regression tests for checkpoint-name handling in the SOURCE
+(approx-unrolling) pipeline.
+"""
+
+import pytest
+
+from bergson.approx_unrolling.approx_unrolling_math import (
+    _checkpoint_step,
+    compute_lr_times_steps_per_segment,
+)
+from bergson.config import ApproxUnrollingConfig
+
+
+def test_checkpoint_step_parses_hf_trainer_dirs():
+    """``checkpoint-<N>`` dir names (and local paths ending in one) parse to N."""
+    assert _checkpoint_step("checkpoint-1000") == 1000
+    assert _checkpoint_step("/path/to/run/checkpoint-42") == 42
+    # A bare digit-only step directory name is also accepted.
+    assert _checkpoint_step("2000") == 2000
+    assert _checkpoint_step("/path/to/run/1500") == 1500
+
+
+def test_checkpoint_step_non_checkpoint_name_raises_valueerror():
+    """A non-``checkpoint-N`` name raises a clear ValueError, not AttributeError."""
+    with pytest.raises(ValueError) as excinfo:
+        _checkpoint_step("EleutherAI/pythia-14m")
+    # Error must be actionable: point the user at the explicit config knobs.
+    msg = str(excinfo.value)
+    assert "lr_list" in msg and "step_size_list" in msg
+
+
+def test_compute_lr_times_steps_hf_id_does_not_attributeerror():
+    """The shipped example (HF model ids, no lr/step lists) must not crash with
+    AttributeError; it should raise an actionable ValueError instead."""
+    cfg = ApproxUnrollingConfig(
+        checkpoints=["EleutherAI/pythia-14m"],
+        segments=1,
+    )
+    with pytest.raises(ValueError):
+        compute_lr_times_steps_per_segment(cfg)
+
+
+def test_compute_lr_times_steps_explicit_lists_bypasses_name_parsing():
+    """When lr_list/step_size_list are set, name parsing is skipped entirely, so
+    non-``checkpoint-N`` checkpoints work end-to-end."""
+    cfg = ApproxUnrollingConfig(
+        checkpoints=["EleutherAI/pythia-14m", "EleutherAI/pythia-14m"],
+        segments=2,
+        lr_list=[1e-5, 2e-5],
+        step_size_list=[3, 4],
+    )
+    assert compute_lr_times_steps_per_segment(cfg) == [1e-5 * 3, 2e-5 * 4]


### PR DESCRIPTION
## Summary

Fixes a crash in the SOURCE (approx-unrolling) pipeline's per-segment LR/step inference.

`compute_lr_times_steps_per_segment` now raises a value error if it can't parse the checkpoint directories (i.e. checkpoints aren't in the `/path/to/checktpoint-X` form) telling the user to set `lr_list`/`step_size_list` explicitly.

SOURCE example has `lr_list`/`step_size_list` set so it doesn't crash.

Removed (incoorect) cli documentation saying SOURCE is incomplete.

Approved by David.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tcZxLbq3c5mKLQcnqndUc