### PR TITLE
Fix EK-FAC gradient store overflow above ~537M tracked params

### DIFF
--- a/bergson/builder.py
+++ b/bergson/builder.py
@@ -123,13 +123,17 @@ class Builder:
             self.num_token_grads = None
             self.offsets = None
             if path is not None:
-                self.grad_buffer = create_index(
+                # ``with_structure=False`` never takes the overflow path, so this
+                # is always a plain 2D memmap (not a FlatGradientView).
+                grad_buffer = create_index(
                     path,
                     num_grads=num_grads,
                     grad_sizes=grad_sizes,
                     dtype=np_dtype,
                     with_structure=False,
                 )
+                assert isinstance(grad_buffer, np.memmap)
+                self.grad_buffer = grad_buffer
             else:
                 self.grad_buffer = np.zeros(
                     (num_grads, total_grad_dim),

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -6,6 +6,7 @@ import random
 import re
 from multiprocessing import cpu_count
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Sequence
 
 import ml_dtypes  # noqa: F401  # registers bfloat16 dtype with numpy
@@ -379,13 +380,78 @@ def _allocate_batches_world(
     return [allocation[rank] for rank in ranks]
 
 
+# numpy stores a structured dtype's record ``itemsize`` in a C ``int`` field, so
+# a structured record cannot exceed ``INT_MAX`` (2**31 - 1) bytes. An
+# unprojected EK-FAC query gradient is stored in full model space, so at fp32 the
+# record overflows this cap once a model has more than ~537M tracked-linear
+# params (2**31 / 4). The on-disk byte layout of the structured record is
+# identical to a flat 2D ``(num_grads, total_grad_dim)`` array, whose shape is
+# ``intp``-sized and therefore has no such ceiling, so oversized stores are
+# served through :class:`FlatGradientView` instead.
+_STRUCT_ITEMSIZE_MAX = int(np.iinfo(np.int32).max)
+
+
+def _structured_dtype_fits(dtype: DTypeLike, grad_sizes: dict[str, int]) -> bool:
+    """Whether a structured record over ``grad_sizes`` fits numpy's C-int cap."""
+    itemsize = np.dtype(dtype).itemsize * sum(grad_sizes.values())
+    return itemsize <= _STRUCT_ITEMSIZE_MAX
+
+
+class FlatGradientView:
+    """Field-accessible view over a flat 2D gradient memmap.
+
+    Emulates the subset of the numpy structured-array interface that Bergson
+    relies on (``view[module_name]``, ``view.dtype.names``, ``len(view)``,
+    ``view.flush()``) while backing the data with a plain
+    ``(num_grads, total_grad_dim)`` array. The flat layout is byte-identical to
+    the structured record layout but is not bound by numpy's 2**31-byte
+    structured-record ``itemsize`` cap, so it lets the EK-FAC gradient store
+    scale past ~537M tracked parameters.
+
+    ``view[name]`` returns the ``(num_grads, grad_sizes[name])`` column block for
+    a module as a live view into the underlying array, so both reads and
+    in-place writes (``view[name][:] = ...``) behave like structured field
+    access. Any non-string key indexes the underlying array directly (row
+    selection), matching ``mmap[i]`` / ``mmap[start:stop]`` on a structured
+    memmap at the flat level.
+    """
+
+    def __init__(self, mmap: np.ndarray, grad_sizes: dict[str, int]):
+        self.base = mmap
+        self.grad_sizes = dict(grad_sizes)
+
+        bounds = np.cumsum([0, *self.grad_sizes.values()])
+        self._spans = {
+            name: (int(bounds[i]), int(bounds[i + 1]))
+            for i, name in enumerate(self.grad_sizes)
+        }
+        # Mirror the ``.dtype.names`` attribute of a structured memmap so callers
+        # can enumerate modules the same way regardless of storage layout. We do
+        # *not* build a real structured dtype here: its itemsize would overflow
+        # numpy's C-int cap, which is the very failure this view exists to avoid.
+        self.dtype = SimpleNamespace(names=tuple(self.grad_sizes.keys()))
+
+    def __len__(self) -> int:
+        return int(self.base.shape[0])
+
+    def __getitem__(self, key: Any) -> np.ndarray:
+        if isinstance(key, str):
+            lo, hi = self._spans[key]
+            return self.base[:, lo:hi]
+        return self.base[key]
+
+    def flush(self) -> None:
+        if isinstance(self.base, np.memmap):
+            self.base.flush()
+
+
 def create_index(
     root: Path,
     num_grads: int,
     grad_sizes: dict[str, int],
     dtype: DTypeLike,
     with_structure: bool = True,
-) -> np.memmap:
+) -> np.memmap | FlatGradientView:
     """Create a memory-mapped file for storing structured gradients
     and persist metadata."""
     grad_path = root / "gradients.bin"
@@ -427,6 +493,18 @@ def create_index(
     # ── 2. Everyone blocks until the file is definitely there & sized ─────────────
     if dist.is_initialized():
         dist.barrier()
+
+    # A structured record whose itemsize overflows numpy's C-int cap cannot be
+    # constructed as a dtype; serve those stores as a flat 2D memmap wrapped in a
+    # field-access view (byte-identical layout, no itemsize ceiling).
+    if with_structure and not _structured_dtype_fits(dtype, grad_sizes):
+        flat = np.memmap(
+            grad_path,
+            dtype=np.dtype(dtype),
+            mode="r+",
+            shape=(num_grads, sum(grad_sizes.values())),
+        )
+        return FlatGradientView(flat, grad_sizes)
 
     if with_structure:
         dtype = np.dtype(struct_dtype)  # type: ignore
@@ -487,20 +565,34 @@ def load_data_string(
     return ds
 
 
-def load_gradients(root_dir: Path | str, structured: bool = True) -> np.memmap:
+def load_gradients(
+    root_dir: Path | str, structured: bool = True
+) -> np.memmap | FlatGradientView:
     """Map the structured gradients stored in `root_dir` into memory."""
     root_dir = Path(root_dir)
     with (root_dir / "info.json").open("r") as f:
         info = json.load(f)
 
     num_grads = info["num_grads"]
+    grad_sizes = info["grad_sizes"]
+
+    # A structured record whose itemsize overflows numpy's C-int cap cannot be
+    # constructed as a dtype; map those stores as a flat 2D memmap and expose the
+    # same field-access interface via a view (byte-identical layout).
+    if structured and not _structured_dtype_fits(info["base_dtype"], grad_sizes):
+        flat = np.memmap(
+            root_dir / "gradients.bin",
+            dtype=np.dtype(info["base_dtype"]),
+            mode="r",
+            shape=(num_grads, sum(grad_sizes.values())),
+        )
+        return FlatGradientView(flat, grad_sizes)
 
     if structured:
         dtype = info["dtype"]
         shape = (num_grads,)
     else:
         dtype = info["base_dtype"]
-        grad_sizes = info["grad_sizes"]
         shape = (num_grads, sum(grad_sizes.values()))
 
     return np.memmap(

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -625,6 +625,9 @@ def load_gradient_dataset(root_dir: Path, structured: bool = True) -> Dataset:
                 col = pa.FixedSizeListArray.from_arrays(flat, mmap[field_name].shape[1])
                 ds = ds.add_column(field_name, col, new_fingerprint=field_name)
         else:
+            # ``structured=False`` never takes the overflow path, so the store is
+            # always a plain 2D memmap here (not a FlatGradientView).
+            assert isinstance(mmap, np.memmap)
             flat = _to_arrow(mmap.reshape(-1).copy())
             col_arrow = pa.FixedSizeListArray.from_arrays(flat, mmap.shape[1])
             ds = ds.add_column("gradients", col_arrow, new_fingerprint="gradients")

--- a/bergson/huggingface.py
+++ b/bergson/huggingface.py
@@ -18,7 +18,7 @@ from transformers.training_args import TrainingArguments
 
 from bergson import AttentionConfig, GradientProcessor
 from bergson.collector.gradient_collectors import StreamingGradientCollector
-from bergson.data import create_index
+from bergson.data import FlatGradientView, create_index
 from bergson.gradients import AdafactorNormalizer, AdamNormalizer
 from bergson.utils.peft import detect_peft_modules
 from bergson.utils.utils import convert_dtype_to_torch
@@ -75,7 +75,7 @@ class GradientCollectorCallback(TrainerCallback):
 
         self.torch_dtype = convert_dtype_to_torch(self.dtype)
 
-    def write_grads(self, grad_buffer: np.memmap):
+    def write_grads(self, grad_buffer: np.memmap | FlatGradientView):
         torch.cuda.synchronize()
         for layer_name, g in self.collector.mod_grads.items():
             grad_buffer[layer_name][self.batch_indices, :] = g.numpy()

--- a/bergson/query/faiss_index.py
+++ b/bergson/query/faiss_index.py
@@ -12,6 +12,7 @@ from numpy.typing import NDArray
 from tqdm import tqdm
 
 from bergson.config.config import FaissConfig
+from bergson.data import FlatGradientView, load_gradients
 from bergson.process_grads import precondition_flat_grads
 
 if TYPE_CHECKING:
@@ -90,16 +91,11 @@ def gradients_loader(root_dir: Path):
     stays memory-mapped so downstream code can stream slices without excessive RAM.
     """
 
-    def load_shard(shard_dir: Path) -> np.memmap:
-        with (shard_dir / "info.json").open("r") as f:
-            info = json.load(f)
-
-        return np.memmap(
-            shard_dir / "gradients.bin",
-            dtype=info["dtype"],
-            mode="r",
-            shape=(info["num_grads"],),
-        )
+    def load_shard(shard_dir: Path) -> "np.memmap | FlatGradientView":
+        # Route through load_gradients so oversized stores (whose structured
+        # record itemsize overflows numpy's C-int cap) are served as a flat 2D
+        # view instead of raising while building the structured dtype.
+        return load_gradients(shard_dir, structured=True)
 
     if (root_dir / "info.json").exists():
         yield load_shard(root_dir)
@@ -288,7 +284,12 @@ class FaissIndex:
             if i == 0:
                 ordered_modules = list(grads.dtype.names or [])
 
-            grads = structured_to_unstructured(grads)
+            # A flat view is already unstructured; only real structured arrays
+            # need the (copying) structured_to_unstructured conversion.
+            if isinstance(grads, FlatGradientView):
+                grads = np.asarray(grads.base)
+            else:
+                grads = structured_to_unstructured(grads)
 
             if i == 0:
                 validate_ram(grads, shard_sizes[-1])

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -77,7 +77,10 @@ def get_query_grads(
     if not score_cfg.modules:
         score_cfg.modules = target_modules
 
+    # ``structured=False`` never takes the overflow path, so this is always a
+    # plain 2D memmap (not a FlatGradientView).
     mmap = load_gradients(Path(score_cfg.query_path), structured=False)
+    assert isinstance(mmap, np.memmap)
 
     sizes = torch.tensor(list(grad_sizes.values()))
     module_offsets = torch.tensor([0] + torch.cumsum(sizes, dim=0).tolist())

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,27 +1,83 @@
 import numpy as np
-import pytest
 
-from bergson.data import create_index, load_gradients
+from bergson.data import FlatGradientView, create_index, load_gradients
 
 
-def test_large_gradients_build(tmp_path, dataset):
-    # Uncompressed gradients from a large (~1.4B-param) model produce a structured
-    # numpy dtype whose itemsize (4 bytes * total elements) overflows the C-int cap
-    # (2**31 - 1 bytes), so structured loading must fail while unstructured loading
-    # succeeds. Fabricate per-module gradient sizes at that scale directly so the
-    # test needs no model and no GPU.
-    grad_sizes = {f"layer_{i}.weight": 50_000_000 for i in range(12)}  # 6e8 elems
+def _oversized_grad_sizes() -> dict[str, int]:
+    """Two modules whose combined fp32 record overflows numpy's C-int itemsize
+    cap (2**31 - 1 bytes), i.e. > 2**31 / 4 float32 elements total.
+
+    This is the regime an unprojected EK-FAC query gradient hits once a model
+    has more than ~537M tracked-linear params. The store is allocated as a
+    *sparse* file (``truncate`` only sets the size), so the test writes/reads a
+    handful of pages rather than materializing ~2 GB.
+    """
+    per_module = 2**31 // 4 // 2 + 1  # just over half the fp32 element cap
+    grad_sizes = {"layer_0.weight": per_module, "layer_1.weight": per_module}
     assert sum(grad_sizes.values()) * np.dtype(np.float32).itemsize > 2**31
+    return grad_sizes
 
-    create_index(
-        tmp_path,
-        num_grads=len(dataset),
-        grad_sizes=grad_sizes,
-        dtype=np.float32,
-        with_structure=False,
-    )
 
-    # Unstructured load works; structured load exceeds numpy's max item size.
-    load_gradients(tmp_path, structured=False)
-    with pytest.raises(ValueError):
-        load_gradients(tmp_path, structured=True)
+def test_large_gradient_store_roundtrips(tmp_path):
+    # A structured record for a >537M-param model overflows numpy's C-int
+    # itemsize cap, so create_index/load_gradients must transparently fall back
+    # to the byte-identical flat 2D layout (served via FlatGradientView) instead
+    # of raising while constructing the structured dtype. CPU-only, no model.
+    grad_sizes = _oversized_grad_sizes()
+    names = list(grad_sizes)
+    size = grad_sizes[names[0]]
+
+    # create_index defaults to with_structure=True (the EK-FAC path); it must not
+    # raise on the oversized record.
+    buf = create_index(tmp_path, num_grads=1, grad_sizes=grad_sizes, dtype=np.float32)
+    assert isinstance(buf, FlatGradientView)
+    assert buf.dtype.names == tuple(names)
+    assert len(buf) == 1
+
+    # Field access returns the module's column block; write sentinels at the
+    # start/end of each module so we exercise the full flattened offset range,
+    # including the boundary between the two modules.
+    buf[names[0]][0, 0] = 1.5
+    buf[names[0]][0, size - 1] = 2.5
+    buf[names[1]][0, 0] = 3.5
+    buf[names[1]][0, size - 1] = 4.5
+    buf.flush()
+
+    # Structured load now succeeds (previously raised ValueError) and round-trips.
+    view = load_gradients(tmp_path, structured=True)
+    assert isinstance(view, FlatGradientView)
+    assert view.dtype.names == tuple(names)
+    assert view[names[0]][0, 0] == 1.5
+    assert view[names[0]][0, size - 1] == 2.5
+    assert view[names[1]][0, 0] == 3.5
+    assert view[names[1]][0, size - 1] == 4.5
+
+    # The flat (unstructured) view of the same bytes must agree: the structured
+    # record layout and the flat 2D layout are byte-identical, so the second
+    # module's block starts exactly at column `size`.
+    flat = load_gradients(tmp_path, structured=False)
+    assert flat.shape == (1, 2 * size)
+    assert flat[0, 0] == 1.5
+    assert flat[0, size - 1] == 2.5
+    assert flat[0, size] == 3.5
+    assert flat[0, 2 * size - 1] == 4.5
+
+
+def test_small_gradient_store_stays_structured(tmp_path):
+    # Below the itemsize cap the behavior is unchanged: create_index/load_gradients
+    # return a genuine structured numpy memmap with real field access.
+    grad_sizes = {"layer_0.weight": 8, "layer_1.weight": 16}
+    assert sum(grad_sizes.values()) * np.dtype(np.float32).itemsize <= 2**31
+
+    buf = create_index(tmp_path, num_grads=3, grad_sizes=grad_sizes, dtype=np.float32)
+    assert isinstance(buf, np.memmap)
+    assert buf.dtype.names == ("layer_0.weight", "layer_1.weight")
+
+    buf["layer_0.weight"][:] = 1.0
+    buf["layer_1.weight"][:] = 2.0
+    buf.flush()
+
+    view = load_gradients(tmp_path, structured=True)
+    assert isinstance(view, np.memmap)
+    assert np.all(view["layer_0.weight"] == 1.0)
+    assert np.all(view["layer_1.weight"] == 2.0)


### PR DESCRIPTION
# Fix EK-FAC gradient store overflow above ~537M tracked params

## Problem

`bergson ekfac` (the EK-FAC influence pipeline) cannot attribute any model with
more than ~537M tracked-linear parameters. The apply-Hessian stage loads a structured memmap which contains unprojected grads so is beyond the structured memmap size limit and aborts with `ValueError: integer won't fit into a C int`.

So `sum(grad_sizes.values())` equals
the full per-example gradient dimension, and at fp32 the record crosses `2**31`
bytes once the model has more than `2**31 / 4 = 536,870,912` tracked params.

The exact failing calls are in the apply stage:

- `bergson/hessians/apply_hessian.py:79` — `load_gradients(self.gradient_path)`
  (structured) maps the unprojected query gradient → overflow.
- `bergson/hessians/apply_hessian.py:83` — `create_index(...)` (structured,
  default) allocates the transformed-gradient output → overflow.

## Fix

You can avoid the crash by loading with the flag structured=False.

For oversized stores only, `create_index` / `load_gradients` now serve the data
as a flat 2D memmap wrapped in a small **field-access view** that preserves the
structured interface the rest of the codebase uses. Small models are completely
unaffected — they still get a genuine numpy structured memmap.

- `bergson/data.py` — added `FlatGradientView`: exposes `view[module_name]`
  (returns the module's `(num_grads, size)` column block as a live, writable view
  into the memmap), `view.dtype.names`, `len(view)`, and `view.flush()`.
- `bergson/data.py` — added `_structured_dtype_fits()`; `create_index`
  (`with_structure=True`) and `load_gradients` (`structured=True`) fall back to
  `FlatGradientView` when the record would overflow the C-int cap, and are
  otherwise unchanged. The persisted `info.json` is unchanged (still records the
  structured `dtype`, `grad_sizes`, and `base_dtype`), so existing stores and
  metadata readers keep working.
- `bergson/query/faiss_index.py` — `gradients_loader` now routes through
  `load_gradients` (so the approximate-query path is overflow-safe too), and the
  loader loop skips the `structured_to_unstructured` copy for an already-flat
  view.

No public API or signature changes. `apply_hessian`'s field-access reads/writes
(`mmap[k]`, `grad_buffer[k][:] = ...`, `len`, `.flush`) work unchanged against
`FlatGradientView`.

## Test

`tests/test_data.py` (CPU-only, no CUDA, no model):

- `test_large_gradient_store_roundtrips` — builds a store whose combined fp32
  record exceeds `2**31` bytes (`> 2**31 / 4` float32 elements across two
  modules), writes sentinels at each module's start/end via structured field
  access, and asserts they round-trip through `create_index` +
  `load_gradients(structured=True)`. It also cross-checks the flat
  (`structured=False`) view of the same bytes to confirm the byte-identical
  layout. The store is a **sparse** file (`truncate` only sets the size), so the
  test touches a handful of pages instead of materializing ~2 GB.
- `test_small_gradient_store_stays_structured` — asserts sub-cap stores still
  return a genuine `np.memmap` structured array with unchanged behavior.

Before this fix the oversized case raises `ValueError: integer won't fit into a
C int` in `create_index`; after, it round-trips. The previous `test_data.py`
(which asserted the failure as expected behavior) is replaced accordingly.

Verified in the pinned venv (numpy 2.5.1, torch 2.9.1+cu128):

```
pytest tests/test_data.py -v        # 2 passed
pytest tests/test_score.py -v       # 8 passed (incl. test_large_gradients_query)
```

## Scope and limitations

- This raises the **storage** ceiling for the EK-FAC gradient store past
  ~537M params; it does not change results for models below the old ceiling.
- EK-FAC influence has a **separate, larger** ceiling that this fix does *not*
  address: the query gradient is materialized **unprojected in full model
  space** on the GPU during `apply_hessian` (and again when reading it back for
  scoring). That is an architectural memory ceiling (order ~7B params on an 80 GB
  GPU, and it also implies a large host/disk footprint), independent of the
  numpy itemsize limit fixed here. Projecting or streaming the unprojected query
  gradient to lift that ceiling is out of scope for this bug fix.
- `FlatGradientView` implements only the subset of the structured-array
  interface Bergson actually uses (field access, `dtype.names`, `len`, `flush`,
  and integer/slice row indexing on the underlying flat array). It is not a
  general drop-in for every numpy structured-array operation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rrSNbhfYPhfuxuBrdJeFG
