### PR TITLE
honor WANDB_MODE=disabled and tolerate missing wandb in logging

### DIFF
--- a/bergson/utils/logging.py
+++ b/bergson/utils/logging.py
@@ -24,9 +24,6 @@ def wandb_log_fn(
 
     def _noop(step: int, loss: float) -> None: ...
 
-    # Honor an explicit opt-out: skip the import entirely so a missing wandb
-    # cannot crash the run. "offline" still writes local runs, so wandb is
-    # required for it and it is intentionally not treated as a no-op here.
     if os.environ.get("WANDB_MODE", "").strip().lower() == "disabled":
         return _noop
 

--- a/bergson/utils/logging.py
+++ b/bergson/utils/logging.py
@@ -15,10 +15,30 @@ def wandb_log_fn(
 
         log_fn = wandb_log_fn("my-project", config={"lr": 1e-4})
         trainer.train(state, data, log_fn=log_fn)
+
+    Logging degrades to a no-op (without importing wandb) when
+    ``WANDB_MODE=disabled`` is set, or when wandb is not installed. This keeps
+    a MAGIC run that has ``wandb_project`` set from crashing post-training just
+    because wandb is missing or explicitly disabled.
     """
-    import wandb  # type: ignore[reportMissingImports]
 
     def _noop(step: int, loss: float) -> None: ...
+
+    # Honor an explicit opt-out: skip the import entirely so a missing wandb
+    # cannot crash the run. "offline" still writes local runs, so wandb is
+    # required for it and it is intentionally not treated as a no-op here.
+    if os.environ.get("WANDB_MODE", "").strip().lower() == "disabled":
+        return _noop
+
+    try:
+        import wandb  # type: ignore[reportMissingImports]
+    except ImportError:
+        warnings.warn(
+            "wandb is not installed; continuing without wandb logging. "
+            "Install wandb or set WANDB_MODE=disabled to silence this warning.",
+            stacklevel=2,
+        )
+        return _noop
 
     if not wandb.run:
         try:

--- a/tests/test_log_fn.py
+++ b/tests/test_log_fn.py
@@ -61,6 +61,36 @@ def test_wandb_log_fn_reuses_existing_run():
         mock_wandb.log.assert_called_once_with({"train/loss": 1.5}, step=0)
 
 
+def test_wandb_log_fn_noop_when_wandb_mode_disabled(monkeypatch):
+    """With WANDB_MODE=disabled, wandb_log_fn is a no-op and never imports
+    wandb. This mirrors a MAGIC run with wandb_project set but wandb either
+    disabled or uninstalled: it must not crash post-training (bug repro
+    bug4_magic_wandb.py)."""
+    monkeypatch.setenv("WANDB_MODE", "disabled")
+    # Make any attempt to import wandb blow up, proving we short-circuit first.
+    with patch.dict("sys.modules", {"wandb": None}):
+        log = wandb_log_fn("my-magic-run", config={"lr": 1e-4})
+
+        # Must return a callable no-op that does not raise.
+        assert callable(log)
+        assert log(0, 1.5) is None
+        assert log(7, 0.123) is None
+
+
+def test_wandb_log_fn_noop_when_wandb_missing(monkeypatch):
+    """If wandb is not importable, wandb_log_fn degrades to a no-op with a
+    warning instead of raising ModuleNotFoundError/ImportError."""
+    # Exercise the import path (not the WANDB_MODE=disabled short-circuit).
+    monkeypatch.delenv("WANDB_MODE", raising=False)
+    # sys.modules["wandb"] = None makes `import wandb` raise ImportError.
+    with patch.dict("sys.modules", {"wandb": None}):
+        with pytest.warns(UserWarning, match="wandb is not installed"):
+            log = wandb_log_fn("my-magic-run", config={"lr": 1e-4})
+
+        assert callable(log)
+        assert log(0, 1.5) is None
+
+
 def test_wandb_log_fn_falls_back_when_init_fails():
     """If wandb.init raises (e.g. dead daemon, bad auth, network), the caller
     gets a no-op log_fn and a warning, not an exception. Without this, a

--- a/tests/test_log_fn.py
+++ b/tests/test_log_fn.py
@@ -33,8 +33,9 @@ def test_log_fn_called_each_step(model, dataset):
         assert isinstance(loss, float)
 
 
-def test_wandb_log_fn_calls_wandb():
+def test_wandb_log_fn_calls_wandb(monkeypatch):
     """wandb_log_fn initializes wandb and logs correctly."""
+    monkeypatch.delenv("WANDB_MODE", raising=False)
     mock_wandb = MagicMock()
     mock_wandb.run = None
     with patch.dict("sys.modules", {"wandb": mock_wandb}):
@@ -48,8 +49,9 @@ def test_wandb_log_fn_calls_wandb():
         mock_wandb.log.assert_called_once_with({"train/loss": 0.123}, step=5)
 
 
-def test_wandb_log_fn_reuses_existing_run():
+def test_wandb_log_fn_reuses_existing_run(monkeypatch):
     """wandb_log_fn doesn't call init if a run already exists."""
+    monkeypatch.delenv("WANDB_MODE", raising=False)
     mock_wandb = MagicMock()
     mock_wandb.run = MagicMock()  # pretend a run exists
     with patch.dict("sys.modules", {"wandb": mock_wandb}):
@@ -91,11 +93,12 @@ def test_wandb_log_fn_noop_when_wandb_missing(monkeypatch):
         assert log(0, 1.5) is None
 
 
-def test_wandb_log_fn_falls_back_when_init_fails():
+def test_wandb_log_fn_falls_back_when_init_fails(monkeypatch):
     """If wandb.init raises (e.g. dead daemon, bad auth, network), the caller
     gets a no-op log_fn and a warning, not an exception. Without this, a
     rank-0 wandb hang/failure deadlocks the rest of the world on the next
     distributed collective."""
+    monkeypatch.delenv("WANDB_MODE", raising=False)
     mock_wandb = MagicMock()
     mock_wandb.run = None
     mock_wandb.init.side_effect = TimeoutError("wandb-service did not respond")


### PR DESCRIPTION
# honor WANDB_MODE=disabled

If `WANDB_MODE=disabled`, don't raise an error if wandb not installed.

Added regression tests in `tests/test_log_fn.py` covering the disabled-mode
short-circuit and the missing-wandb fallback; existing wandb tests still pass.


---

david has reviewed and simplified, looks reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVQqDEpNVTfvzVcfrvKNej
