### PR TITLE
Collect gradients from masked prompt tokens in prompt/completion contexts

### DIFF
--- a/bergson/__init__.py
+++ b/bergson/__init__.py
@@ -16,9 +16,11 @@ from .config.config import (
     ScoreConfig,
 )
 from .data import (
+    ModuleGradients,
     TokenGradients,
     load_gradient_dataset,
     load_gradients,
+    load_module_gradients,
     load_token_gradients,
 )
 from .gradients import GradientProcessor
@@ -36,7 +38,9 @@ __all__ = [
     "collect_gradients",
     "load_gradients",
     "load_gradient_dataset",
+    "load_module_gradients",
     "load_token_gradients",
+    "ModuleGradients",
     "TokenGradients",
     "Builder",
     "load_from_optimizer",

--- a/bergson/builder.py
+++ b/bergson/builder.py
@@ -127,7 +127,6 @@ class Builder:
                     num_grads=num_grads,
                     grad_sizes=grad_sizes,
                     dtype=np_dtype,
-                    with_structure=False,
                 )
             else:
                 self.grad_buffer = np.zeros(

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -762,8 +762,6 @@ class CollectorComputer:
             ):
                 batch = self.data[indices]
 
-                # Compute padded tensors and valid_mask before entering context
-                # TODO check if valid_mask has bug
                 # Local padding only: bin-packer enforces a per-rank
                 # ``max_len × batch_size ≤ N`` budget that a global-max
                 # all-reduce would silently violate.
@@ -775,8 +773,25 @@ class CollectorComputer:
                 )
                 total_processed += valid_mask.sum()
 
+                # ``valid_mask`` marks completion positions (labels[t+1] != -100)
+                # and drives the loss-scoped consumers (Hessian factors, MAGIC).
+                # Per-token gradient rows, however, cover EVERY real position:
+                # g_t is nonzero at prompt positions too (completion losses
+                # backprop through them via attention), so storing all positions
+                # makes the per-token rows sum to the per-document gradient. Only
+                # right-padding and the final position (predicts nothing) drop out.
+                if self.collector.attribute_tokens:
+                    lengths = torch.tensor(
+                        [len(ids) for ids in batch["input_ids"]],
+                        device=self.device,
+                    )
+                    positions = torch.arange(x.size(1), device=self.device)
+                    row_mask = (positions.unsqueeze(0) + 1) < lengths.unsqueeze(1)
+                else:
+                    row_mask = valid_mask
+
                 with (
-                    self.collector.with_batch(valid_mask),
+                    self.collector.with_batch(row_mask),
                     (
                         record_function(f"step_{step}")
                         if self.cfg.profile

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -773,13 +773,10 @@ class CollectorComputer:
                 )
                 total_processed += valid_mask.sum()
 
-                # ``valid_mask`` marks completion positions (labels[t+1] != -100)
-                # and drives the loss-scoped consumers (Hessian factors, MAGIC).
-                # Per-token gradient rows, however, cover EVERY real position:
-                # g_t is nonzero at prompt positions too (completion losses
-                # backprop through them via attention), so storing all positions
-                # makes the per-token rows sum to the per-document gradient. Only
-                # right-padding and the final position (predicts nothing) drop out.
+                # Per-token rows span every real position (g_t is nonzero at
+                # prompt positions too), so they sum to the per-doc gradient.
+                # valid_mask is left completion-only for the KFAC/Shampoo Hessian
+                # collectors that also run through this loop.
                 if self.collector.attribute_tokens:
                     lengths = torch.tensor(
                         [len(ids) for ids in batch["input_ids"]],

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -86,7 +86,7 @@ class HookCollectorBase(ContextDecorator, ABC):
 
     attribute_tokens: bool = False
     """When True, compute per-position gradients instead of per-example, filtered
-    to valid positions using ``_current_valid_mask``."""
+    to gradient-bearing positions using ``_current_collection_mask``."""
 
     lo: float = float("-inf")
     """Lower clamp bound for gradients. May be narrowed in subclass ``setup()``."""
@@ -297,26 +297,27 @@ class HookCollectorBase(ContextDecorator, ABC):
         self.processor._projection_matrices[key] = A
         return A
 
-    def with_batch(self, valid_mask: Tensor | None = None) -> "HookCollectorBase":
+    def with_batch(self, collection_mask: Tensor | None = None) -> "HookCollectorBase":
         """
-        Set the current batch indices and valid mask before entering the context.
+        Set the current collection mask before entering the context.
 
-        This allows hooks to access batch indices and valid mask during
-        forward/backward passes.
+        This allows hooks to access the mask during forward/backward passes.
         Usage:
-            with collector.with_batch(indices, valid_mask):
+            with collector.with_batch(collection_mask):
                 # forward/backward pass
-                # hooks can access self._current_indices and self._current_valid_mask
+                # hooks can access self._current_collection_mask
 
         Args:
-            indices: List of data indices in the current batch.
-            valid_mask: Optional boolean tensor of shape [batch_size, seq_len]
-                indicating which positions have valid labels for loss computation.
+            collection_mask: Optional boolean tensor of shape [batch_size, seq_len]
+                indicating every position containing a non-padding token with a
+                next-token target (excludes each sequence's final token). Unlike
+                ``pad_and_tensor``'s ``valid_masks``, it is independent of label
+                masking.
 
         Returns:
             self, for use as a context manager.
         """
-        self._current_valid_mask = valid_mask
+        self._current_collection_mask = collection_mask
         return self
 
     def __enter__(self):
@@ -515,7 +516,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     P = self.double_sided_projection(name, P, g, p, o, i)
 
                 P = P.flatten(2)  # [N, S, grad_dim]
-                P = P[self._current_valid_mask]  # [total_valid, grad_dim]
+                P = P[self._current_collection_mask]  # [total_valid, grad_dim]
             else:
                 P = g.mT @ a  # [N,O,S] @ [N,S,I] → [N,O,I]
 
@@ -564,7 +565,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     # [N, S, O/p, 1] * [N, S, 1, I/q] → [N, S, O/p, I/q]
                     P = g.unsqueeze(-1) * a.unsqueeze(-2)
                 P = P.flatten(2)  # [N, S, grad_dim]
-                P = P[self._current_valid_mask]  # [total_valid, grad_dim]
+                P = P[self._current_collection_mask]  # [total_valid, grad_dim]
             else:
                 if bias_grad is not None and p is not None:
                     P = self.double_sided_projection_with_bias(
@@ -601,7 +602,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                 )
                 if self.attribute_tokens:
                     P = P.flatten(2)  # [N, S, grad_dim]
-                    P = P[self._current_valid_mask]  # [total_valid, grad_dim]
+                    P = P[self._current_collection_mask]  # [total_valid, grad_dim]
             else:
                 # a was already projected in forward if p is set;
                 # project g individually
@@ -617,7 +618,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     if bias_grad is not None:
                         P = torch.cat([P, bias_grad.unsqueeze(-1)], dim=-1)
                     P = P.flatten(2)  # [N, S, grad_dim]
-                    P = P[self._current_valid_mask]  # [total_valid, grad_dim]
+                    P = P[self._current_collection_mask]  # [total_valid, grad_dim]
                 else:
                     P = g.mT @ a  # [N, O/p, I/p]
                     if bias_grad is not None:
@@ -765,30 +766,16 @@ class CollectorComputer:
                 # Local padding only: bin-packer enforces a per-rank
                 # ``max_len × batch_size ≤ N`` budget that a global-max
                 # all-reduce would silently violate.
-                x, y, valid_mask = pad_and_tensor(
+                x, y, _, collection_mask = pad_and_tensor(
                     batch["input_ids"],
                     labels=batch.get("labels"),
                     device=self.device,
                     sync_max_len=False,
                 )
-                total_processed += valid_mask.sum()
-
-                # Per-token rows span every real position (g_t is nonzero at
-                # prompt positions too), so they sum to the per-doc gradient.
-                # valid_mask is left completion-only for the KFAC/Shampoo Hessian
-                # collectors that also run through this loop.
-                if self.collector.attribute_tokens:
-                    lengths = torch.tensor(
-                        [len(ids) for ids in batch["input_ids"]],
-                        device=self.device,
-                    )
-                    positions = torch.arange(x.size(1), device=self.device)
-                    row_mask = (positions.unsqueeze(0) + 1) < lengths.unsqueeze(1)
-                else:
-                    row_mask = valid_mask
+                total_processed += collection_mask.sum()
 
                 with (
-                    self.collector.with_batch(row_mask),
+                    self.collector.with_batch(collection_mask),
                     (
                         record_function(f"step_{step}")
                         if self.cfg.profile

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -33,27 +33,27 @@ from .utils.utils import (
 
 
 def compute_num_token_grads(data: Dataset) -> np.ndarray:
-    """Compute the number of valid gradient positions per example.
+    """Number of per-token gradient rows stored per example.
 
-    A token at position t produces a gradient iff the *next* token's label
-    is not -100 (the ignore index).  When there is no explicit ``labels``
-    column every position except the last is valid, so
-    ``num_token_grads = length - 1``.
+    Position ``t``'s row is ``g_t (x) a_t``. ``g_t`` is generally nonzero even
+    at prompt / masked positions, because the completion-token losses backprop
+    through them via causal attention -- masking is applied to the *loss*, not
+    to the gradient. Storing every position therefore makes the per-token rows
+    sum to the per-document gradient. Only the final position (which predicts
+    nothing after ``logits[:, :-1]``) and right-padding are excluded, so
+    ``num_token_grads = length - 1`` regardless of the label mask.
 
     Returns
     -------
     np.ndarray of shape ``(len(data),)`` with dtype int64.
     """
-    if "labels" in data.column_names:
-        # Count positions where labels[t+1] != -100 for t in 0..len-2
-        counts = []
-        for labels in data["labels"]:
-            labels_arr = np.asarray(labels)
-            counts.append(int(np.sum(labels_arr[1:] != -100)))
-        return np.array(counts, dtype=np.int64)
+    if "length" in data.column_names:
+        lengths = np.asarray(data["length"], dtype=np.int64)
+    elif "input_ids" in data.column_names:
+        lengths = np.asarray([len(x) for x in data["input_ids"]], dtype=np.int64)
     else:
-        lengths = np.array(data["length"], dtype=np.int64)
-        return lengths - 1
+        lengths = np.asarray([len(x) for x in data["labels"]], dtype=np.int64)
+    return lengths - 1
 
 
 def create_token_index(

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -617,12 +617,17 @@ def pad_and_tensor(
     dtype: torch.dtype | None = torch.long,
     device: torch.device | None = None,
     sync_max_len: bool = True,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Pad a list of sequences to the same length and convert them to tensors.
     Returns a tuple of padded sequences and labels. The labels are the same as the
     sequences, but with -100 for the padding positions, which is useful for ignoring
     padding in loss calculations.
+
+    Also returns two masks: ``valid_masks`` marks positions whose next-token
+    label is not -100 (loss positions), while ``collection_masks`` marks every
+    non-padding position but each sequence's last, independent of label
+    masking (the gradient-bearing positions).
 
     When ``sync_max_len`` is True (default) and a process group is
     initialized, the padding length is reduced to the global max across
@@ -659,7 +664,13 @@ def pad_and_tensor(
     valid_masks = torch.zeros(N, S, dtype=torch.bool, device=device)
     valid_masks[:, :-1] = padded_labels[:, 1:] != -100
 
-    return padded_tokens, padded_labels, valid_masks
+    # Compute collection_masks: every non-padding position but each
+    # sequence's last, regardless of label masking.
+    lengths = torch.tensor([len(seq) for seq in sequences], device=device)
+    positions = torch.arange(S, device=device)
+    collection_masks = (positions.unsqueeze(0) + 1) < lengths.unsqueeze(1)
+
+    return padded_tokens, padded_labels, valid_masks, collection_masks
 
 
 def tokenize(

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -6,7 +6,7 @@ import random
 import re
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Iterator, Sequence
 
 import ml_dtypes  # noqa: F401  # registers bfloat16 dtype with numpy
 import numpy as np
@@ -379,19 +379,33 @@ def _allocate_batches_world(
     return [allocation[rank] for rank in ranks]
 
 
+def column_offsets(grad_sizes: dict[str, int]) -> dict[str, tuple[int, int]]:
+    """Map each module name to its ``(start, end)`` column range in a flat
+    ``(num_grads, total_grad_dim)`` gradient array laid out in `grad_sizes`
+    order (the on-disk layout of :func:`create_index`)."""
+    offsets = {}
+    start = 0
+    for name, size in grad_sizes.items():
+        offsets[name] = (start, start + size)
+        start += size
+    return offsets
+
+
 def create_index(
     root: Path,
     num_grads: int,
     grad_sizes: dict[str, int],
     dtype: DTypeLike,
-    with_structure: bool = True,
 ) -> np.memmap:
-    """Create a memory-mapped file for storing structured gradients
-    and persist metadata."""
+    """Create a memory-mapped ``(num_grads, total_grad_dim)`` gradient file
+    (modules laid out in `grad_sizes` order) and persist metadata."""
     grad_path = root / "gradients.bin"
     rank = dist.get_rank() if dist.is_initialized() else 0
 
-    # Build a json-serializable structured dtype
+    # Legacy structured dtype, still written so external readers of older
+    # bergson gradient stores can open new files. In-library code always maps
+    # the file flat: a structured record's itemsize overflows numpy's C-int
+    # cap above ~537M tracked fp32 params.
     struct_dtype = {
         "names": [name for name in grad_sizes.keys()],
         "formats": [f"({size},){np.dtype(dtype).str}" for size in grad_sizes.values()],
@@ -428,18 +442,11 @@ def create_index(
     if dist.is_initialized():
         dist.barrier()
 
-    if with_structure:
-        dtype = np.dtype(struct_dtype)  # type: ignore
-        shape = (num_grads,)
-    else:
-        dtype = np.dtype(dtype)
-        shape = (num_grads, sum(grad_sizes.values()))
-
     return np.memmap(
         grad_path,
-        dtype=dtype,
+        dtype=np.dtype(dtype),
         mode="r+",
-        shape=shape,
+        shape=(num_grads, sum(grad_sizes.values())),
     )
 
 
@@ -487,38 +494,73 @@ def load_data_string(
     return ds
 
 
-def load_gradients(root_dir: Path | str, structured: bool = True) -> np.memmap:
-    """Map the structured gradients stored in `root_dir` into memory."""
+def load_gradients(root_dir: Path | str) -> np.memmap:
+    """Map the gradients stored in `root_dir` into memory as a flat
+    ``(num_grads, total_grad_dim)`` array, with modules laid out in
+    ``grad_sizes`` order (see :func:`column_offsets` for per-module slicing)."""
     root_dir = Path(root_dir)
     with (root_dir / "info.json").open("r") as f:
         info = json.load(f)
 
-    num_grads = info["num_grads"]
-
-    if structured:
-        dtype = info["dtype"]
-        shape = (num_grads,)
+    if "base_dtype" in info:
+        dtype = np.dtype(info["base_dtype"])
     else:
-        dtype = info["base_dtype"]
-        grad_sizes = info["grad_sizes"]
-        shape = (num_grads, sum(grad_sizes.values()))
+        # Stores written before base_dtype existed only carry the structured
+        # dtype; recover the scalar dtype from a field format like "(768,)<f4".
+        dtype = np.dtype(info["dtype"]["formats"][0]).base
 
     return np.memmap(
         root_dir / "gradients.bin",
         dtype=dtype,
         mode="r",
-        shape=shape,
+        shape=(info["num_grads"], sum(info["grad_sizes"].values())),
     )
 
 
-def load_gradient_dataset(root_dir: Path, structured: bool = True) -> Dataset:
+class ModuleGradients:
+    """Dict-like, module-name-keyed view over a flat gradient store:
+    ``grads[name]`` returns the ``(num_grads, size)`` column slice for that
+    module. Replaces structured-dtype field access, whose per-record itemsize
+    overflows numpy's C-int cap above ~537M tracked fp32 params."""
+
+    def __init__(self, mmap: np.memmap, grad_sizes: dict[str, int]):
+        self.mmap = mmap
+        self.offsets = column_offsets(grad_sizes)
+
+    def __getitem__(self, name: str) -> np.ndarray:
+        lo, hi = self.offsets[name]
+        return self.mmap[:, lo:hi]
+
+    def __len__(self) -> int:
+        return len(self.mmap)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.offsets)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.offsets
+
+    def keys(self):
+        return self.offsets.keys()
+
+
+def load_module_gradients(root_dir: Path | str) -> ModuleGradients:
+    """Load the gradients stored in `root_dir` keyed by module name."""
+    root_dir = Path(root_dir)
+    with (root_dir / "info.json").open("r") as f:
+        grad_sizes = json.load(f)["grad_sizes"]
+
+    return ModuleGradients(load_gradients(root_dir), grad_sizes)
+
+
+def load_gradient_dataset(root_dir: Path) -> Dataset:
     """Load a dataset of gradients from `root_dir`."""
 
     def load_shard(dir: Path) -> Dataset:
         ds = Dataset.load_from_disk(str(dir / "data.hf"))
 
         # Add gradients to HF dataset.
-        mmap = load_gradients(dir, structured=structured)
+        mmap = load_gradients(dir)
 
         def _to_arrow(arr: np.ndarray) -> pa.Array:
             """Convert numpy array to PyArrow, casting bfloat16 to float32."""
@@ -526,16 +568,9 @@ def load_gradient_dataset(root_dir: Path, structured: bool = True) -> Dataset:
                 arr = arr.astype(np.float32)
             return pa.array(arr)
 
-        if structured:
-            assert mmap.dtype.names is not None
-            for field_name in mmap.dtype.names:
-                flat = _to_arrow(mmap[field_name].reshape(-1).copy())
-                col = pa.FixedSizeListArray.from_arrays(flat, mmap[field_name].shape[1])
-                ds = ds.add_column(field_name, col, new_fingerprint=field_name)
-        else:
-            flat = _to_arrow(mmap.reshape(-1).copy())
-            col_arrow = pa.FixedSizeListArray.from_arrays(flat, mmap.shape[1])
-            ds = ds.add_column("gradients", col_arrow, new_fingerprint="gradients")
+        flat = _to_arrow(mmap.reshape(-1).copy())
+        col_arrow = pa.FixedSizeListArray.from_arrays(flat, mmap.shape[1])
+        ds = ds.add_column("gradients", col_arrow, new_fingerprint="gradients")
 
         return ds
 

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -402,10 +402,7 @@ def create_index(
     grad_path = root / "gradients.bin"
     rank = dist.get_rank() if dist.is_initialized() else 0
 
-    # Legacy structured dtype, still written so external readers of older
-    # bergson gradient stores can open new files. In-library code always maps
-    # the file flat: a structured record's itemsize overflows numpy's C-int
-    # cap above ~537M tracked fp32 params.
+    # Legacy structured dtype, still written for external readers of older stores
     struct_dtype = {
         "names": [name for name in grad_sizes.keys()],
         "formats": [f"({size},){np.dtype(dtype).str}" for size in grad_sizes.values()],
@@ -505,8 +502,7 @@ def load_gradients(root_dir: Path | str) -> np.memmap:
     if "base_dtype" in info:
         dtype = np.dtype(info["base_dtype"])
     else:
-        # Stores written before base_dtype existed only carry the structured
-        # dtype; recover the scalar dtype from a field format like "(768,)<f4".
+        # Old stores lack base_dtype; recover the scalar dtype from a field format
         dtype = np.dtype(info["dtype"]["formats"][0]).base
 
     return np.memmap(
@@ -518,10 +514,9 @@ def load_gradients(root_dir: Path | str) -> np.memmap:
 
 
 class ModuleGradients:
-    """Dict-like, module-name-keyed view over a flat gradient store:
+    """Dict-like, module-name-keyed view over a flat memmapped gradient store:
     ``grads[name]`` returns the ``(num_grads, size)`` column slice for that
-    module. Replaces structured-dtype field access, whose per-record itemsize
-    overflows numpy's C-int cap above ~537M tracked fp32 params."""
+    module."""
 
     def __init__(self, mmap: np.memmap, grad_sizes: dict[str, int]):
         self.mmap = mmap

--- a/bergson/diagnose.py
+++ b/bergson/diagnose.py
@@ -72,8 +72,8 @@ def _get_example_loss(model, x, y, idx=0):
 
 def _measure(model, short_ids, long_ids, device):
     """Measure gradient cosine similarity: alone vs mixed batch."""
-    x_alone, y_alone, _ = pad_and_tensor([short_ids], device=device)
-    x_mixed, y_mixed, _ = pad_and_tensor([short_ids, long_ids], device=device)
+    x_alone, y_alone, _, _ = pad_and_tensor([short_ids], device=device)
+    x_mixed, y_mixed, _, _ = pad_and_tensor([short_ids, long_ids], device=device)
 
     # Pass 1: alone
     model.zero_grad()

--- a/bergson/hessians/apply_hessian.py
+++ b/bergson/hessians/apply_hessian.py
@@ -10,11 +10,11 @@ import torch.distributed as dist
 from simple_parsing import ArgumentParser
 
 from bergson.config import InversionConfig
-from bergson.data import create_index, load_gradients
+from bergson.data import column_offsets, create_index, load_gradients
 from bergson.distributed import init_dist
 from bergson.hessians.preconditioner import FactoredPreconditioner
 from bergson.utils.logger import get_logger
-from bergson.utils.utils import get_device
+from bergson.utils.utils import get_device, numpy_to_tensor
 
 
 @dataclass
@@ -26,6 +26,8 @@ class EkfacConfig:
     """If True, use the corrected eigenvalues, this requires
     `hessian_method_path` to have been created with
     `HessianConfig.ev_correction=True`."""
+    apply_batch_size: int = 32
+    """Number of query gradients moved on-device and preconditioned at a time."""
     debug: bool = False
 
 
@@ -84,6 +86,7 @@ class EkfacApplicator:
         mmap = load_gradients(self.gradient_path)
         with open(os.path.join(self.gradient_path, "info.json")) as f:
             info = json.load(f)
+        in_offsets = column_offsets(info["grad_sizes"])
 
         grad_buffer = create_index(
             Path(self.cfg.run_path),
@@ -91,43 +94,53 @@ class EkfacApplicator:
             grad_sizes=grad_sizes,
             dtype=np.float32,
         )
+        out_offsets = column_offsets(grad_sizes)
 
+        num_queries = info["num_grads"]
         self.logger.info(
-            f"Loaded gradients for {len(mmap)} queries and computing IVHP..."
+            f"Loaded gradients for {num_queries} queries and computing IVHP..."
         )
 
-        # Load the gradients into memory. They are mmap'd read-only; `from_numpy`
-        # uses the same buffer and warns that writes would be unsafe.
-        # We never write through `grads` (the preconditioner returns fresh
-        # tensors) so we suppress the warning.
-        grads: dict[str, torch.Tensor] = {}
-        for name in preconditioner.eigen_a:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    message="The given NumPy array is not writable",
-                    category=UserWarning,
-                )
-                grads[name] = torch.from_numpy(mmap[name][:]).to(
-                    device=self.device, dtype=torch.float32
-                )
+        # Precondition the queries
+        for start in range(0, num_queries, self.cfg.apply_batch_size):
+            end = min(start + self.cfg.apply_batch_size, num_queries)
 
-        transformed = preconditioner.apply(grads)
+            # The gradients are mmap'd read-only which pytorch doesn't
+            # support: suppress the warning (the preconditioner returns
+            # fresh tensors.
+            grads: dict[str, torch.Tensor] = {}
+            for name in preconditioner.eigen_a:
+                lo, hi = in_offsets[name]
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message="The given NumPy array is not writable",
+                        category=UserWarning,
+                    )
+                    grads[name] = numpy_to_tensor(mmap[start:end, lo:hi]).to(
+                        device=self.device, dtype=torch.float32
+                    )
+
+            transformed = preconditioner.apply(grads)
+            del grads
+
+            self.logger.debug("Finished H^{-1} G = Q_S @ (G' / lambda) @ Q_A^T batch")
+
+            # Stage the async D2H copies, synchronize once, then read them
+            # into the numpy buffer. `.numpy()` is a host read so the
+            # sync must sit between it and the copies.
+            staged = {
+                name: v.to(device="cpu", non_blocking=True)
+                for name, v in transformed.items()
+            }
+            del transformed
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            for name, t in staged.items():
+                lo, hi = out_offsets[name]
+                grad_buffer[start:end, lo:hi] = t.flatten(1).numpy()
 
         self.logger.debug("Finished H^{-1} G = Q_S @ (G' / lambda) @ Q_A^T")
-
-        # Stage the async D2H copies, synchronize once, then read them into the
-        # (pageable) numpy buffer — the collector/builder idiom. `.numpy()` is a
-        # host read, so the sync must sit between the copies and it; the earlier
-        # bug synchronized *before* issuing the copies, leaving NaNs.
-        staged = {
-            name: v.to(device="cpu", non_blocking=True)
-            for name, v in transformed.items()
-        }
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        for name, t in staged.items():
-            grad_buffer[name][:] = t.flatten(1).numpy()
 
         grad_buffer.flush()
 

--- a/bergson/hessians/kfac.py
+++ b/bergson/hessians/kfac.py
@@ -44,10 +44,10 @@ class CovarianceCollector(HookCollectorBase):
         """Compute activation covariance: A^T @ A."""
         name = assert_type(str, module._name)
         A_cov_ki = self.A_cov_dict[name]
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
         assert mask is not None, "Valid mask not set for forward hook."
 
-        # a: [N, S, I], valid_masks: [N, S] -> select valid positions
+        # a: [N, S, I], collection_masks: [N, S] -> select collected positions
         a_bi = a[mask].to(self.dtype)  # [num_valid, I]
 
         # Augment with a ones column so A matches the [O, I+1] gradient layout
@@ -75,7 +75,7 @@ class CovarianceCollector(HookCollectorBase):
         """Compute gradient covariance: G^T @ G."""
         name = assert_type(str, module._name)
         S_cov_po = self.S_cov_dict[name]
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
 
         # g: [N, S, O], mask: [N, S] -> select valid positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]

--- a/bergson/hessians/shampoo.py
+++ b/bergson/hessians/shampoo.py
@@ -44,10 +44,10 @@ class ShampooCollector(HookCollectorBase):
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         """Compute activation covariance: A^T @ A."""
 
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
         assert mask is not None, "Valid mask not set for forward hook."
 
-        # a: [N, S, I], valid_masks: [N, S] -> select valid positions
+        # a: [N, S, I], collection_masks: [N, S] -> select collected positions
         a_bi = a[mask]  # [num_valid, I]
 
         # Augment with a ones column so the [O, I+1] per-batch gradient matches
@@ -64,7 +64,7 @@ class ShampooCollector(HookCollectorBase):
         name = assert_type(str, module._name)
         S_shampoo_po = self.S_shampoo_dict[name]
         A_shampoo_ki = self.A_shampoo_dict[name]
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
 
         # g: [N, S, O], mask: [N, S] -> select valid positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]

--- a/bergson/hessians/tkfac.py
+++ b/bergson/hessians/tkfac.py
@@ -45,10 +45,10 @@ class TraceCovarianceCollector(HookCollectorBase):
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         """Compute activation covariance: A^T @ A."""
 
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
         assert mask is not None, "Valid mask not set for forward hook."
 
-        # a: [N, S, I], valid_masks: [N, S] -> select valid positions
+        # a: [N, S, I], collection_masks: [N, S] -> select collected positions
         a_bi = a[mask]  # [num_valid, I]
 
         # Augment with a ones column so A matches the [O, I+1] gradient layout
@@ -65,7 +65,7 @@ class TraceCovarianceCollector(HookCollectorBase):
         name = assert_type(str, module._name)
         S_tcov_po = self.S_tcov_dict[name]
         A_tcov_ki = self.A_tcov_dict[name]
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
 
         # g: [N, S, O], mask: [N, S] -> select valid positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]

--- a/bergson/huggingface.py
+++ b/bergson/huggingface.py
@@ -18,7 +18,7 @@ from transformers.training_args import TrainingArguments
 
 from bergson import AttentionConfig, GradientProcessor
 from bergson.collector.gradient_collectors import StreamingGradientCollector
-from bergson.data import create_index
+from bergson.data import column_offsets, create_index
 from bergson.gradients import AdafactorNormalizer, AdamNormalizer
 from bergson.utils.peft import detect_peft_modules
 from bergson.utils.utils import convert_dtype_to_torch
@@ -78,7 +78,8 @@ class GradientCollectorCallback(TrainerCallback):
     def write_grads(self, grad_buffer: np.memmap):
         torch.cuda.synchronize()
         for layer_name, g in self.collector.mod_grads.items():
-            grad_buffer[layer_name][self.batch_indices, :] = g.numpy()
+            lo, hi = self.grad_offsets[layer_name]
+            grad_buffer[self.batch_indices, lo:hi] = g.numpy()
 
         self.collector.mod_grads.clear()
 
@@ -119,6 +120,7 @@ class GradientCollectorCallback(TrainerCallback):
         self.grad_sizes = {
             name: math.prod(s) for name, s in self.collector.shapes().items()
         }
+        self.grad_offsets = column_offsets(self.grad_sizes)
 
         # Record forward and backward hooks
         self.collector.__enter__()

--- a/bergson/magic/data_stream.py
+++ b/bergson/magic/data_stream.py
@@ -109,7 +109,7 @@ class DataStream:
 
         indices = self.batch_rows(i)
         batch = self.dataset[indices]
-        x, y, valid_mask = pad_and_tensor(
+        x, y, valid_mask, _ = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=self.device,

--- a/bergson/query/attributor.py
+++ b/bergson/query/attributor.py
@@ -1,3 +1,4 @@
+import json
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, Literal
@@ -7,7 +8,7 @@ from torch import Tensor, nn
 
 from bergson.collector.gradient_collectors import TraceCollector
 from bergson.config import InversionConfig
-from bergson.data import load_gradients
+from bergson.data import column_offsets, load_gradients
 from bergson.gradients import GradientProcessor
 from bergson.hessians.preconditioner import (
     DensePreconditioner,
@@ -121,17 +122,20 @@ class Attributor:
             self.ordered_modules = self.faiss_index.ordered_modules
             return
 
-        # Load the gradients into memory
+        # Load the gradients into memory. The store is mapped flat rather than
+        # structured — a structured record's itemsize overflows the C-int cap
+        # above ~537M tracked fp32 params — and sliced per module by column.
         mmap = load_gradients(index_path)
-        assert mmap.dtype.names is not None
+        with (index_path / "info.json").open("r") as f:
+            grad_sizes = json.load(f)["grad_sizes"]
         # Copy gradients into device memory
         self.grads = {
-            name: numpy_to_tensor(mmap[name]).to(device=device, dtype=dtype)
-            for name in mmap.dtype.names
+            name: numpy_to_tensor(mmap[:, lo:hi]).to(device=device, dtype=dtype)
+            for name, (lo, hi) in column_offsets(grad_sizes).items()
         }
-        self.N = mmap[mmap.dtype.names[0]].shape[0]
+        self.N = len(mmap)
 
-        self.ordered_modules = mmap.dtype.names
+        self.ordered_modules = list(grad_sizes)
 
         if unit_norm:
             if self.preconditioner is not None:

--- a/bergson/query/attributor.py
+++ b/bergson/query/attributor.py
@@ -122,9 +122,6 @@ class Attributor:
             self.ordered_modules = self.faiss_index.ordered_modules
             return
 
-        # Load the gradients into memory. The store is mapped flat rather than
-        # structured — a structured record's itemsize overflows the C-int cap
-        # above ~537M tracked fp32 params — and sliced per module by column.
         mmap = load_gradients(index_path)
         with (index_path / "info.json").open("r") as f:
             grad_sizes = json.load(f)["grad_sizes"]

--- a/bergson/query/faiss_index.py
+++ b/bergson/query/faiss_index.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Protocol
 import numpy as np
 import psutil
 import torch
-from numpy.lib.recfunctions import structured_to_unstructured
 from numpy.typing import NDArray
 from tqdm import tqdm
 
 from bergson.config.config import FaissConfig
+from bergson.data import load_gradients
 from bergson.process_grads import precondition_flat_grads
 
 if TYPE_CHECKING:
@@ -83,23 +83,19 @@ def normalize_grads(
 
 def gradients_loader(root_dir: Path):
     """
-    Yield memory-mapped gradient shards stored under ``root_dir``.
+    Yield ``(gradients, module_names)`` pairs for the shards under ``root_dir``.
 
     Handles both single-shard exports (``info.json`` directly under ``root_dir``)
-    and multi-shard layouts (directories named ``*shard*``). Each yielded object
-    stays memory-mapped so downstream code can stream slices without excessive RAM.
+    and multi-shard layouts (directories named ``*shard*``). Gradients are
+    memory-mapped as ``(num_grads, total_grad_dim)``.
+    so downstream code can stream slices without excessive RAM.
     """
 
-    def load_shard(shard_dir: Path) -> np.memmap:
+    def load_shard(shard_dir: Path) -> tuple[np.memmap, list[str]]:
         with (shard_dir / "info.json").open("r") as f:
             info = json.load(f)
 
-        return np.memmap(
-            shard_dir / "gradients.bin",
-            dtype=info["dtype"],
-            mode="r",
-            shape=(info["num_grads"],),
-        )
+        return load_gradients(shard_dir), list(info["grad_sizes"])
 
     if (root_dir / "info.json").exists():
         yield load_shard(root_dir)
@@ -302,11 +298,9 @@ class FaissIndex:
             faiss.write_index(index, str(shard_path))
 
         ordered_modules = []
-        for i, grads in enumerate(tqdm(dl, desc="Loading gradients")):
+        for i, (grads, module_names) in enumerate(tqdm(dl, desc="Loading gradients")):
             if i == 0:
-                ordered_modules = list(grads.dtype.names or [])
-
-            grads = structured_to_unstructured(grads)
+                ordered_modules = module_names
 
             if i == 0:
                 validate_ram(grads, shard_sizes[-1])

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -15,6 +15,7 @@ from bergson.config.config import IndexConfig, PreprocessConfig, ScoreConfig
 from bergson.config.config_io import load_subconfig
 from bergson.data import (
     allocate_batches,
+    column_offsets,
     load_gradients,
 )
 from bergson.distributed import (
@@ -79,18 +80,15 @@ def get_query_grads(
     if not score_cfg.modules:
         score_cfg.modules = target_modules
 
-    mmap = load_gradients(Path(score_cfg.query_path), structured=False)
-
-    sizes = torch.tensor(list(grad_sizes.values()))
-    module_offsets = torch.tensor([0] + torch.cumsum(sizes, dim=0).tolist())
+    mmap = load_gradients(Path(score_cfg.query_path))
 
     # Cast to float32 only for dtypes not natively supported by numpy (e.g. bfloat16)
     needs_cast = not np.issubdtype(mmap.dtype, np.floating)
     grads: dict[str, torch.Tensor] = {}
-    for i, name in enumerate(grad_sizes.keys()):
+    for name, (lo, hi) in column_offsets(grad_sizes).items():
         if name not in target_modules:
             continue
-        sliced = mmap[:, module_offsets[i] : module_offsets[i + 1]]
+        sliced = mmap[:, lo:hi]
         if needs_cast:
             grads[name] = torch.from_numpy(sliced.astype(np.float32))
         else:

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -85,7 +85,7 @@ def per_doc_query_losses(
         for i in range(len(query_stream)):
             rows = query_stream.batch_rows(i)
             batch = ds[rows]
-            x, y, _ = pad_and_tensor(
+            x, y, _, _ = pad_and_tensor(
                 batch["input_ids"], labels=batch.get("labels"), device=device
             )
             if "doc_ids" in batch:

--- a/examples/filter_data.py
+++ b/examples/filter_data.py
@@ -361,9 +361,9 @@ def _get_attribution_indices(
     if args.query_scores:
         query_dataset = train.filter(lambda x: x["quality"] == "excellent")
     elif args.query_dataset:
-        query_dataset = load_gradient_dataset(
-            Path(args.query_dataset), structured=False
-        ).with_format("torch")
+        query_dataset = load_gradient_dataset(Path(args.query_dataset)).with_format(
+            "torch"
+        )
     else:
         query_dataset = train
 
@@ -532,7 +532,7 @@ def main(
             )
 
         build_index(args, args.index_dataset, model=sft_model_path)
-        grad_dataset = load_gradient_dataset(Path(args.index_dataset), structured=False)
+        grad_dataset = load_gradient_dataset(Path(args.index_dataset))
 
         # Split gradient dataset the same way
         grad_split = grad_dataset.train_test_split(test_size=0.05, seed=args.seed)

--- a/examples/less/less.py
+++ b/examples/less/less.py
@@ -464,7 +464,7 @@ def _compute_epoch_scores(
     eval_queries = []
     for subdir in sorted(eval_index_path.iterdir()):
         if subdir.is_dir():
-            eval_grad_ds = load_gradient_dataset(subdir, structured=False)
+            eval_grad_ds = load_gradient_dataset(subdir)
             eval_grad_ds.set_format("torch")
 
             # Compute the mean of the gradients in the evaluation subset
@@ -855,7 +855,7 @@ def main(
             train_grad_parts = []
             for subdir in sorted(epoch_train_index.iterdir()):
                 if subdir.is_dir():
-                    grad_ds = load_gradient_dataset(subdir, structured=False)
+                    grad_ds = load_gradient_dataset(subdir)
                     grad_ds = grad_ds.add_column(
                         "ds_name", [subdir.stem] * len(grad_ds)
                     )

--- a/examples/semantic/asymmetric.py
+++ b/examples/semantic/asymmetric.py
@@ -12,26 +12,27 @@ import numpy as np
 from datasets import Dataset, DatasetDict, concatenate_datasets, load_from_disk
 
 from bergson.config import IndexConfig
+from bergson.data import ModuleGradients
 from examples.semantic.data import (
     HF_ANALYSIS_MODEL,
     load_experiment_data,
 )
 
 
-def _load_gradients_as_float(grads: np.memmap, name: str) -> np.ndarray:
-    """Load a gradient field and convert from bfloat16 to float32.
+def _load_gradients_as_float(grads: ModuleGradients, name: str) -> np.ndarray:
+    """Load a module's gradients and convert from bfloat16 to float32.
 
     Args:
-        grads: Structured gradient memmap.
-        name: Field name to access.
+        grads: Module-keyed view over a flat gradient store.
+        name: Module name to access.
 
     Returns:
         Float32 numpy array.
     """
-    g = grads[name]
-    # Gradients are stored as bfloat16 (2-byte void)
-    if g.dtype == np.dtype("|V2"):
-        g = g.view(ml_dtypes.bfloat16).astype(np.float32)
+    g = np.asarray(grads[name])
+    # Gradients may be stored as bfloat16, which torch can't view directly
+    if g.dtype != np.float32:
+        g = g.astype(np.float32)
     return g
 
 
@@ -451,7 +452,7 @@ def score_asymmetric_eval(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -497,11 +498,11 @@ def score_asymmetric_eval(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -569,7 +570,7 @@ def score_asymmetric_eval(
         )
 
     # Load eval gradients
-    eval_grads = load_gradients(eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(eval_grads_path)
     eval_grad_list = []
     for name in tqdm(module_names, desc="Loading eval grads"):
         g = torch.from_numpy(_load_gradients_as_float(eval_grads, name))
@@ -707,7 +708,7 @@ def compute_style_hessian(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
 
     base_path = Path(base_path)
@@ -725,11 +726,11 @@ def compute_style_hessian(
     train_ds = _load_hf_dataset(data_path / "train.hf")
 
     train_styles = train_ds["style"]  # type: ignore[index]
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Separate indices by style
     dominant_indices = [
@@ -820,7 +821,7 @@ def score_asymmetric_eval_with_pca_projection(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -868,11 +869,11 @@ def score_asymmetric_eval_with_pca_projection(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -920,7 +921,7 @@ def score_asymmetric_eval_with_pca_projection(
         )
 
     # Load eval gradients and apply PCA projection
-    eval_grads = load_gradients(eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(eval_grads_path)
     eval_grad_list = []
 
     # Track cumulative dimension for concatenation
@@ -1146,7 +1147,7 @@ def score_majority_style_eval(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -1190,11 +1191,11 @@ def score_majority_style_eval(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -1234,7 +1235,7 @@ def score_majority_style_eval(
         )
 
     # Load eval gradients
-    eval_grads = load_gradients(majority_eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(majority_eval_grads_path)
     eval_grad_list = []
     for name in tqdm(module_names, desc="Loading eval grads"):
         g = torch.from_numpy(_load_gradients_as_float(eval_grads, name))
@@ -1316,7 +1317,7 @@ def score_summed_eval(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -1376,11 +1377,11 @@ def score_summed_eval(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -1435,8 +1436,8 @@ def score_summed_eval(
 
     # Load both eval gradient sets
     print("Loading eval gradients (minority + majority)...")
-    minority_grads = load_gradients(eval_minority_grads_path, structured=True)
-    majority_grads = load_gradients(eval_majority_grads_path, structured=True)
+    minority_grads = load_module_gradients(eval_minority_grads_path)
+    majority_grads = load_module_gradients(eval_majority_grads_path)
 
     # Sum gradients: for each eval fact, sum minority + majority style gradients
     # Align by semantic fact (identifier, field) since templates may differ
@@ -1964,7 +1965,7 @@ def score_with_inner_product(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -1990,11 +1991,11 @@ def score_with_inner_product(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -2021,10 +2022,8 @@ def score_with_inner_product(
         eval_grads_path = base_path / "eval_grads_majority"
     elif eval_style == "summed":
         # Need to sum minority + majority
-        minority_grads = load_gradients(base_path / "eval_grads", structured=True)
-        majority_grads = load_gradients(
-            base_path / "eval_grads_majority", structured=True
-        )
+        minority_grads = load_module_gradients(base_path / "eval_grads")
+        majority_grads = load_module_gradients(base_path / "eval_grads_majority")
 
         # Load eval datasets for alignment
         eval_minority_ds = _load_hf_dataset(data_path / "eval.hf")
@@ -2074,7 +2073,7 @@ def score_with_inner_product(
 
     # Load eval gradients
     print(f"Loading {eval_style} eval gradients...")
-    eval_grads = load_gradients(eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(eval_grads_path)
 
     eval_grad_list = []
     for name in tqdm(module_names, desc="Loading eval grads"):
@@ -2356,7 +2355,7 @@ def score_summed_rewrites(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -2409,11 +2408,11 @@ def score_summed_rewrites(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -2468,8 +2467,8 @@ def score_summed_rewrites(
 
     # Load both eval gradient sets
     print("Loading eval gradients (shakespeare + pirate)...")
-    shakespeare_grads = load_gradients(shakespeare_grads_path, structured=True)
-    pirate_grads = load_gradients(pirate_grads_path, structured=True)
+    shakespeare_grads = load_module_gradients(shakespeare_grads_path)
+    pirate_grads = load_module_gradients(pirate_grads_path)
 
     # Sum gradients: for each eval fact, sum shakespeare + pirate style gradients
     summed_grad_list = []
@@ -2530,7 +2529,7 @@ def score_original_style_eval(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -2569,11 +2568,11 @@ def score_original_style_eval(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -2615,7 +2614,7 @@ def score_original_style_eval(
 
     # Load original eval gradients
     print("Loading original style eval gradients...")
-    original_grads = load_gradients(original_grads_path, structured=True)
+    original_grads = load_module_gradients(original_grads_path)
 
     eval_grad_list = []
     for name in tqdm(module_names, desc="Loading original eval grads"):
@@ -2706,7 +2705,7 @@ def _score_single_style_eval(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -2748,11 +2747,11 @@ def _score_single_style_eval(
     )
 
     # Load train gradients
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -2787,7 +2786,7 @@ def _score_single_style_eval(
         )
 
     # Load eval gradients
-    eval_grads = load_gradients(grads_path, structured=True)
+    eval_grads = load_module_gradients(grads_path)
     eval_grad_list = []
     for name in tqdm(module_names, desc=f"Loading {style} eval grads"):
         g = torch.from_numpy(_load_gradients_as_float(eval_grads, name))

--- a/examples/semantic/attribute_preservation.py
+++ b/examples/semantic/attribute_preservation.py
@@ -728,7 +728,7 @@ def score_attribute_eval(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import ModuleGradients, load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -779,11 +779,11 @@ def score_attribute_eval(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -795,10 +795,10 @@ def score_attribute_eval(
             H = proc.hessians[name].to(device=device)
             h_inv[name] = damped_psd_power(H, power=-1, damping_factor=damping_factor)
 
-    def load_grad_as_float(grads: np.memmap, name: str) -> np.ndarray:
-        g = grads[name]
-        if g.dtype == np.dtype("|V2"):
-            g = g.view(ml_dtypes.bfloat16).astype(np.float32)
+    def load_grad_as_float(grads: ModuleGradients, name: str) -> np.ndarray:
+        g = np.asarray(grads[name])
+        if g.dtype != np.float32:
+            g = g.astype(np.float32)
         return g
 
     # Prepare train gradients
@@ -865,7 +865,7 @@ def score_attribute_eval(
         print(result.stdout)
 
     # Load eval gradients
-    eval_grads = load_gradients(eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(eval_grads_path)
     eval_grad_list = []
     for name in tqdm(module_names, desc="Loading eval grads"):
         g = torch.from_numpy(load_grad_as_float(eval_grads, name))
@@ -1148,7 +1148,7 @@ def score_attribute_eval_with_pca(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import ModuleGradients, load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -1202,11 +1202,11 @@ def score_attribute_eval_with_pca(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -1218,10 +1218,10 @@ def score_attribute_eval_with_pca(
             H = proc.hessians[name].to(device=device)
             h_inv[name] = damped_psd_power(H, -1.0, damping_factor=damping_factor)
 
-    def load_grad_as_float(grads: np.memmap, name: str) -> np.ndarray:
-        g = grads[name]
-        if g.dtype == np.dtype("|V2"):
-            g = g.view(ml_dtypes.bfloat16).astype(np.float32)
+    def load_grad_as_float(grads: ModuleGradients, name: str) -> np.ndarray:
+        g = np.asarray(grads[name])
+        if g.dtype != np.float32:
+            g = g.astype(np.float32)
         return g
 
     # Prepare train gradients (no PCA projection on train - only on eval)
@@ -1283,7 +1283,7 @@ def score_attribute_eval_with_pca(
         print(result.stdout)
 
     # Load eval gradients and apply PCA projection
-    eval_grads = load_gradients(eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(eval_grads_path)
     eval_grad_list = []
 
     for name in tqdm(module_names, desc="Loading and projecting eval grads"):
@@ -1510,7 +1510,7 @@ def compute_style_hessian_from_data(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import ModuleGradients, load_module_gradients
     from bergson.gradients import GradientProcessor
 
     base_path = Path(base_path)
@@ -1530,11 +1530,11 @@ def compute_style_hessian_from_data(
         train_ds = train_ds["train"]
 
     train_styles = train_ds["style"]
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Get unique styles
     unique_styles = list(set(train_styles))
@@ -1550,10 +1550,10 @@ def compute_style_hessian_from_data(
     # Load base processor
     base_proc = GradientProcessor.load(index_path)
 
-    def load_grad_as_float(grads: np.memmap, name: str) -> np.ndarray:
-        g = grads[name]
-        if g.dtype == np.dtype("|V2"):
-            g = g.view(ml_dtypes.bfloat16).astype(np.float32)
+    def load_grad_as_float(grads: ModuleGradients, name: str) -> np.ndarray:
+        g = np.asarray(grads[name])
+        if g.dtype != np.float32:
+            g = g.astype(np.float32)
         return g
 
     # Compute per-module style means and R_between
@@ -1621,7 +1621,7 @@ def compute_eval_second_moment(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import ModuleGradients, load_module_gradients
     from bergson.gradients import GradientProcessor
 
     base_path = Path(base_path)
@@ -1638,18 +1638,18 @@ def compute_eval_second_moment(
 
     print("Computing H_eval (second moment of eval gradients)...")
 
-    eval_grads = load_gradients(eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(eval_grads_path)
 
     with open(eval_grads_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     base_proc = GradientProcessor.load(index_path)
 
-    def load_grad_as_float(grads: np.memmap, name: str) -> np.ndarray:
-        g = grads[name]
-        if g.dtype == np.dtype("|V2"):
-            g = g.view(ml_dtypes.bfloat16).astype(np.float32)
+    def load_grad_as_float(grads: ModuleGradients, name: str) -> np.ndarray:
+        g = np.asarray(grads[name])
+        if g.dtype != np.float32:
+            g = g.astype(np.float32)
         return g
 
     eval_precs = {}
@@ -1757,7 +1757,7 @@ def score_majority_style_eval(
     import torch
     from tqdm import tqdm
 
-    from bergson.data import load_gradients
+    from bergson.data import ModuleGradients, load_module_gradients
     from bergson.gradients import GradientProcessor
     from bergson.utils.math import damped_psd_power
 
@@ -1798,11 +1798,11 @@ def score_majority_style_eval(
 
     # Load train gradients
     print("Loading train gradients...")
-    train_grads = load_gradients(index_path, structured=True)
+    train_grads = load_module_gradients(index_path)
 
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load hessian if specified
     h_inv = {}
@@ -1814,10 +1814,10 @@ def score_majority_style_eval(
             H = proc.hessians[name].to(device=device)
             h_inv[name] = damped_psd_power(H, power=-1, damping_factor=damping_factor)
 
-    def load_grad_as_float(grads: np.memmap, name: str) -> np.ndarray:
-        g = grads[name]
-        if g.dtype == np.dtype("|V2"):
-            g = g.view(ml_dtypes.bfloat16).astype(np.float32)
+    def load_grad_as_float(grads: ModuleGradients, name: str) -> np.ndarray:
+        g = np.asarray(grads[name])
+        if g.dtype != np.float32:
+            g = g.astype(np.float32)
         return g
 
     # Prepare train gradients
@@ -1868,7 +1868,7 @@ def score_majority_style_eval(
         print(result.stdout)
 
     # Load eval gradients
-    eval_grads = load_gradients(majority_eval_grads_path, structured=True)
+    eval_grads = load_module_gradients(majority_eval_grads_path)
     eval_grad_list = []
     for name in tqdm(module_names, desc="Loading eval grads"):
         g = torch.from_numpy(load_grad_as_float(eval_grads, name))

--- a/examples/semantic/hessians.py
+++ b/examples/semantic/hessians.py
@@ -8,27 +8,27 @@ import numpy as np
 import torch
 from tqdm import tqdm
 
-from bergson.data import load_gradients
+from bergson.data import ModuleGradients, load_module_gradients
 from bergson.gradients import GradientProcessor
 from bergson.utils.utils import numpy_to_tensor
 
 from .data import create_qwen_only_dataset
 
 
-def _load_gradients_as_float(grads: np.memmap, name: str) -> np.ndarray:
-    """Load a gradient field and convert from bfloat16 to float32.
+def _load_gradients_as_float(grads: ModuleGradients, name: str) -> np.ndarray:
+    """Load a module's gradients and convert from bfloat16 to float32.
 
     Args:
-        grads: Structured gradient memmap.
-        name: Field name to access.
+        grads: Module-keyed view over a flat gradient store.
+        name: Module name to access.
 
     Returns:
         Float32 numpy array.
     """
-    g = grads[name]
-    # Gradients are stored as bfloat16 (2-byte void)
-    if g.dtype == np.dtype("|V2"):
-        g = g.view(ml_dtypes.bfloat16).astype(np.float32)
+    g = np.asarray(grads[name])
+    # Gradients may be stored as bfloat16, which torch can't view directly
+    if g.dtype != np.float32:
+        g = g.astype(np.float32)
     return g
 
 
@@ -217,12 +217,11 @@ def compute_between_hessian_means(
     pirate_path = Path(pirate_index_path)
     shakespeare_path = Path(shakespeare_index_path)
 
-    # Load structured gradients (per-module) instead of flattened
-    print("  Loading pirate gradients (structured)...")
-    pirate_grads = load_gradients(pirate_path, structured=True)
+    print("  Loading pirate gradients (per-module)...")
+    pirate_grads = load_module_gradients(pirate_path)
 
-    print("  Loading shakespeare gradients (structured)...")
-    shakespeare_grads = load_gradients(shakespeare_path, structured=True)
+    print("  Loading shakespeare gradients (per-module)...")
+    shakespeare_grads = load_module_gradients(shakespeare_path)
 
     # Load a processor to get module names and metadata
     pirate_proc = GradientProcessor.load(pirate_path)
@@ -233,7 +232,6 @@ def compute_between_hessian_means(
 
     print(f"  Computing per-module R_between for {len(module_names)} modules...")
     for name in tqdm(module_names):
-        # Get gradients for this module (numpy structured array access)
         pirate_mod = numpy_to_tensor(pirate_grads[name]).float()
         shakespeare_mod = numpy_to_tensor(shakespeare_grads[name]).float()
 
@@ -346,11 +344,11 @@ def compute_summed_loss_hessian(
     pirate_path = Path(pirate_index_path)
     shakespeare_path = Path(shakespeare_index_path)
 
-    # Load structured gradients
+    # Load per-module gradients
     print("  Loading pirate gradients...")
-    pirate_grads = load_gradients(pirate_path, structured=True)
+    pirate_grads = load_module_gradients(pirate_path)
     print("  Loading shakespeare gradients...")
-    shakespeare_grads = load_gradients(shakespeare_path, structured=True)
+    shakespeare_grads = load_module_gradients(shakespeare_path)
 
     # Load datasets to match facts
     pirate_ds = load_from_disk(
@@ -463,11 +461,11 @@ def compute_pca_style_subspace(
     pirate_path = Path(pirate_index_path)
     shakespeare_path = Path(shakespeare_index_path)
 
-    # Load structured gradients
+    # Load per-module gradients
     print("  Loading pirate gradients...")
-    pirate_grads = load_gradients(pirate_path, structured=True)
+    pirate_grads = load_module_gradients(pirate_path)
     print("  Loading shakespeare gradients...")
-    shakespeare_grads = load_gradients(shakespeare_path, structured=True)
+    shakespeare_grads = load_module_gradients(shakespeare_path)
 
     # Load datasets to match facts
     pirate_ds = load_from_disk("data/facts_dataset_pirate-Qwen3-8B-Base.hf")
@@ -600,9 +598,9 @@ def report_pca_variance(
 
     print("Computing PCA variance analysis...")
     print("  Loading pirate gradients...")
-    pirate_grads = load_gradients(pirate_path, structured=True)
+    pirate_grads = load_module_gradients(pirate_path)
     print("  Loading shakespeare gradients...")
-    shakespeare_grads = load_gradients(shakespeare_path, structured=True)
+    shakespeare_grads = load_module_gradients(shakespeare_path)
 
     pirate_ds = load_from_disk("data/facts_dataset_pirate-Qwen3-8B-Base.hf")
     shakespeare_ds = load_from_disk("data/facts_dataset_shakespeare-Qwen3-8B-Base.hf")
@@ -786,14 +784,14 @@ def compute_eval_hessian(
 
     eval_path = Path(eval_grads_path)
 
-    # Load structured gradients
+    # Load per-module gradients
     print("  Loading eval gradients...")
-    eval_grads = load_gradients(eval_path, structured=True)
+    eval_grads = load_module_gradients(eval_path)
 
     # Get module names from info.json
     with open(eval_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Load a reference processor to get metadata
     # (use reference if eval doesn't have precs)
@@ -863,11 +861,11 @@ def compute_train_eval_mixed_hessian(
     train_path = Path(train_index_path)
     eval_path = Path(eval_grads_path)
 
-    # Load structured gradients
+    # Load per-module gradients
     print("  Loading train gradients...")
-    train_grads = load_gradients(train_path, structured=True)
+    train_grads = load_module_gradients(train_path)
     print("  Loading eval gradients...")
-    eval_grads = load_gradients(eval_path, structured=True)
+    eval_grads = load_module_gradients(eval_path)
 
     # Load a processor to get metadata and module names
     base_proc = GradientProcessor.load(train_path)
@@ -875,7 +873,7 @@ def compute_train_eval_mixed_hessian(
     # Get module names from info.json
     with open(train_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
 
     # Compute per-module mixed second moment matrices
     mixed_precs = {}

--- a/examples/semantic/metrics.py
+++ b/examples/semantic/metrics.py
@@ -69,13 +69,13 @@ def compute_metrics_groupwise(
 
     # Load gradient dataset with metadata
     print("Loading gradient dataset...")
-    grad_ds = load_gradient_dataset(index_path, structured=True)
+    grad_ds = load_gradient_dataset(index_path)
     print(f"  Loaded {len(grad_ds)} rows")
 
-    # Get gradient column names
+    # Get gradient module names
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    grad_columns = info["dtype"]["names"]
+    grad_columns = list(info["grad_sizes"])
     print(f"  Gradient columns: {len(grad_columns)} modules")
 
     # Build style lookup (Qwen only, no Llama)
@@ -117,7 +117,7 @@ def compute_metrics_groupwise(
 
     # Load gradients directly from memmap (much faster than HF dataset)
     print("Loading gradients from memmap...")
-    grad_mmap = load_gradients(index_path, structured=False)
+    grad_mmap = load_gradients(index_path)
     # Select only the kept rows
     all_grads = torch.from_numpy(grad_mmap[keep_indices].copy()).float()
     print(f"  Gradient tensor shape: {all_grads.shape}")

--- a/examples/semantic/scoring.py
+++ b/examples/semantic/scoring.py
@@ -9,7 +9,7 @@ import torch
 from tqdm import tqdm
 
 from bergson import IndexConfig
-from bergson.data import load_gradients
+from bergson.data import load_gradients, load_module_gradients
 from bergson.gradients import GradientProcessor
 from bergson.process_grads import mix_autocorrelation_matrices
 from bergson.utils.math import damped_psd_power
@@ -87,12 +87,12 @@ def compute_scores_fast(
 
     # Load gradients
     print("Loading gradients from index...")
-    grads = load_gradients(index_path, structured=True)
+    grads = load_module_gradients(index_path)
 
     # Get module names
     with open(index_path / "info.json") as f:
         info = json.load(f)
-    module_names = info["dtype"]["names"]
+    module_names = list(info["grad_sizes"])
     n_samples = info["num_grads"]
 
     print(f"  {n_samples} samples, {len(module_names)} modules")
@@ -154,9 +154,7 @@ def compute_scores_fast(
     else:
         # No preconditioning - just concatenate modules
         print("Concatenating gradients (no preconditioning)...")
-        all_grads = torch.from_numpy(
-            load_gradients(index_path, structured=False).copy()
-        ).float()
+        all_grads = torch.from_numpy(load_gradients(index_path).copy()).float()
 
         print(f"Gradient matrix shape: {all_grads.shape}")
 

--- a/examples/semantics_experiment.py
+++ b/examples/semantics_experiment.py
@@ -37,7 +37,7 @@ if not run_path.exists():
 # Check whether items with the same subject value have a greater cosine similarity score
 # Than items from dissimilar subjects
 
-gradient_ds = load_gradient_dataset(run_path, structured=False)
+gradient_ds = load_gradient_dataset(run_path)
 
 subjects = gradient_ds["subject"]
 

--- a/notebooks/style_ablation.ipynb
+++ b/notebooks/style_ablation.ipynb
@@ -21,7 +21,7 @@
    "cell_type": "markdown",
    "id": "0daba9a3e5df",
    "metadata": {},
-   "source": "## 1. Load the Dataset\n\nThe dataset is hosted on HuggingFace with pre-computed style rewrites. It has five splits:\n\n| Split | Description |\n|-------|-------------|\n| `train` | 13,500 samples — 95% shakespeare (dominant), 5% pirate (minority) |\n| `eval` | 4,500 samples — exclusive facts in pirate style (forces semantic matching) |\n| `eval_majority_style` | Same facts as eval but in shakespeare style (control) |\n| `eval_original_style` | Same facts in original unstyled text |\n| `eval_pirate_style` | Same facts in pirate style |\n\nEach sample has: `reworded` (stylized text), `fact` (original), `style`, `identifier` (which person), `field` (which attribute), and `template` (which phrasing)."
+   "source": "## 1. Load the Dataset\n\nThe dataset is hosted on HuggingFace with pre-computed style rewrites. It has five splits:\n\n| Split | Description |\n|-------|-------------|\n| `train` | 13,500 samples \u2014 95% shakespeare (dominant), 5% pirate (minority) |\n| `eval` | 4,500 samples \u2014 exclusive facts in pirate style (forces semantic matching) |\n| `eval_majority_style` | Same facts as eval but in shakespeare style (control) |\n| `eval_original_style` | Same facts in original unstyled text |\n| `eval_pirate_style` | Same facts in pirate style |\n\nEach sample has: `reworded` (stylized text), `fact` (original), `style`, `identifier` (which person), `field` (which attribute), and `template` (which phrasing)."
   },
   {
    "cell_type": "code",
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "id": "0661c10f9e92",
    "metadata": {},
-   "source": "### Understand the dataset design\n\nThe key insight is **disjoint partitioning**: some facts only appear in the dominant (shakespeare) style in training. When we query with a pirate-style version of that fact, the *only* way to find the right training sample is semantic matching — style matching would point to the wrong samples.\n\n- **Exclusive facts** (~50%): Only in dominant style in training. Eval queries use the minority style for these.\n- **Shared facts** (~50%): In both styles. These are the \"decoys\" that style-matching would find."
+   "source": "### Understand the dataset design\n\nThe key insight is **disjoint partitioning**: some facts only appear in the dominant (shakespeare) style in training. When we query with a pirate-style version of that fact, the *only* way to find the right training sample is semantic matching \u2014 style matching would point to the wrong samples.\n\n- **Exclusive facts** (~50%): Only in dominant style in training. Eval queries use the minority style for these.\n- **Shared facts** (~50%): In both styles. These are the \"decoys\" that style-matching would find."
   },
   {
    "cell_type": "code",
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "id": "6b66599db492",
    "metadata": {},
-   "source": "## 2. Build the Gradient Index (Training Set)\n\nThis is the most expensive step: we collect per-sample gradients for every training example. bergson uses hook-based gradient collection — for each linear layer, it captures `P = g^T @ a` (the outer product of the output gradient and the input activation), optionally projected to lower dimension.\n\nWe use `bergson build` via the CLI, which handles:\n1. Loading the model and tokenizer\n2. Discovering all linear layers\n3. Token-budget batching (packing samples to maximize GPU utilization)\n4. Per-sample gradient collection with random projection\n5. Computing second-moment hessians"
+   "source": "## 2. Build the Gradient Index (Training Set)\n\nThis is the most expensive step: we collect per-sample gradients for every training example. bergson uses hook-based gradient collection \u2014 for each linear layer, it captures `P = g^T @ a` (the outer product of the output gradient and the input activation), optionally projected to lower dimension.\n\nWe use `bergson build` via the CLI, which handles:\n1. Loading the model and tokenizer\n2. Discovering all linear layers\n3. Token-budget batching (packing samples to maximize GPU utilization)\n4. Per-sample gradient collection with random projection\n5. Computing second-moment hessians"
   },
   {
    "cell_type": "code",
@@ -149,7 +149,7 @@
    "cell_type": "markdown",
    "id": "18fa438d7142",
    "metadata": {},
-   "source": "### Inspect the index\n\nLet's look at what `bergson build` produced. The gradients are stored as a memory-mapped structured numpy array — each field corresponds to a linear layer in the model."
+   "source": "### Inspect the index\n\nLet's look at what `bergson build` produced. The gradients are stored as a memory-mapped structured numpy array \u2014 each field corresponds to a linear layer in the model."
   },
   {
    "cell_type": "code",
@@ -162,7 +162,7 @@
     "\n",
     "import numpy as np\n",
     "\n",
-    "from bergson.data import load_gradients\n",
+    "from bergson.data import load_module_gradients\n",
     "\n",
     "# Load index metadata\n",
     "with open(Path(INDEX_PATH) / \"info.json\") as f:\n",
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "id": "3c933806c577",
    "metadata": {},
-   "source": "## 4. Load Gradients and Score\n\nNow we do the core attribution step manually. For each eval query, we compute cosine similarity against all training gradients:\n\n```\nscore(query, train_i) = normalize(g_query) · normalize(g_train_i)\n```\n\nThe gradients are stored per-module in bfloat16. We'll convert to float32 and concatenate across modules to get a single vector per sample."
+   "source": "## 4. Load Gradients and Score\n\nNow we do the core attribution step manually. For each eval query, we compute cosine similarity against all training gradients:\n\n```\nscore(query, train_i) = normalize(g_query) \u00b7 normalize(g_train_i)\n```\n\nThe gradients are stored per-module in bfloat16. We'll convert to float32 and concatenate across modules to get a single vector per sample."
   },
   {
    "cell_type": "code",
@@ -247,11 +247,11 @@
     "\n",
     "def load_grads_as_float(grads_path, module_names):\n",
     "    \"\"\"Load structured gradients and concatenate across modules as float32.\"\"\"\n",
-    "    grads = load_gradients(grads_path, structured=True)\n",
+    "    grads = load_module_gradients(grads_path)\n",
     "    parts = []\n",
     "    for name in module_names:\n",
     "        g = grads[name]\n",
-    "        # Stored as bfloat16 (2-byte void) — convert to float32\n",
+    "        # Stored as bfloat16 (2-byte void) \u2014 convert to float32\n",
     "        if g.dtype == np.dtype(\"|V2\"):\n",
     "            g = g.view(ml_dtypes.bfloat16).astype(np.float32)\n",
     "        parts.append(g)\n",
@@ -371,14 +371,14 @@
     "print(f\"  Top-1 Semantic Accuracy: {m['top1_semantic']:.2%}\")\n",
     "print(f\"  Top-5 Semantic Recall:   {m['top5_semantic_recall']:.2%}\")\n",
     "print(f\"  Top-1 Style Leakage:     {m['top1_leak']:.2%}\")\n",
-    "print(\"\\n→ High leakage = attribution is matching on style, not semantics\")"
+    "print(\"\\n\u2192 High leakage = attribution is matching on style, not semantics\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "06853b033b1d",
    "metadata": {},
-   "source": "## 6. Majority Style Control\n\nAs a sanity check, we score using majority-style (shakespeare) eval queries. Since these match the training distribution, there's no style mismatch — attribution should work well."
+   "source": "## 6. Majority Style Control\n\nAs a sanity check, we score using majority-style (shakespeare) eval queries. Since these match the training distribution, there's no style mismatch \u2014 attribution should work well."
   },
   {
    "cell_type": "code",
@@ -397,14 +397,14 @@
     "print(f\"  Top-1 Semantic Accuracy: {m['top1_semantic']:.2%}\")\n",
     "print(f\"  Top-5 Semantic Recall:   {m['top5_semantic_recall']:.2%}\")\n",
     "print(f\"  Top-1 Style Leakage:     {m['top1_leak']:.2%}\")\n",
-    "print(\"\\n→ This is the upper bound — when styles match, attribution works\")"
+    "print(\"\\n\u2192 This is the upper bound \u2014 when styles match, attribution works\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "5028698312ca",
    "metadata": {},
-   "source": "## 7. Hessian Strategies\n\nPreconditioning transforms gradients before scoring: `score(q, t) = (g_q @ H^{-1}) · g_t`\n\nThis can downweight common/systematic directions.\n\n### Train second moment (standard influence functions)\n`H = G_train^T @ G_train` — the standard influence function hessian (an approximation to the Fisher information matrix). This downweights directions that are common across training data, which often correspond to style rather than content."
+   "source": "## 7. Hessian Strategies\n\nPreconditioning transforms gradients before scoring: `score(q, t) = (g_q @ H^{-1}) \u00b7 g_t`\n\nThis can downweight common/systematic directions.\n\n### Train second moment (standard influence functions)\n`H = G_train^T @ G_train` \u2014 the standard influence function hessian (an approximation to the Fisher information matrix). This downweights directions that are common across training data, which often correspond to style rather than content."
   },
   {
    "cell_type": "code",
@@ -433,7 +433,7 @@
     "    Returns:\n",
     "        (n_eval, total_dim) numpy array of preconditioned gradients\n",
     "    \"\"\"\n",
-    "    grads = load_gradients(eval_grads_path, structured=True)\n",
+    "    grads = load_module_gradients(eval_grads_path)\n",
     "    parts = []\n",
     "\n",
     "    for name in module_names:\n",
@@ -532,7 +532,7 @@
    "cell_type": "markdown",
    "id": "7864b419e1b2",
    "metadata": {},
-   "source": "### Influence Functions + PCA Ablation\n\nCombining the train second moment hessian with PCA ablation gives the best results — but requires holding both the preconditioned and raw gradient matrices in RAM simultaneously. **This cell requires more RAM than Colab Free provides** (~25 GB); skip it if running on a free T4."
+   "source": "### Influence Functions + PCA Ablation\n\nCombining the train second moment hessian with PCA ablation gives the best results \u2014 but requires holding both the preconditioned and raw gradient matrices in RAM simultaneously. **This cell requires more RAM than Colab Free provides** (~25 GB); skip it if running on a free T4."
   },
   {
    "cell_type": "code",
@@ -629,13 +629,13 @@
    "cell_type": "markdown",
    "id": "35b395d22e62",
    "metadata": {},
-   "source": "## 10. Key Takeaways\n\nThe fundamental insight is that **the problem isn't about finding the right hessian** — it's about the **query gradient itself being a style outlier**.\n\nWhen the eval data is in a minority style (5% of training), its gradients are dominated by style-specific components that match the small minority-style portion of training rather than the semantically-correct majority-style matches.\n\n### Strategy descriptions\n\n| Strategy | Description |\n|----------|-------------|\n| `no_hess` | Bare gradient cosine similarity. Style dominates. |\n| `majority_no_hess` | Query in the majority style — no style mismatch. Upper bound. |\n| `influence_fn` | Standard influence function hessian (`G_train^T @ G_train`). |\n| `pca_k100` | Project out top-100 PCA components from eval gradients. |\n| `influence_fn_pca_k100` | Standard influence functions + top-100 PCA ablation. |"
+   "source": "## 10. Key Takeaways\n\nThe fundamental insight is that **the problem isn't about finding the right hessian** \u2014 it's about the **query gradient itself being a style outlier**.\n\nWhen the eval data is in a minority style (5% of training), its gradients are dominated by style-specific components that match the small minority-style portion of training rather than the semantically-correct majority-style matches.\n\n### Strategy descriptions\n\n| Strategy | Description |\n|----------|-------------|\n| `no_hess` | Bare gradient cosine similarity. Style dominates. |\n| `majority_no_hess` | Query in the majority style \u2014 no style mismatch. Upper bound. |\n| `influence_fn` | Standard influence function hessian (`G_train^T @ G_train`). |\n| `pca_k100` | Project out top-100 PCA components from eval gradients. |\n| `influence_fn_pca_k100` | Standard influence functions + top-100 PCA ablation. |"
   },
   {
    "cell_type": "markdown",
    "id": "c6cb8ed44cd8",
    "metadata": {},
-   "source": "## 11. Try It Yourself\n\nThe cells above expose all the building blocks. Here are some things to experiment with:\n\n- **Change the PCA ablation rank**: Try different `k` values in `pca_ablate_eval` — smaller k removes less style signal, larger k risks removing semantic signal too\n- **Change the projection dimension**: Try `PROJECTION_DIM = 0` (full gradients) or `32` and re-run\n- **Try different damping values**: The `damping` parameter in `apply_hessian_per_module` controls regularization strength\n- **Build a custom hessian**: Use the gradient loading code to compute any matrix `H` and pass it to `apply_hessian_per_module`\n- **Change the model**: Try a larger model like `Qwen/Qwen3-1.7B-Base` (needs ~8GB VRAM) to see if the effect scales"
+   "source": "## 11. Try It Yourself\n\nThe cells above expose all the building blocks. Here are some things to experiment with:\n\n- **Change the PCA ablation rank**: Try different `k` values in `pca_ablate_eval` \u2014 smaller k removes less style signal, larger k risks removing semantic signal too\n- **Change the projection dimension**: Try `PROJECTION_DIM = 0` (full gradients) or `32` and re-run\n- **Try different damping values**: The `damping` parameter in `apply_hessian_per_module` controls regularization strength\n- **Build a custom hessian**: Use the gradient loading code to compute any matrix `H` and pass it to `apply_hessian_per_module`\n- **Change the model**: Try a larger model like `Qwen/Qwen3-1.7B-Base` (needs ~8GB VRAM) to see if the effect scales"
   },
   {
    "cell_type": "code",

--- a/tests/ekfac_tests/compute_ekfac_ground_truth.py
+++ b/tests/ekfac_tests/compute_ekfac_ground_truth.py
@@ -343,19 +343,19 @@ def compute_covariance(
 
     for sl in tqdm(batches, desc=f"Rank {rank} covariances"):
         batch = data[sl]
-        x, y, valid_masks = pad_and_tensor(
+        x, y, _, collection_mask = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=device,
         )
 
-        total_processed += valid_masks.sum()
+        total_processed += collection_mask.sum()
 
         # Run both collectors simultaneously during the same forward/backward pass
         # This ensures they see exactly the same gradients
-        with collector.with_batch(valid_masks):
+        with collector.with_batch(collection_mask):
             if ekfac_collector is not None:
-                ekfac_ctx = ekfac_collector.with_batch(valid_masks)
+                ekfac_ctx = ekfac_collector.with_batch(collection_mask)
             else:
                 ekfac_ctx = None
 
@@ -643,15 +643,15 @@ def compute_eigenvalue_correction_amortized(
 
     for sl in tqdm(batches, desc=f"Rank {rank} eigenvalue corrections"):
         batch = data[sl]
-        x, y, valid_masks = pad_and_tensor(
+        x, y, _, collection_mask = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=device,
         )
 
-        total_processed += valid_masks.sum()
+        total_processed += collection_mask.sum()
 
-        with collector.with_batch(valid_masks):
+        with collector.with_batch(collection_mask):
             logits = model(x).logits
             losses = F.cross_entropy(
                 logits[:, :-1].reshape(-1, logits.size(-1)),

--- a/tests/ekfac_tests/ground_truth/collector.py
+++ b/tests/ekfac_tests/ground_truth/collector.py
@@ -24,7 +24,7 @@ class GroundTruthCovarianceCollector(HookCollectorBase):
 
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         name = assert_type(str, module._name)
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
 
         # a: [N, S, I], valid_masks: [N, S] -> select valid positions
         if mask is not None:
@@ -41,7 +41,7 @@ class GroundTruthCovarianceCollector(HookCollectorBase):
 
     def backward_hook(self, module: nn.Module, g: Tensor) -> None:
         name = assert_type(str, module._name)
-        mask = self._current_valid_mask
+        mask = self._current_collection_mask
 
         # g: [N, S, O], valid_masks: [N, S] -> select valid positions
         if mask is not None:

--- a/tests/ekfac_tests/test_factored_preconditioner.py
+++ b/tests/ekfac_tests/test_factored_preconditioner.py
@@ -17,7 +17,7 @@ import torch
 from safetensors.torch import load_file, save_file
 
 from bergson.config import InversionConfig
-from bergson.data import create_index, load_gradients
+from bergson.data import create_index, load_module_gradients
 from bergson.hessians.apply_hessian import EkfacApplicator, EkfacConfig
 from bergson.hessians.inversion import INVERSIONS
 from bergson.hessians.preconditioner import FactoredPreconditioner
@@ -25,7 +25,7 @@ from bergson.hessians.sharded_computation import shard_bounds
 
 
 def _make_query_gradients(query_path: str, grad_sizes: dict[str, int], num_grads: int):
-    """Write a small structured query-gradient index with random gradients."""
+    """Write a small query-gradient index with random gradients."""
     index = create_index(
         root=Path(query_path),
         num_grads=num_grads,
@@ -33,8 +33,7 @@ def _make_query_gradients(query_path: str, grad_sizes: dict[str, int], num_grads
         dtype=np.float32,
     )
     rng = np.random.default_rng(0)
-    for name, size in grad_sizes.items():
-        index[name][:] = rng.standard_normal((num_grads, size)).astype(np.float32)
+    index[:] = rng.standard_normal(index.shape).astype(np.float32)
     index.flush()
 
 
@@ -54,7 +53,7 @@ def _apply(
     )
     inversion_cfg = InversionConfig(inversion=inversion, damping_factor=damping_factor)
     EkfacApplicator(cfg, inversion_cfg=inversion_cfg).compute_ivhp_sharded()
-    return load_gradients(out_path)
+    return load_module_gradients(out_path)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -93,7 +92,7 @@ def test_factored_matches_ekfac_applicator(
     }
 
     # In-memory query gradients, matching what the Attributor holds.
-    src = load_gradients(query_path)
+    src = load_module_gradients(query_path)
     grads = {
         name: torch.from_numpy(np.asarray(src[name][:])).float() for name in grad_sizes
     }
@@ -128,7 +127,7 @@ def test_two_sided_factored_equals_full_inverse(ekfac_results_path: str, tmp_pat
     num_grads = 3
     query_path = str(tmp_path / "query")
     _make_query_gradients(query_path, grad_sizes, num_grads)
-    src = load_gradients(query_path)
+    src = load_module_gradients(query_path)
     grads = {
         name: torch.from_numpy(np.asarray(src[name][:])).float() for name in grad_sizes
     }

--- a/tests/ekfac_tests/test_inversion.py
+++ b/tests/ekfac_tests/test_inversion.py
@@ -14,13 +14,13 @@ import torch
 from safetensors.torch import load_file
 
 from bergson.config import InversionConfig
-from bergson.data import create_index, load_gradients
+from bergson.data import create_index, load_module_gradients
 from bergson.hessians.apply_hessian import EkfacApplicator, EkfacConfig
 from bergson.hessians.inversion import INVERSIONS
 
 
 def _make_query_gradients(query_path: str, grad_sizes: dict[str, int], num_grads: int):
-    """Write a small structured query-gradient index with random gradients."""
+    """Write a small query-gradient index with random gradients."""
     index = create_index(
         root=Path(query_path),
         num_grads=num_grads,
@@ -28,8 +28,7 @@ def _make_query_gradients(query_path: str, grad_sizes: dict[str, int], num_grads
         dtype=np.float32,
     )
     rng = np.random.default_rng(0)
-    for name, size in grad_sizes.items():
-        index[name][:] = rng.standard_normal((num_grads, size)).astype(np.float32)
+    index[:] = rng.standard_normal(index.shape).astype(np.float32)
     index.flush()
 
 
@@ -49,7 +48,7 @@ def _apply(
     )
     inversion_cfg = InversionConfig(inversion=inversion, damping_factor=damping_factor)
     EkfacApplicator(cfg, inversion_cfg=inversion_cfg).compute_ivhp_sharded()
-    return load_gradients(out_path)
+    return load_module_gradients(out_path)
 
 
 def test_inversion_methods_apply(ekfac_results_path: str, tmp_path):

--- a/tests/ekfac_tests/test_masked_prompt_covariance.py
+++ b/tests/ekfac_tests/test_masked_prompt_covariance.py
@@ -1,0 +1,155 @@
+"""Regression test: KFAC covariance accumulators must include masked/prompt
+positions, not just the loss-masked completion.
+
+``g_t`` (the gradient of the loss w.r.t. a module's output at position ``t``)
+is generally nonzero at prompt positions too, because completion-token losses
+backprop through them via causal attention. The activation/gradient
+covariances (A_cov, S_cov) that KFAC/EKFAC use to approximate the Fisher/GGN
+should therefore be accumulated over every real (non-padding) position except
+the last, exactly like the per-token gradient rows tested in
+``tests/test_attribute_tokens.py::test_masked_prompt_token_grads_cover_all_positions``.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from bergson.config import HessianConfig, IndexConfig
+from bergson.hessians.hessian_approximations import collect_hessians
+from bergson.utils.utils import get_device
+from tests.ekfac_tests.test_utils import load_sharded_covariances
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_kfac_covariance_covers_all_positions(tmp_path, model):
+    """A_cov/S_cov must match a reference computed over every real position
+    (prompt + completion), not just the completion the loss is masked to."""
+    from datasets import Dataset
+
+    device = torch.device(get_device(0))
+    model = model.float().to(device)
+
+    input_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    # Leading 6 positions are prompt (masked), trailing 4 are the completion.
+    labels = [-100, -100, -100, -100, -100, -100, 7, 8, 9, 10]
+    length = len(input_ids)
+
+    ds = Dataset.from_dict(
+        {
+            "input_ids": [input_ids],
+            "labels": [labels],
+            "length": [length],
+        }
+    )
+
+    target_modules = {
+        name
+        for name, module in model.base_model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+    }
+
+    index_cfg = IndexConfig(
+        run_path=str(tmp_path / "run"),
+        loss_reduction="sum",
+        include_bias=False,
+    )
+    index_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+    hessian_cfg = HessianConfig(
+        method="kfac", hessian_dtype="fp32", use_dataset_labels=True
+    )
+
+    collect_hessians(
+        model=model,
+        data=ds,
+        index_cfg=index_cfg,
+        batches=[[0]],
+        target_modules=target_modules,
+        hessian_cfg=hessian_cfg,
+    )
+
+    a_cov = load_sharded_covariances(index_cfg.partial_run_path / "activation_sharded")
+    s_cov = load_sharded_covariances(index_cfg.partial_run_path / "gradient_sharded")
+
+    # --- Independent reference: capture g (output grad) and a (input
+    # activation) for every target module in a single backward, matching
+    # fwd_bwd_hessian_factory's use_dataset_labels=True loss exactly.
+    x = torch.tensor([input_ids], device=device)
+    y = torch.tensor([labels], device=device)
+
+    cap: dict[str, dict] = {}
+    handles = []
+    for n in target_modules:
+        m = model.base_model.get_submodule(n)
+        handles.append(
+            m.register_forward_hook(
+                lambda _mod, inp, _out, n=n: cap.setdefault(n, {}).update(
+                    a=inp[0].detach()
+                )
+            )
+        )
+        handles.append(
+            m.register_full_backward_hook(
+                lambda _mod, _gi, go, n=n: cap.setdefault(n, {}).update(
+                    g=go[0].detach()
+                )
+            )
+        )
+    model.zero_grad(set_to_none=True)
+    logits = model(x).logits[:, :-1]
+    losses = F.cross_entropy(
+        logits.reshape(-1, logits.size(-1)),
+        y[:, 1:].reshape(-1),
+        reduction="none",
+    ).reshape_as(y[:, 1:])
+    losses.sum(1).sum().backward()  # loss_reduction="sum" -> denom=1.0
+    for h in handles:
+        h.remove()
+
+    max_prompt_frac = 0.0
+    for n in target_modules:
+        a_full = cap[n]["a"][0].double()  # [S, I]
+        g_full = cap[n]["g"][0].double()  # [S, O]
+
+        # Every real position but the last (length - 1 rows), independent of
+        # the completion mask.
+        a_ref = a_full[: length - 1]
+        g_ref = g_full[: length - 1]
+        a_cov_ref = a_ref.mT @ a_ref
+        s_cov_ref = g_ref.mT @ g_ref
+
+        # Completion-only reference, for the "prompt really contributes" check.
+        vmask = torch.zeros(length, dtype=torch.bool, device=device)
+        vmask[:-1] = y[0, 1:] != -100
+        g_comp = g_full * vmask.unsqueeze(-1)
+        s_cov_comp = g_comp.mT @ g_comp
+
+        torch.testing.assert_close(
+            a_cov[n].double().cpu(),
+            a_cov_ref.cpu(),
+            atol=1e-3,
+            rtol=1e-3,
+            msg=f"module {n}: activation covariance must cover all real "
+            f"positions, not just the completion",
+        )
+        torch.testing.assert_close(
+            s_cov[n].double().cpu(),
+            s_cov_ref.cpu(),
+            atol=1e-3,
+            rtol=1e-3,
+            msg=f"module {n}: gradient covariance must cover all real "
+            f"positions, not just the completion",
+        )
+        max_prompt_frac = max(
+            max_prompt_frac,
+            (
+                (s_cov_ref.cpu() - s_cov_comp.cpu()).norm()
+                / s_cov_ref.cpu().norm().clamp_min(1e-12)
+            ).item(),
+        )
+
+    # Prompt positions genuinely contribute, so the fix is materially
+    # different from the old completion-only behavior.
+    assert max_prompt_frac > 0.1, (
+        f"expected a substantial prompt-position contribution to the gradient "
+        f"covariance, got max fraction {max_prompt_frac:.4f}"
+    )

--- a/tests/test_attribute_tokens.py
+++ b/tests/test_attribute_tokens.py
@@ -37,7 +37,9 @@ def test_compute_num_token_grads_no_labels():
 
 
 def test_compute_num_token_grads_with_labels():
-    """Only positions where labels[t+1] != -100 produce gradients."""
+    """Every real position produces a gradient row (length - 1), regardless of
+    the label mask: g_t is nonzero even at prompt positions, so per-token rows
+    cover all positions and sum to the per-doc gradient."""
     ds = Dataset.from_dict(
         {
             "input_ids": [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
@@ -46,13 +48,13 @@ def test_compute_num_token_grads_with_labels():
         }
     )
     sl = compute_num_token_grads(ds)
-    # first:  labels[1:] = [-100, 3, 4, 5]  → 3 valid
-    # second: labels[1:] = [7, -100, 9, 10] → 3 valid
-    np.testing.assert_array_equal(sl, [3, 3])
+    # length - 1, independent of where the completion mask falls
+    np.testing.assert_array_equal(sl, [4, 4])
 
 
 def test_compute_num_token_grads_all_masked():
-    """All labels -100 → zero valid positions."""
+    """Even with all labels -100 we store length - 1 rows (they carry zero
+    gradient, but the row count stays position-based, not label-based)."""
     ds = Dataset.from_dict(
         {
             "input_ids": [[1, 2, 3]],
@@ -61,7 +63,7 @@ def test_compute_num_token_grads_all_masked():
         }
     )
     sl = compute_num_token_grads(ds)
-    np.testing.assert_array_equal(sl, [0])
+    np.testing.assert_array_equal(sl, [2])
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +281,8 @@ def test_token_build_e2e(tmp_path: Path, model, dataset):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_token_build_with_labels(tmp_path: Path, model):
-    """Build with partial labels — only assistant tokens get gradients."""
+    """Build with partial labels — per-token rows cover every real position
+    (length - 1), not just the completion, so they sum to the per-doc grad."""
     model = model.float()
     dataset = Dataset.from_dict(
         {
@@ -311,13 +314,12 @@ def test_token_build_with_labels(tmp_path: Path, model):
 
     tg = TokenGradients(cfg.partial_run_path)
 
-    # first example: labels[1:] = [-100, 3, 4, 5] → 3 valid
-    assert tg.num_token_grads[0] == 3
-    assert tg[0].shape[0] == 3
+    # length - 1 rows per example, independent of the completion mask
+    assert tg.num_token_grads[0] == 4
+    assert tg[0].shape[0] == 4
 
-    # second example: labels[1:] = [7, -100, 9, 10] → 3 valid
-    assert tg.num_token_grads[1] == 3
-    assert tg[1].shape[0] == 3
+    assert tg.num_token_grads[1] == 4
+    assert tg[1].shape[0] == 4
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -825,4 +827,145 @@ def test_trackstar_token_scores_sum_to_sequence_scores_on_disk(
                 f"Example {i}: on-disk token sum {tok_sum:.6e} != "
                 f"on-disk per-doc score {seq_scores[i]:.6e}"
             ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Masked-prompt semantics: per-token rows cover ALL positions and sum to the
+# per-document gradient (== the autograd gradient of the completion-masked loss)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_masked_prompt_token_grads_cover_all_positions(tmp_path, model):
+    """With a prompt mask there is ONE mask: the loss mask. The per-doc gradient
+    is the true autograd gradient of the completion-masked loss, which includes
+    prompt-position contributions (completion losses backprop through the prompt
+    via causal attention).
+
+    Per-token gradients cover EVERY real position (prompt + completion), so:
+      * there are ``length - 1`` rows per example, and
+      * the rows sum to the per-doc gradient == the autograd gradient.
+
+    The test also checks that the prompt genuinely contributes (per-token sum !=
+    completion-only sum), so the all-positions behavior is materially different
+    from a completion-only decomposition -- i.e. masked positions really are
+    included.
+    """
+    model = model.float()
+
+    # Prompt/completion mask: the leading 6 positions are prompt (labels == -100),
+    # the trailing 4 are the completion.
+    masked = Dataset.from_dict(
+        {
+            "input_ids": [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
+            "labels": [[-100, -100, -100, -100, -100, -100, 7, 8, 9, 10]],
+            "length": [10],
+        }
+    )
+
+    target_modules = {
+        name
+        for name, module in model.base_model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+    }
+    processor = GradientProcessor(projection_dim=None)  # raw grads, no projection
+
+    seq_collector = _collect_in_memory(
+        model, masked, processor, target_modules,
+        attribute_tokens=False, run_path=str(tmp_path / "seq"),
+    )
+    tok_collector = _collect_in_memory(
+        model, masked, processor, target_modules,
+        attribute_tokens=True, run_path=str(tmp_path / "tok"),
+    )
+    offsets = tok_collector.builder.offsets
+    names = sorted(seq_collector.gradients.keys())
+    device = next(model.parameters()).device
+
+    for ex in range(len(masked)):
+        length = masked[ex]["length"]
+        start, end = int(offsets[ex]), int(offsets[ex + 1])
+        # one gradient row per real position except the last (length - 1)
+        assert end - start == length - 1
+
+        x = torch.tensor([masked[ex]["input_ids"]], device=device)
+        y = torch.tensor([masked[ex]["labels"]], device=device)
+        # completion positions only (for the "prompt really contributes" check)
+        vmask = torch.zeros(x.size(1), dtype=torch.bool, device=device)
+        vmask[:-1] = y[0, 1:] != -100
+
+        # Independent autograd reference: capture g (output grad) and a (input
+        # activation) for every target module in a single backward.
+        cap: dict[str, dict] = {}
+        handles = []
+        for n in names:
+            m = model.base_model.get_submodule(n)
+            handles.append(
+                m.register_forward_hook(
+                    lambda mod, inp, out, n=n: cap.setdefault(n, {}).update(
+                        a=inp[0].detach()
+                    )
+                )
+            )
+            handles.append(
+                m.register_full_backward_hook(
+                    lambda mod, gi, go, n=n: cap.setdefault(n, {}).update(
+                        g=go[0].detach()
+                    )
+                )
+            )
+        model.zero_grad(set_to_none=True)
+        logits = model(x).logits[:, :-1]
+        loss = torch.nn.functional.cross_entropy(
+            logits.reshape(-1, logits.size(-1)),
+            y[:, 1:].reshape(-1),
+            reduction="sum",  # matches _collect_in_memory(loss_reduction="sum")
+            ignore_index=-100,
+        )
+        loss.backward()
+        for h in handles:
+            h.remove()
+
+        max_prompt_frac = 0.0
+        for n in names:
+            module = model.base_model.get_submodule(n)
+            o, i_dim = module.weight.shape
+            a = cap[n]["a"][0].double()  # [S, I]
+            g = cap[n]["g"][0].double()  # [S, O]
+
+            full = g.mT @ a  # sum over ALL positions == autograd weight grad
+            comp = (g * vmask.unsqueeze(-1)).mT @ a  # completion positions only
+
+            seq_grad = seq_collector.gradients[n][ex].reshape(o, i_dim).double().cpu()
+            tok_sum = (
+                tok_collector.gradients[n][start:end]
+                .sum(0)
+                .reshape(o, i_dim)
+                .double()
+                .cpu()
+            )
+
+            # doc/sequence gradient == true masked-loss gradient (incl. prompt)
+            torch.testing.assert_close(
+                seq_grad, full.cpu(), atol=1e-3, rtol=1e-3,
+                msg=f"ex {ex} module {n}: per-doc grad must equal the autograd "
+                f"gradient of the masked loss (no separate gradient mask)",
+            )
+            # per-token rows now cover ALL positions, so they sum to the doc grad
+            torch.testing.assert_close(
+                tok_sum, full.cpu(), atol=1e-3, rtol=1e-3,
+                msg=f"ex {ex} module {n}: per-token rows must sum to the per-doc "
+                f"gradient (all positions included)",
+            )
+            max_prompt_frac = max(
+                max_prompt_frac,
+                ((full - comp).norm() / full.norm().clamp_min(1e-12)).item(),
+            )
+
+        # Prompt positions genuinely contribute, so including them is materially
+        # different from a completion-only decomposition (which would omit them).
+        assert max_prompt_frac > 0.1, (
+            f"ex {ex}: expected a substantial prompt-position contribution, got "
+            f"max fraction {max_prompt_frac:.4f}"
         )

--- a/tests/test_attribute_tokens.py
+++ b/tests/test_attribute_tokens.py
@@ -872,12 +872,20 @@ def test_masked_prompt_token_grads_cover_all_positions(tmp_path, model):
     processor = GradientProcessor(projection_dim=None)  # raw grads, no projection
 
     seq_collector = _collect_in_memory(
-        model, masked, processor, target_modules,
-        attribute_tokens=False, run_path=str(tmp_path / "seq"),
+        model,
+        masked,
+        processor,
+        target_modules,
+        attribute_tokens=False,
+        run_path=str(tmp_path / "seq"),
     )
     tok_collector = _collect_in_memory(
-        model, masked, processor, target_modules,
-        attribute_tokens=True, run_path=str(tmp_path / "tok"),
+        model,
+        masked,
+        processor,
+        target_modules,
+        attribute_tokens=True,
+        run_path=str(tmp_path / "tok"),
     )
     offsets = tok_collector.builder.offsets
     names = sorted(seq_collector.gradients.keys())
@@ -948,13 +956,19 @@ def test_masked_prompt_token_grads_cover_all_positions(tmp_path, model):
 
             # doc/sequence gradient == true masked-loss gradient (incl. prompt)
             torch.testing.assert_close(
-                seq_grad, full.cpu(), atol=1e-3, rtol=1e-3,
+                seq_grad,
+                full.cpu(),
+                atol=1e-3,
+                rtol=1e-3,
                 msg=f"ex {ex} module {n}: per-doc grad must equal the autograd "
                 f"gradient of the masked loss (no separate gradient mask)",
             )
             # per-token rows now cover ALL positions, so they sum to the doc grad
             torch.testing.assert_close(
-                tok_sum, full.cpu(), atol=1e-3, rtol=1e-3,
+                tok_sum,
+                full.cpu(),
+                atol=1e-3,
+                rtol=1e-3,
                 msg=f"ex {ex} module {n}: per-token rows must sum to the per-doc "
                 f"gradient (all positions included)",
             )

--- a/tests/test_batch_size_invariance.py
+++ b/tests/test_batch_size_invariance.py
@@ -86,14 +86,10 @@ def test_gradient_scale_invariance(tmp_path, batch_size_a, batch_size_b):
         assert proc.returncode == 0, f"bergson build failed:\n{stderr}"
 
     # Load gradients
-    grads_a = torch.from_numpy(
-        load_gradients(index_a_path, structured=False).copy()
-    ).float()
-    grads_b = torch.from_numpy(
-        load_gradients(index_b_path, structured=False).copy()
-    ).float()
+    grads_a = torch.from_numpy(load_gradients(index_a_path).copy()).float()
+    grads_b = torch.from_numpy(load_gradients(index_b_path).copy()).float()
     grads_combined = torch.from_numpy(
-        load_gradients(index_combined_path, structured=False).copy()
+        load_gradients(index_combined_path).copy()
     ).float()
 
     # Split combined to match a and b

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM
 
 from bergson import GradientProcessor, collect_gradients
 from bergson.config import AttentionConfig, IndexConfig
-from bergson.data import load_gradients
+from bergson.data import load_module_gradients
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -26,17 +26,17 @@ def test_build_consistency(tmp_path: Path, model, dataset):
         cfg=cfg,
     )
 
-    index = load_gradients(cfg.partial_run_path)
+    index = load_module_gradients(cfg.partial_run_path)
 
     cache_path = Path("runs/test_build_cache.npy")
 
     assert cache_path.exists()
     # if not cache_path.exists():
     #   Regenerate cache
-    #   np.save(cache_path, index[index.dtype.names[0]][0])
+    #   np.save(cache_path, index[next(iter(index))][0])
 
     cached_item_grad = np.load(cache_path)
-    first_module_grad = index[index.dtype.names[0]][0]
+    first_module_grad = index[next(iter(index))][0]
 
     assert np.allclose(first_module_grad, cached_item_grad, atol=1e-6)
 
@@ -65,8 +65,8 @@ def test_split_attention_build(tmp_path: Path, model, dataset):
     ), "Expected artifacts in the temp run_path"
 
     # Verify that per-head gradient columns exist and have non-zero values
-    index = load_gradients(cfg.partial_run_path)
-    module_names = index.dtype.names
+    index = load_module_gradients(cfg.partial_run_path)
+    module_names = list(index.keys())
     head_modules = [n for n in module_names if "head_" in n]
     assert (
         len(head_modules) == 2
@@ -102,9 +102,9 @@ def test_conv1d_build(tmp_path: Path, dataset):
         Path(cfg.partial_run_path).iterdir()
     ), "Expected artifacts in the run path"
 
-    index = load_gradients(cfg.partial_run_path)
+    index = load_module_gradients(cfg.partial_run_path)
 
-    assert len(modules := index.dtype.names) != 0
+    assert len(modules := list(index.keys())) != 0
     assert len(index[modules[0]]) == len(dataset)
     assert index[modules[0]][0].sum().item() != 0.0
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,15 +1,14 @@
 import numpy as np
-import pytest
 
-from bergson.data import create_index, load_gradients
+from bergson.data import create_index, load_gradients, load_module_gradients
 
 
 def test_large_gradients_build(tmp_path, dataset):
-    # Uncompressed gradients from a large (~1.4B-param) model produce a structured
-    # numpy dtype whose itemsize (4 bytes * total elements) overflows the C-int cap
-    # (2**31 - 1 bytes), so structured loading must fail while unstructured loading
-    # succeeds. Fabricate per-module gradient sizes at that scale directly so the
-    # test needs no model and no GPU.
+    # Uncompressed gradients from a large (~1.4B-param) model have rows whose
+    # size (4 bytes * total elements) overflows the C-int cap (2**31 - 1 bytes)
+    # that numpy imposes on a structured record's itemsize — the reason the
+    # store is mapped flat. Fabricate per-module gradient sizes at that scale
+    # directly so the test needs no model and no GPU.
     grad_sizes = {f"layer_{i}.weight": 50_000_000 for i in range(12)}  # 6e8 elems
     assert sum(grad_sizes.values()) * np.dtype(np.float32).itemsize > 2**31
 
@@ -18,10 +17,31 @@ def test_large_gradients_build(tmp_path, dataset):
         num_grads=len(dataset),
         grad_sizes=grad_sizes,
         dtype=np.float32,
-        with_structure=False,
     )
 
-    # Unstructured load works; structured load exceeds numpy's max item size.
-    load_gradients(tmp_path, structured=False)
-    with pytest.raises(ValueError):
-        load_gradients(tmp_path, structured=True)
+    mmap = load_gradients(tmp_path)
+    assert mmap.shape == (len(dataset), sum(grad_sizes.values()))
+
+    # The module-keyed view slices the same rows by column.
+    grads = load_module_gradients(tmp_path)
+    assert len(grads) == len(dataset)
+    assert list(grads.keys()) == list(grad_sizes)
+    assert grads["layer_3.weight"].shape == (len(dataset), 50_000_000)
+
+
+def test_module_gradients_roundtrip(tmp_path, dataset):
+    grad_sizes = {"a.weight": 3, "b.weight": 5}
+    buffer = create_index(
+        tmp_path,
+        num_grads=len(dataset),
+        grad_sizes=grad_sizes,
+        dtype=np.float32,
+    )
+    rng = np.random.default_rng(0)
+    expected = rng.standard_normal((len(dataset), 8)).astype(np.float32)
+    buffer[:] = expected
+    buffer.flush()
+
+    grads = load_module_gradients(tmp_path)
+    np.testing.assert_array_equal(grads["a.weight"], expected[:, :3])
+    np.testing.assert_array_equal(grads["b.weight"], expected[:, 3:])

--- a/tests/test_distributed_batch_budget.py
+++ b/tests/test_distributed_batch_budget.py
@@ -55,7 +55,7 @@ def _worker(rank: int, world_size: int, port: int, results) -> None:
             # bin-packer's per-rank budget invariant is preserved. The
             # MAGIC path (default sync_max_len=True) still globally
             # syncs and is expected to over-pad in this scenario.
-            padded, _, _ = pad_and_tensor(input_ids, sync_max_len=False)
+            padded, _, _, _ = pad_and_tensor(input_ids, sync_max_len=False)
             cost = padded.shape[0] * padded.shape[1]
             worst = max(worst, cost)
         results[rank] = worst

--- a/tests/test_faiss_ann_cpu_load.py
+++ b/tests/test_faiss_ann_cpu_load.py
@@ -14,13 +14,13 @@ neighbours for both an ANN (IVF) index and an exact ``Flat`` index. The unit tes
 exercise the ``index_to_device`` guard directly. Adapted from the bug2 repro.
 """
 
-import json
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 from bergson.config import FaissConfig
+from bergson.data import create_index
 from bergson.query.faiss_index import FaissIndex, _is_gpu_resident, index_to_device
 
 
@@ -37,34 +37,12 @@ requires_faiss = pytest.mark.skipif(not _has_faiss(), reason="faiss not availabl
 
 
 def _write_gradient_store(root: Path, n: int, dim: int) -> np.ndarray:
-    """Write a tiny on-disk gradient store matching bergson's info.json layout."""
-    root.mkdir(parents=True, exist_ok=True)
-    grad_sizes = {"module_a": dim}
-    struct_dtype = {
-        "names": list(grad_sizes),
-        "formats": [f"({s},)<f4" for s in grad_sizes.values()],
-        "itemsize": 4 * sum(grad_sizes.values()),
-    }
+    """Write a tiny on-disk gradient store with random gradients."""
     rng = np.random.default_rng(0)
     data = rng.standard_normal((n, dim)).astype("<f4")
-    mm = np.memmap(
-        root / "gradients.bin",
-        dtype=np.dtype(struct_dtype),
-        mode="w+",
-        shape=(n,),
-    )
-    mm["module_a"] = data
+    mm = create_index(root, num_grads=n, grad_sizes={"module_a": dim}, dtype=np.float32)
+    mm[:] = data
     mm.flush()
-    with (root / "info.json").open("w") as f:
-        json.dump(
-            {
-                "num_grads": n,
-                "dtype": struct_dtype,
-                "grad_sizes": grad_sizes,
-                "base_dtype": "float32",
-            },
-            f,
-        )
     return data
 
 

--- a/tests/test_force_math_sdp.py
+++ b/tests/test_force_math_sdp.py
@@ -7,7 +7,7 @@ import torch
 
 from bergson import GradientProcessor, collect_gradients
 from bergson.config import IndexConfig
-from bergson.data import load_gradients
+from bergson.data import load_module_gradients
 from bergson.utils.worker_utils import apply_force_math_sdp
 
 
@@ -91,9 +91,9 @@ def test_force_math_sdp_persists_through_collect(
         not torch.backends.cuda.mem_efficient_sdp_enabled()
     ), "mem-efficient SDP was re-enabled during collect_gradients"
 
-    mixed_index = load_gradients(cfg.partial_run_path)
+    mixed_index = load_module_gradients(cfg.partial_run_path)
     mixed_grad_short = torch.from_numpy(
-        mixed_index[mixed_index.dtype.names[0]][0].copy()
+        mixed_index[next(iter(mixed_index))][0].copy()
     ).float()
 
     # Now collect with only the short doc
@@ -112,9 +112,9 @@ def test_force_math_sdp_persists_through_collect(
         cfg=cfg_alone,
     )
 
-    alone_index = load_gradients(cfg_alone.partial_run_path)
+    alone_index = load_module_gradients(cfg_alone.partial_run_path)
     alone_grad_short = torch.from_numpy(
-        alone_index[alone_index.dtype.names[0]][0].copy()
+        alone_index[next(iter(alone_index))][0].copy()
     ).float()
 
     cos_sim = torch.nn.functional.cosine_similarity(

--- a/tests/test_global_projection.py
+++ b/tests/test_global_projection.py
@@ -9,7 +9,7 @@ from bergson import GradientProcessor, collect_gradients
 from bergson.collector.collector import CollectorComputer, create_projection_matrix
 from bergson.collector.gradient_collectors import GradientCollector
 from bergson.config import IndexConfig
-from bergson.data import load_gradients
+from bergson.data import load_module_gradients
 
 
 def test_global_projector_processor_field_default():
@@ -145,8 +145,8 @@ def test_global_projector_e2e(tmp_path: Path, model, dataset):
 
     collect_gradients(model=model.cuda(), data=dataset, processor=processor, cfg=cfg)
 
-    grads = load_gradients(cfg.partial_run_path)
-    assert grads.dtype.names == ("gradients",)
+    grads = load_module_gradients(cfg.partial_run_path)
+    assert list(grads.keys()) == ["gradients"]
     assert grads["gradients"].shape == (len(dataset), proj_dim)
 
 

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -52,7 +52,7 @@ def test_reduce_cli(tmp_path: Path):
 
     # Load the gradient index
     index_cfg = IndexConfig(run_path=str(tmp_path / "test_reduce_e2e"))
-    ds = load_gradient_dataset(Path(index_cfg.run_path), structured=False)
+    ds = load_gradient_dataset(Path(index_cfg.run_path))
     assert len(ds) == 1
 
     grads = torch.tensor(ds["gradients"][:])
@@ -71,7 +71,7 @@ def test_programmatic_reduce(tmp_path: Path):
     build(index_cfg, PreprocessConfig(aggregation="mean"))
 
     # Assert 1-row reduction exists at the tmp_path
-    ds = load_gradient_dataset(Path(index_cfg.run_path), structured=False)
+    ds = load_gradient_dataset(Path(index_cfg.run_path))
     assert len(ds) == 1
 
 
@@ -112,7 +112,7 @@ def test_reduce_with_preconditioning(tmp_path: Path, model, dataset):
         preprocess_cfg=preprocess_cfg,
     )
 
-    ds_out = load_gradient_dataset(reduce_index_cfg.partial_run_path, structured=False)
+    ds_out = load_gradient_dataset(reduce_index_cfg.partial_run_path)
     assert len(ds_out) == 1
     grads = torch.tensor(ds_out["gradients"][:])
     assert not torch.isnan(grads).any()

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -23,7 +23,7 @@ from bergson.config import (
     ScoreConfig,
 )
 from bergson.config.config_io import save_run_config
-from bergson.data import create_index
+from bergson.data import column_offsets, create_index
 from bergson.gradients import GradientProcessor
 from bergson.hessians.preconditioner import (
     DensePreconditioner,
@@ -69,7 +69,6 @@ def test_large_gradients_query(tmp_path: Path, dataset):
         num_grads=len(dataset),
         grad_sizes=grad_sizes,
         dtype=np.float32,
-        with_structure=False,
     )
 
     result = subprocess.run(
@@ -568,8 +567,8 @@ def _write_query_index(
     index = create_index(
         path, num_grads=num_grads, grad_sizes=grad_sizes, dtype=np.float32
     )
-    for name in grad_sizes:
-        index[name][:] = grads[name].numpy()
+    for name, (lo, hi) in column_offsets(grad_sizes).items():
+        index[:, lo:hi] = grads[name].numpy()
     index.flush()
     # Persist preprocess_cfg like the CLI does, so get_query_grads can tell
     # whether the query was already preconditioned upstream (e.g. at reduce).

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -15,7 +15,7 @@ from trl import SFTConfig, SFTTrainer
 
 from bergson import GradientProcessor
 from bergson.config import AttentionConfig
-from bergson.data import load_gradients
+from bergson.data import load_gradients, load_module_gradients
 from bergson.gradients import AdafactorNormalizer, AdamNormalizer
 from bergson.huggingface import (
     GradientCollectorCallback,
@@ -295,8 +295,8 @@ class TestGradientCollectorCallback:
 
         # Verify per-head gradient files were created
         gradient_dir = tmp_path / "gradients" / "train" / "epoch_0"
-        gradients = load_gradients(gradient_dir)
-        module_names = gradients.dtype.names
+        gradients = load_module_gradients(gradient_dir)
+        module_names = list(gradients.keys())
 
         head_modules = [n for n in module_names if "head_" in n]
         assert len(head_modules) == num_heads, (


### PR DESCRIPTION
Background: In SFT the answer token loss flows back through the masked positions via the attention mechanism, so the effective parameter update uses gradients even from masked positions.

The importance weightings placed on masked tokens cannot be straightforwardly intervened on (e.g. reduced to 0) to change the loss so per-token gradients on masked positions don't have naive token filtering utility, but they are useful for interpretability and per-sequence filtering or re-weighting.

@SrGonao interested in feedback on prompt/completion gradient collection and whether you agree with this