### PR TITLE
fix: Normalize per-token autocorrelation Grams by row count; rename masks

### DIFF
--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -305,18 +305,18 @@ class HookCollectorBase(ContextDecorator, ABC):
             return int(compute_num_token_grads(data).sum())
         return len(data)
 
-    def with_batch(self, position_mask: Tensor | None = None) -> "HookCollectorBase":
+    def with_batch(self, collection_mask: Tensor | None = None) -> "HookCollectorBase":
         """
-        Set the current position mask before entering the context.
+        Set the current collection mask before entering the context.
 
         This allows hooks to access the mask during forward/backward passes.
         Usage:
-            with collector.with_batch(position_mask):
+            with collector.with_batch(collection_mask):
                 # forward/backward pass
-                # hooks can access self._current_position_mask
+                # hooks can access self._current_collection_mask
 
         Args:
-            position_mask: Optional boolean tensor of shape [batch_size, seq_len],
+            collection_mask: Optional boolean tensor of shape [batch_size, seq_len],
                 aligned with input positions, marking which positions the hooks
                 collect. This normally spans every real (non-padding) position
                 but each sequence's last.
@@ -324,7 +324,7 @@ class HookCollectorBase(ContextDecorator, ABC):
         Returns:
             self, for use as a context manager.
         """
-        self._current_position_mask = position_mask
+        self._current_collection_mask = collection_mask
         return self
 
     def __enter__(self):
@@ -523,7 +523,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     P = self.double_sided_projection(name, P, g, p, o, i)
 
                 P = P.flatten(2)  # [N, S, grad_dim]
-                P = P[self._current_position_mask]  # [total_valid, grad_dim]
+                P = P[self._current_collection_mask]  # [total_valid, grad_dim]
             else:
                 P = g.mT @ a  # [N,O,S] @ [N,S,I] → [N,O,I]
 
@@ -572,7 +572,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     # [N, S, O/p, 1] * [N, S, 1, I/q] → [N, S, O/p, I/q]
                     P = g.unsqueeze(-1) * a.unsqueeze(-2)
                 P = P.flatten(2)  # [N, S, grad_dim]
-                P = P[self._current_position_mask]  # [total_valid, grad_dim]
+                P = P[self._current_collection_mask]  # [total_valid, grad_dim]
             else:
                 if bias_grad is not None and p is not None:
                     P = self.double_sided_projection_with_bias(
@@ -609,7 +609,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                 )
                 if self.attribute_tokens:
                     P = P.flatten(2)  # [N, S, grad_dim]
-                    P = P[self._current_position_mask]  # [total_valid, grad_dim]
+                    P = P[self._current_collection_mask]  # [total_valid, grad_dim]
             else:
                 # a was already projected in forward if p is set;
                 # project g individually
@@ -625,7 +625,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     if bias_grad is not None:
                         P = torch.cat([P, bias_grad.unsqueeze(-1)], dim=-1)
                     P = P.flatten(2)  # [N, S, grad_dim]
-                    P = P[self._current_position_mask]  # [total_valid, grad_dim]
+                    P = P[self._current_collection_mask]  # [total_valid, grad_dim]
                 else:
                     P = g.mT @ a  # [N, O/p, I/p]
                     if bias_grad is not None:
@@ -773,20 +773,17 @@ class CollectorComputer:
                 # Local padding only: bin-packer enforces a per-rank
                 # ``max_len × batch_size ≤ N`` budget that a global-max
                 # all-reduce would silently violate.
-                # Gradients flow back through attention to every real position
-                # regardless of loss masking, so collectors get a mask over all
-                # gradient-carrying positions (each real position but the last).
-                x, y, _, position_mask = pad_and_tensor(
+                x, y, _, collection_mask = pad_and_tensor(
                     batch["input_ids"],
                     labels=batch.get("labels"),
                     device=self.device,
                     sync_max_len=False,
                 )
                 # Must count the same positions the collectors ingest.
-                total_processed += position_mask.sum()
+                total_processed += collection_mask.sum()
 
                 with (
-                    self.collector.with_batch(position_mask),
+                    self.collector.with_batch(collection_mask),
                     (
                         record_function(f"step_{step}")
                         if self.cfg.profile

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -28,7 +28,7 @@ from tqdm.auto import tqdm
 from transformers import PreTrainedModel
 
 from bergson.config import AttentionConfig, HessianConfig, IndexConfig
-from bergson.data import pad_and_tensor
+from bergson.data import compute_num_token_grads, pad_and_tensor
 from bergson.gradients import (
     AdafactorNormalizer,
     AdamNormalizer,
@@ -85,8 +85,7 @@ class HookCollectorBase(ContextDecorator, ABC):
     """
 
     attribute_tokens: bool = False
-    """When True, compute per-position gradients instead of per-example, filtered
-    to gradient-bearing positions using ``_current_collection_mask``."""
+    """When True, compute per-position gradients instead of per-example."""
 
     lo: float = float("-inf")
     """Lower clamp bound for gradients. May be narrowed in subclass ``setup()``."""
@@ -297,27 +296,35 @@ class HookCollectorBase(ContextDecorator, ABC):
         self.processor._projection_matrices[key] = A
         return A
 
-    def with_batch(self, collection_mask: Tensor | None = None) -> "HookCollectorBase":
+    def num_rows(self, data: Dataset) -> int:
+        """Number of gradient rows accumulated into an autocorrelation Gram
+        over ``data``: one per gradient-carrying token when
+        ``attribute_tokens`` is set, else one per document. Used to normalize
+        the Gram into a second moment over the matching unit."""
+        if self.attribute_tokens:
+            return int(compute_num_token_grads(data).sum())
+        return len(data)
+
+    def with_batch(self, position_mask: Tensor | None = None) -> "HookCollectorBase":
         """
-        Set the current collection mask before entering the context.
+        Set the current position mask before entering the context.
 
         This allows hooks to access the mask during forward/backward passes.
         Usage:
-            with collector.with_batch(collection_mask):
+            with collector.with_batch(position_mask):
                 # forward/backward pass
-                # hooks can access self._current_collection_mask
+                # hooks can access self._current_position_mask
 
         Args:
-            collection_mask: Optional boolean tensor of shape [batch_size, seq_len]
-                indicating every position containing a non-padding token with a
-                next-token target (excludes each sequence's final token). Unlike
-                ``pad_and_tensor``'s ``valid_masks``, it is independent of label
-                masking.
+            position_mask: Optional boolean tensor of shape [batch_size, seq_len],
+                aligned with input positions, marking which positions the hooks
+                collect. This normally spans every real (non-padding) position
+                but each sequence's last.
 
         Returns:
             self, for use as a context manager.
         """
-        self._current_collection_mask = collection_mask
+        self._current_position_mask = position_mask
         return self
 
     def __enter__(self):
@@ -516,7 +523,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     P = self.double_sided_projection(name, P, g, p, o, i)
 
                 P = P.flatten(2)  # [N, S, grad_dim]
-                P = P[self._current_collection_mask]  # [total_valid, grad_dim]
+                P = P[self._current_position_mask]  # [total_valid, grad_dim]
             else:
                 P = g.mT @ a  # [N,O,S] @ [N,S,I] → [N,O,I]
 
@@ -565,7 +572,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     # [N, S, O/p, 1] * [N, S, 1, I/q] → [N, S, O/p, I/q]
                     P = g.unsqueeze(-1) * a.unsqueeze(-2)
                 P = P.flatten(2)  # [N, S, grad_dim]
-                P = P[self._current_collection_mask]  # [total_valid, grad_dim]
+                P = P[self._current_position_mask]  # [total_valid, grad_dim]
             else:
                 if bias_grad is not None and p is not None:
                     P = self.double_sided_projection_with_bias(
@@ -602,7 +609,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                 )
                 if self.attribute_tokens:
                     P = P.flatten(2)  # [N, S, grad_dim]
-                    P = P[self._current_collection_mask]  # [total_valid, grad_dim]
+                    P = P[self._current_position_mask]  # [total_valid, grad_dim]
             else:
                 # a was already projected in forward if p is set;
                 # project g individually
@@ -618,7 +625,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     if bias_grad is not None:
                         P = torch.cat([P, bias_grad.unsqueeze(-1)], dim=-1)
                     P = P.flatten(2)  # [N, S, grad_dim]
-                    P = P[self._current_collection_mask]  # [total_valid, grad_dim]
+                    P = P[self._current_position_mask]  # [total_valid, grad_dim]
                 else:
                     P = g.mT @ a  # [N, O/p, I/p]
                     if bias_grad is not None:
@@ -766,16 +773,20 @@ class CollectorComputer:
                 # Local padding only: bin-packer enforces a per-rank
                 # ``max_len × batch_size ≤ N`` budget that a global-max
                 # all-reduce would silently violate.
-                x, y, _, collection_mask = pad_and_tensor(
+                # Gradients flow back through attention to every real position
+                # regardless of loss masking, so collectors get a mask over all
+                # gradient-carrying positions (each real position but the last).
+                x, y, _, position_mask = pad_and_tensor(
                     batch["input_ids"],
                     labels=batch.get("labels"),
                     device=self.device,
                     sync_max_len=False,
                 )
-                total_processed += collection_mask.sum()
+                # Must count the same positions the collectors ingest.
+                total_processed += position_mask.sum()
 
                 with (
-                    self.collector.with_batch(collection_mask),
+                    self.collector.with_batch(position_mask),
                     (
                         record_function(f"step_{step}")
                         if self.cfg.profile

--- a/bergson/collector/dist_autocorrelation_gradient_collector.py
+++ b/bergson/collector/dist_autocorrelation_gradient_collector.py
@@ -135,7 +135,7 @@ class GradientCollectorWithDistributedAutocorrelationMatrices(HookCollectorBase)
             process_autocorrelation_matrices(
                 self.processor,
                 self.processor.hessians,
-                len(self.data),
+                self.num_rows(self.data),
                 grad_sizes,
                 self.rank,
             )

--- a/bergson/collector/in_memory_collector.py
+++ b/bergson/collector/in_memory_collector.py
@@ -113,7 +113,7 @@ class InMemoryCollector(HookCollectorBase):
             process_autocorrelation_matrices(
                 self.processor,
                 self.processor.hessians,
-                len(self.data),
+                self.num_rows(self.data),
                 grad_sizes,
                 self.rank,
             )

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -650,14 +650,16 @@ def pad_and_tensor(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Pad a list of sequences to the same length and convert them to tensors.
-    Returns a tuple of padded sequences and labels. The labels are the same as the
-    sequences, but with -100 for the padding positions, which is useful for ignoring
-    padding in loss calculations.
+    Returns a tuple of (padded sequences, padded labels, shift_loss_masks,
+    position_masks). The labels are the same as the sequences, but with -100
+    for the padding positions, which is useful for ignoring padding in loss
+    calculations.
 
-    Also returns two masks: ``valid_masks`` marks positions whose next-token
-    label is not -100 (loss positions), while ``collection_masks`` marks every
+    Both masks are aligned with input positions. ``shift_loss_masks[i]`` is
+    True iff ``labels[i+1] != -100``, i.e. it marks the input positions whose
+    next-token prediction is supervised. ``position_masks`` marks every
     non-padding position but each sequence's last, independent of label
-    masking (the gradient-bearing positions).
+    masking (the gradient-carrying positions).
 
     When ``sync_max_len`` is True (default) and a process group is
     initialized, the padding length is reduced to the global max across
@@ -689,18 +691,18 @@ def pad_and_tensor(
     padded_tokens = torch.tensor(padded, dtype=dtype, device=device)
     padded_labels = torch.tensor(labels, dtype=dtype, device=device)
 
-    # Compute valid_masks: position i is valid if labels[i+1] != -100
+    # shift_loss_masks[i] = labels[i+1] != -100
     N, S = padded_tokens.shape
-    valid_masks = torch.zeros(N, S, dtype=torch.bool, device=device)
-    valid_masks[:, :-1] = padded_labels[:, 1:] != -100
+    shift_loss_masks = torch.zeros(N, S, dtype=torch.bool, device=device)
+    shift_loss_masks[:, :-1] = padded_labels[:, 1:] != -100
 
-    # Compute collection_masks: every non-padding position but each
+    # Compute position_masks: every non-padding position but each
     # sequence's last, regardless of label masking.
     lengths = torch.tensor([len(seq) for seq in sequences], device=device)
     positions = torch.arange(S, device=device)
-    collection_masks = (positions.unsqueeze(0) + 1) < lengths.unsqueeze(1)
+    position_masks = (positions.unsqueeze(0) + 1) < lengths.unsqueeze(1)
 
-    return padded_tokens, padded_labels, valid_masks, collection_masks
+    return padded_tokens, padded_labels, shift_loss_masks, position_masks
 
 
 def tokenize(

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -651,13 +651,13 @@ def pad_and_tensor(
     """
     Pad a list of sequences to the same length and convert them to tensors.
     Returns a tuple of (padded sequences, padded labels, shift_loss_masks,
-    position_masks). The labels are the same as the sequences, but with -100
+    collection_masks). The labels are the same as the sequences, but with -100
     for the padding positions, which is useful for ignoring padding in loss
     calculations.
 
     Both masks are aligned with input positions. ``shift_loss_masks[i]`` is
     True iff ``labels[i+1] != -100``, i.e. it marks the input positions whose
-    next-token prediction is supervised. ``position_masks`` marks every
+    next-token prediction is supervised. ``collection_masks`` marks every
     non-padding position but each sequence's last, independent of label
     masking (the gradient-carrying positions).
 
@@ -696,13 +696,13 @@ def pad_and_tensor(
     shift_loss_masks = torch.zeros(N, S, dtype=torch.bool, device=device)
     shift_loss_masks[:, :-1] = padded_labels[:, 1:] != -100
 
-    # Compute position_masks: every non-padding position but each
+    # Compute collection_masks: every non-padding position but each
     # sequence's last, regardless of label masking.
     lengths = torch.tensor([len(seq) for seq in sequences], device=device)
     positions = torch.arange(S, device=device)
-    position_masks = (positions.unsqueeze(0) + 1) < lengths.unsqueeze(1)
+    collection_masks = (positions.unsqueeze(0) + 1) < lengths.unsqueeze(1)
 
-    return padded_tokens, padded_labels, shift_loss_masks, position_masks
+    return padded_tokens, padded_labels, shift_loss_masks, collection_masks
 
 
 def tokenize(

--- a/bergson/hessians/autocorrelation.py
+++ b/bergson/hessians/autocorrelation.py
@@ -21,7 +21,8 @@ class AutocorrelationCollector(HookCollectorBase):
     """
 
     data: Dataset
-    """The dataset the Hessian is fit on (its length normalizes the Gram)."""
+    """The dataset the Hessian is fit on (its row count — documents, or
+    tokens under ``attribute_tokens`` — normalizes the Gram)."""
 
     path: str
     """Directory the fitted GradientProcessor is saved to."""
@@ -54,7 +55,7 @@ class AutocorrelationCollector(HookCollectorBase):
             process_autocorrelation_matrices(
                 self.processor,
                 self.processor.hessians,
-                len(self.data),
+                self.num_rows(self.data),
                 grad_sizes,
                 self.rank,
             )

--- a/bergson/hessians/kfac.py
+++ b/bergson/hessians/kfac.py
@@ -44,10 +44,10 @@ class CovarianceCollector(HookCollectorBase):
         """Compute activation covariance: A^T @ A."""
         name = assert_type(str, module._name)
         A_cov_ki = self.A_cov_dict[name]
-        mask = self._current_position_mask
-        assert mask is not None, "Position mask not set for forward hook."
+        mask = self._current_collection_mask
+        assert mask is not None, "Collection mask not set for forward hook."
 
-        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
+        # a: [N, S, I], collection mask: [N, S] -> select gradient-carrying positions
         a_bi = a[mask].to(self.dtype)  # [num_valid, I]
 
         # Augment with a ones column so A matches the [O, I+1] gradient layout
@@ -75,7 +75,7 @@ class CovarianceCollector(HookCollectorBase):
         """Compute gradient covariance: G^T @ G."""
         name = assert_type(str, module._name)
         S_cov_po = self.S_cov_dict[name]
-        mask = self._current_position_mask
+        mask = self._current_collection_mask
 
         # g: [N, S, O], mask: [N, S] -> select gradient-carrying positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]

--- a/bergson/hessians/kfac.py
+++ b/bergson/hessians/kfac.py
@@ -44,10 +44,10 @@ class CovarianceCollector(HookCollectorBase):
         """Compute activation covariance: A^T @ A."""
         name = assert_type(str, module._name)
         A_cov_ki = self.A_cov_dict[name]
-        mask = self._current_collection_mask
-        assert mask is not None, "Valid mask not set for forward hook."
+        mask = self._current_position_mask
+        assert mask is not None, "Position mask not set for forward hook."
 
-        # a: [N, S, I], collection_masks: [N, S] -> select collected positions
+        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
         a_bi = a[mask].to(self.dtype)  # [num_valid, I]
 
         # Augment with a ones column so A matches the [O, I+1] gradient layout
@@ -75,9 +75,9 @@ class CovarianceCollector(HookCollectorBase):
         """Compute gradient covariance: G^T @ G."""
         name = assert_type(str, module._name)
         S_cov_po = self.S_cov_dict[name]
-        mask = self._current_collection_mask
+        mask = self._current_position_mask
 
-        # g: [N, S, O], mask: [N, S] -> select valid positions
+        # g: [N, S, O], mask: [N, S] -> select gradient-carrying positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]
 
         # Compute local covariance

--- a/bergson/hessians/shampoo.py
+++ b/bergson/hessians/shampoo.py
@@ -44,10 +44,10 @@ class ShampooCollector(HookCollectorBase):
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         """Compute activation covariance: A^T @ A."""
 
-        mask = self._current_position_mask
-        assert mask is not None, "Position mask not set for forward hook."
+        mask = self._current_collection_mask
+        assert mask is not None, "Collection mask not set for forward hook."
 
-        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
+        # a: [N, S, I], collection mask: [N, S] -> select gradient-carrying positions
         a_bi = a[mask]  # [num_valid, I]
 
         # Augment with a ones column so the [O, I+1] per-batch gradient matches
@@ -64,7 +64,7 @@ class ShampooCollector(HookCollectorBase):
         name = assert_type(str, module._name)
         S_shampoo_po = self.S_shampoo_dict[name]
         A_shampoo_ki = self.A_shampoo_dict[name]
-        mask = self._current_position_mask
+        mask = self._current_collection_mask
 
         # g: [N, S, O], mask: [N, S] -> select gradient-carrying positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]

--- a/bergson/hessians/shampoo.py
+++ b/bergson/hessians/shampoo.py
@@ -44,10 +44,10 @@ class ShampooCollector(HookCollectorBase):
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         """Compute activation covariance: A^T @ A."""
 
-        mask = self._current_collection_mask
-        assert mask is not None, "Valid mask not set for forward hook."
+        mask = self._current_position_mask
+        assert mask is not None, "Position mask not set for forward hook."
 
-        # a: [N, S, I], collection_masks: [N, S] -> select collected positions
+        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
         a_bi = a[mask]  # [num_valid, I]
 
         # Augment with a ones column so the [O, I+1] per-batch gradient matches
@@ -64,9 +64,9 @@ class ShampooCollector(HookCollectorBase):
         name = assert_type(str, module._name)
         S_shampoo_po = self.S_shampoo_dict[name]
         A_shampoo_ki = self.A_shampoo_dict[name]
-        mask = self._current_collection_mask
+        mask = self._current_position_mask
 
-        # g: [N, S, O], mask: [N, S] -> select valid positions
+        # g: [N, S, O], mask: [N, S] -> select gradient-carrying positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]
         a_bi = module._inputs.to(self.dtype)
         assert isinstance(a_bi, Tensor)

--- a/bergson/hessians/tkfac.py
+++ b/bergson/hessians/tkfac.py
@@ -45,10 +45,10 @@ class TraceCovarianceCollector(HookCollectorBase):
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         """Compute activation covariance: A^T @ A."""
 
-        mask = self._current_position_mask
-        assert mask is not None, "Position mask not set for forward hook."
+        mask = self._current_collection_mask
+        assert mask is not None, "Collection mask not set for forward hook."
 
-        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
+        # a: [N, S, I], collection mask: [N, S] -> select gradient-carrying positions
         a_bi = a[mask]  # [num_valid, I]
 
         # Augment with a ones column so A matches the [O, I+1] gradient layout
@@ -65,7 +65,7 @@ class TraceCovarianceCollector(HookCollectorBase):
         name = assert_type(str, module._name)
         S_tcov_po = self.S_tcov_dict[name]
         A_tcov_ki = self.A_tcov_dict[name]
-        mask = self._current_position_mask
+        mask = self._current_collection_mask
 
         # g: [N, S, O], mask: [N, S] -> select gradient-carrying positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]

--- a/bergson/hessians/tkfac.py
+++ b/bergson/hessians/tkfac.py
@@ -45,10 +45,10 @@ class TraceCovarianceCollector(HookCollectorBase):
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         """Compute activation covariance: A^T @ A."""
 
-        mask = self._current_collection_mask
-        assert mask is not None, "Valid mask not set for forward hook."
+        mask = self._current_position_mask
+        assert mask is not None, "Position mask not set for forward hook."
 
-        # a: [N, S, I], collection_masks: [N, S] -> select collected positions
+        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
         a_bi = a[mask]  # [num_valid, I]
 
         # Augment with a ones column so A matches the [O, I+1] gradient layout
@@ -65,9 +65,9 @@ class TraceCovarianceCollector(HookCollectorBase):
         name = assert_type(str, module._name)
         S_tcov_po = self.S_tcov_dict[name]
         A_tcov_ki = self.A_tcov_dict[name]
-        mask = self._current_collection_mask
+        mask = self._current_position_mask
 
-        # g: [N, S, O], mask: [N, S] -> select valid positions
+        # g: [N, S, O], mask: [N, S] -> select gradient-carrying positions
         g_bo = g[mask].to(self.dtype)  # [num_valid, O]
         a_bi = module._inputs.to(self.dtype)
         assert isinstance(a_bi, Tensor)

--- a/bergson/magic/data_stream.py
+++ b/bergson/magic/data_stream.py
@@ -109,7 +109,7 @@ class DataStream:
 
         indices = self.batch_rows(i)
         batch = self.dataset[indices]
-        x, y, valid_mask, _ = pad_and_tensor(
+        x, y, shift_loss_mask, _ = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=self.device,
@@ -130,7 +130,7 @@ class DataStream:
             "input_ids": x,
             "labels": y,
             "example_weight": self.weights[indices],
-            "valid_mask": valid_mask,
+            "shift_loss_mask": shift_loss_mask,
         }
 
     def __iter__(self):

--- a/bergson/process_autocorrelation.py
+++ b/bergson/process_autocorrelation.py
@@ -7,13 +7,19 @@ from bergson.gradients import GradientProcessor
 def process_autocorrelation_matrices(
     processor: GradientProcessor,
     hessians: dict[str, torch.Tensor],
-    len_data: int,
+    num_rows: int,
     grad_sizes: dict[str, int],
     rank: int,
 ):
     """
     Aggregate autocorrelation matrices across ranks and compute their eigen
     decomposition distributed across all ranks.
+
+    ``num_rows`` is the number of gradient rows summed into the Gram — the
+    document count for per-sequence gradients, or the gradient-carrying token
+    count when ``attribute_tokens`` produced per-token rows — so the
+    normalized matrix is the second moment over whichever unit the rows
+    represent.
     """
     hessians_eigen = {}
 
@@ -24,7 +30,7 @@ def process_autocorrelation_matrices(
         print("Saving hessians...")
 
     for name, prec in hessians.items():
-        hessians[name] = (prec / len_data).cpu()
+        hessians[name] = (prec / num_rows).cpu()
 
     if rank == 0:
         print("Computing hessian eigen decompositions...")

--- a/bergson/utils/math.py
+++ b/bergson/utils/math.py
@@ -12,7 +12,7 @@ def weighted_causal_lm_ce(
     *,
     example_weight: Tensor | None = None,
     ignore_index: int = -100,
-    valid_mask: Tensor | None = None,
+    shift_loss_mask: Tensor | None = None,
     vocab_size: int | None = None,
     reduction: str = "mean",
     **kwargs,  # Ignored
@@ -21,15 +21,17 @@ def weighted_causal_lm_ce(
     HuggingFace-compatible causal LM loss with per-example weighting.
 
     Args:
-    logits         : [B, T, V] float tensor of prediction scores
-    labels         : [B, T] long tensor of target token ids, or ignore_index
-    example_weight : [B] or [B, T] float tensor of weights
-    ignore_index   : int, label value to ignore in loss computation
-    vocab_size     : optional int, vocabulary size (for validation)
-    reduction      : "mean": mean over all valid tokens in the batch
-                     (standard). "sum_of_means": mean over
-                     each sample's tokens, summed over the batch with no
-                     batch-size division.
+    logits          : [B, T, V] float tensor of prediction scores
+    labels          : [B, T] long tensor of target token ids, or ignore_index
+    example_weight  : [B] or [B, T] float tensor of weights
+    ignore_index    : int, label value to ignore in loss computation
+    shift_loss_mask : optional [B, T] bool tensor;
+                      mask[i] = labels[i+1] != ignore_index
+    vocab_size      : optional int, vocabulary size (for validation)
+    reduction       : "mean": mean over all valid tokens in the batch
+                      (standard). "sum_of_means": mean over
+                      each sample's tokens, summed over the batch with no
+                      batch-size division.
     """
     assert logits.ndim == 3 and labels.ndim == 2
     B, T, V = logits.shape
@@ -72,15 +74,16 @@ def weighted_causal_lm_ce(
     if reduction == "sum_of_means":
         # Per-sample token-mean, summed over the batch (no /B).
         row_valid = (
-            valid_mask[:, :-1].to(tok_loss.dtype)
-            if valid_mask is not None
+            shift_loss_mask[:, :-1].to(tok_loss.dtype)
+            if shift_loss_mask is not None
             else (shift_labels != ignore_index).to(tok_loss.dtype)
         )
         row_counts = row_valid.sum(dim=1).clamp_min(1.0)  # [B]
         row_loss = (tok_loss * w).sum(dim=1) / row_counts  # [B]
         return row_loss.sum()
 
-    denom = valid_mask[:, :-1].sum() if valid_mask is not None else T - 1
+    # The mask's last column is always False, so no [:, :-1] slice is needed.
+    denom = shift_loss_mask.sum() if shift_loss_mask is not None else T - 1
     return (tok_loss * w).sum() / denom
 
 

--- a/tests/ekfac_tests/compute_ekfac_ground_truth.py
+++ b/tests/ekfac_tests/compute_ekfac_ground_truth.py
@@ -343,19 +343,19 @@ def compute_covariance(
 
     for sl in tqdm(batches, desc=f"Rank {rank} covariances"):
         batch = data[sl]
-        x, y, _, position_mask = pad_and_tensor(
+        x, y, _, collection_mask = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=device,
         )
 
-        total_processed += position_mask.sum()
+        total_processed += collection_mask.sum()
 
         # Run both collectors simultaneously during the same forward/backward pass
         # This ensures they see exactly the same gradients
-        with collector.with_batch(position_mask):
+        with collector.with_batch(collection_mask):
             if ekfac_collector is not None:
-                ekfac_ctx = ekfac_collector.with_batch(position_mask)
+                ekfac_ctx = ekfac_collector.with_batch(collection_mask)
             else:
                 ekfac_ctx = None
 
@@ -643,15 +643,15 @@ def compute_eigenvalue_correction_amortized(
 
     for sl in tqdm(batches, desc=f"Rank {rank} eigenvalue corrections"):
         batch = data[sl]
-        x, y, _, position_mask = pad_and_tensor(
+        x, y, _, collection_mask = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=device,
         )
 
-        total_processed += position_mask.sum()
+        total_processed += collection_mask.sum()
 
-        with collector.with_batch(position_mask):
+        with collector.with_batch(collection_mask):
             logits = model(x).logits
             losses = F.cross_entropy(
                 logits[:, :-1].reshape(-1, logits.size(-1)),

--- a/tests/ekfac_tests/compute_ekfac_ground_truth.py
+++ b/tests/ekfac_tests/compute_ekfac_ground_truth.py
@@ -343,19 +343,19 @@ def compute_covariance(
 
     for sl in tqdm(batches, desc=f"Rank {rank} covariances"):
         batch = data[sl]
-        x, y, _, collection_mask = pad_and_tensor(
+        x, y, _, position_mask = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=device,
         )
 
-        total_processed += collection_mask.sum()
+        total_processed += position_mask.sum()
 
         # Run both collectors simultaneously during the same forward/backward pass
         # This ensures they see exactly the same gradients
-        with collector.with_batch(collection_mask):
+        with collector.with_batch(position_mask):
             if ekfac_collector is not None:
-                ekfac_ctx = ekfac_collector.with_batch(collection_mask)
+                ekfac_ctx = ekfac_collector.with_batch(position_mask)
             else:
                 ekfac_ctx = None
 
@@ -643,15 +643,15 @@ def compute_eigenvalue_correction_amortized(
 
     for sl in tqdm(batches, desc=f"Rank {rank} eigenvalue corrections"):
         batch = data[sl]
-        x, y, _, collection_mask = pad_and_tensor(
+        x, y, _, position_mask = pad_and_tensor(
             batch["input_ids"],
             labels=batch.get("labels"),
             device=device,
         )
 
-        total_processed += collection_mask.sum()
+        total_processed += position_mask.sum()
 
-        with collector.with_batch(collection_mask):
+        with collector.with_batch(position_mask):
             logits = model(x).logits
             losses = F.cross_entropy(
                 logits[:, :-1].reshape(-1, logits.size(-1)),

--- a/tests/ekfac_tests/ground_truth/collector.py
+++ b/tests/ekfac_tests/ground_truth/collector.py
@@ -24,9 +24,9 @@ class GroundTruthCovarianceCollector(HookCollectorBase):
 
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         name = assert_type(str, module._name)
-        mask = self._current_position_mask
+        mask = self._current_collection_mask
 
-        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
+        # a: [N, S, I], collection mask: [N, S] -> select gradient-carrying positions
         if mask is not None:
             a = a[mask].float()  # [num_valid, I]
         else:
@@ -41,9 +41,9 @@ class GroundTruthCovarianceCollector(HookCollectorBase):
 
     def backward_hook(self, module: nn.Module, g: Tensor) -> None:
         name = assert_type(str, module._name)
-        mask = self._current_position_mask
+        mask = self._current_collection_mask
 
-        # g: [N, S, O], position mask: [N, S] -> select gradient-carrying positions
+        # g: [N, S, O], collection mask: [N, S] -> select gradient-carrying positions
         if mask is not None:
             g = g[mask].float()  # [num_valid, O]
         else:

--- a/tests/ekfac_tests/ground_truth/collector.py
+++ b/tests/ekfac_tests/ground_truth/collector.py
@@ -24,9 +24,9 @@ class GroundTruthCovarianceCollector(HookCollectorBase):
 
     def forward_hook(self, module: nn.Module, a: Tensor) -> None:
         name = assert_type(str, module._name)
-        mask = self._current_collection_mask
+        mask = self._current_position_mask
 
-        # a: [N, S, I], valid_masks: [N, S] -> select valid positions
+        # a: [N, S, I], position mask: [N, S] -> select gradient-carrying positions
         if mask is not None:
             a = a[mask].float()  # [num_valid, I]
         else:
@@ -41,9 +41,9 @@ class GroundTruthCovarianceCollector(HookCollectorBase):
 
     def backward_hook(self, module: nn.Module, g: Tensor) -> None:
         name = assert_type(str, module._name)
-        mask = self._current_collection_mask
+        mask = self._current_position_mask
 
-        # g: [N, S, O], valid_masks: [N, S] -> select valid positions
+        # g: [N, S, O], position mask: [N, S] -> select gradient-carrying positions
         if mask is not None:
             g = g[mask].float()  # [num_valid, O]
         else:

--- a/tests/ekfac_tests/test_fim_accuracy.py
+++ b/tests/ekfac_tests/test_fim_accuracy.py
@@ -98,10 +98,10 @@ def compute_exact_fim(
     [
         ((512,), 100, False, 0.05),
         ((512,), 100, True, 0.05),
-        ((4,), 10000, False, 0.05),  # rel_error = ~0.25 without position-mask logic
-        ((4,), 10000, True, 0.10),  # rel_error = ~0.25 without position-mask logic
-        ((512, 2), 100, False, 0.05),  # rel_error = ~0.6 without position-mask logic
-        ((512, 2), 100, True, 0.20),  # rel_error = ~1.2 without position-mask logic
+        ((4,), 10000, False, 0.05),  # rel_error = ~0.25 without collection-mask logic
+        ((4,), 10000, True, 0.10),  # rel_error = ~0.25 without collection-mask logic
+        ((512, 2), 100, False, 0.05),  # rel_error = ~0.6 without collection-mask logic
+        ((512, 2), 100, True, 0.20),  # rel_error = ~1.2 without collection-mask logic
     ],
 )
 def test_kfac_fim_accuracy(seq_lengths, num_batches, max_rel_error, sample, tmp_path):

--- a/tests/ekfac_tests/test_fim_accuracy.py
+++ b/tests/ekfac_tests/test_fim_accuracy.py
@@ -98,10 +98,10 @@ def compute_exact_fim(
     [
         ((512,), 100, False, 0.05),
         ((512,), 100, True, 0.05),
-        ((4,), 10000, False, 0.05),  # rel_error = ~0.25 without valid_masks logic
-        ((4,), 10000, True, 0.10),  # rel_error = ~0.25 without valid_masks logic
-        ((512, 2), 100, False, 0.05),  # rel_error = ~0.6 without valid_masks logic
-        ((512, 2), 100, True, 0.20),  # rel_error = ~1.2 without valid_masks logic
+        ((4,), 10000, False, 0.05),  # rel_error = ~0.25 without position-mask logic
+        ((4,), 10000, True, 0.10),  # rel_error = ~0.25 without position-mask logic
+        ((512, 2), 100, False, 0.05),  # rel_error = ~0.6 without position-mask logic
+        ((512, 2), 100, True, 0.20),  # rel_error = ~1.2 without position-mask logic
     ],
 )
 def test_kfac_fim_accuracy(seq_lengths, num_batches, max_rel_error, sample, tmp_path):

--- a/tests/ekfac_tests/test_fim_scaling.py
+++ b/tests/ekfac_tests/test_fim_scaling.py
@@ -51,7 +51,7 @@ class CountingCovarianceCollector(CovarianceCollector):
         self.ingested = dict.fromkeys(self.target_info, 0)
 
     def forward_hook(self, module, a):
-        mask = self._current_position_mask
+        mask = self._current_collection_mask
         assert mask is not None
         name = assert_type(str, module._name)
         self.ingested[name] += int(mask.sum())

--- a/tests/ekfac_tests/test_fim_scaling.py
+++ b/tests/ekfac_tests/test_fim_scaling.py
@@ -1,0 +1,154 @@
+"""Regression test for FIM covariance scaling under label masking.
+
+The K-FAC covariance accumulators (``A_cov = Σ aaᵀ``, ``S_cov = Σ ggᵀ``)
+ingest every gradient-carrying position — each real position except the
+last — regardless of loss masking, because gradients flow back through
+attention to prompt positions. ``total_processed.pt`` is later used to
+normalize these sums into means (see ``eigenvectors.py``), so it must
+count exactly the ingested positions. It used to count supervised
+(non-``-100``-label) positions instead, which diverges under prompt
+masking and mis-scales the FIM.
+"""
+
+import pytest
+import torch
+from datasets import Dataset
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from bergson.collector.collector import CollectorComputer
+from bergson.config import IndexConfig
+from bergson.gradients import GradientProcessor
+from bergson.hessians.autocorrelation import AutocorrelationCollector
+from bergson.hessians.kfac import CovarianceCollector
+from bergson.utils.utils import assert_type, get_device
+
+INPUT_IDS = [
+    [1, 2, 3, 4, 5, 6],
+    [7, 8, 9, 10],
+    [11, 12, 13, 14, 15],
+]
+# Prompt-masked labels: the supervised-token count (6) differs from the
+# number of gradient-carrying positions (length - 1 per doc = 12).
+LABELS = [
+    [-100, -100, -100, 4, 5, 6],
+    [-100, -100, 9, 10],
+    [-100, -100, -100, -100, 15],
+]
+
+
+def make_model():
+    torch.manual_seed(0)
+    config = AutoConfig.from_pretrained("trl-internal-testing/tiny-Phi3ForCausalLM")
+    model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.float32)
+    return model.to(get_device(0))
+
+
+class CountingCovarianceCollector(CovarianceCollector):
+    """CovarianceCollector that records how many positions each hook ingests."""
+
+    def setup(self) -> None:
+        super().setup()
+        self.ingested = dict.fromkeys(self.target_info, 0)
+
+    def forward_hook(self, module, a):
+        mask = self._current_position_mask
+        assert mask is not None
+        name = assert_type(str, module._name)
+        self.ingested[name] += int(mask.sum())
+        super().forward_hook(module, a)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_total_processed_matches_ingested_positions(tmp_path):
+    model = make_model()
+    data = Dataset.from_dict({"input_ids": INPUT_IDS, "labels": LABELS})
+
+    expected_positions = sum(len(ids) - 1 for ids in INPUT_IDS)
+    supervised_tokens = sum(sum(tok != -100 for tok in doc[1:]) for doc in LABELS)
+    assert supervised_tokens != expected_positions, "test data must diverge"
+
+    run_cfg = IndexConfig(run_path=str(tmp_path / "run"))
+    run_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+
+    collector = CountingCovarianceCollector(
+        model=model.base_model,
+        dtype=torch.float32,
+        path=str(tmp_path / "cov"),
+        processor=GradientProcessor(),
+    )
+    computer = CollectorComputer(
+        model=model,
+        data=data,
+        collector=collector,
+        cfg=run_cfg,
+    )
+    computer.run_with_collector_hooks()
+
+    # Every module's covariance ingested all gradient-carrying positions,
+    # prompt included.
+    for name, count in collector.ingested.items():
+        assert (
+            count == expected_positions
+        ), f"{name} ingested {count} positions, expected {expected_positions}"
+
+    # The saved normalizer counts the same positions the covariances ingested.
+    total_processed = torch.load(run_cfg.partial_run_path / "total_processed.pt")
+    assert int(total_processed) == expected_positions
+
+
+class RawGramAutocorrelation(AutocorrelationCollector):
+    """AutocorrelationCollector that also keeps the unnormalized Grams."""
+
+    def setup(self) -> None:
+        super().setup()
+        self.raw_grams: dict[str, torch.Tensor] = {}
+
+    def backward_hook(self, module, g):
+        name = assert_type(str, module._name)
+        P = self._compute_gradient(module, g).float()
+        if name in self.raw_grams:
+            self.raw_grams[name] += P.mT @ P
+        else:
+            self.raw_grams[name] = P.mT @ P
+        super().backward_hook(module, g)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("attribute_tokens", [False, True])
+def test_autocorrelation_normalized_by_row_count(tmp_path, attribute_tokens):
+    """The autocorrelation Gram is divided by the number of gradient rows it
+    summed: documents for per-sequence gradients, gradient-carrying tokens
+    for per-token gradients."""
+    model = make_model()
+    data = Dataset.from_dict({"input_ids": INPUT_IDS, "labels": LABELS})
+
+    expected_rows = (
+        sum(len(ids) - 1 for ids in INPUT_IDS) if attribute_tokens else len(INPUT_IDS)
+    )
+
+    run_cfg = IndexConfig(run_path=str(tmp_path / "run"))
+    run_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+
+    processor = GradientProcessor()
+    collector = RawGramAutocorrelation(
+        model=model.base_model,
+        data=data,
+        path=str(tmp_path / "processor"),
+        processor=processor,
+        attribute_tokens=attribute_tokens,
+        target_modules={"layers.0.mlp.down_proj", "layers.1.self_attn.o_proj"},
+    )
+    computer = CollectorComputer(
+        model=model,
+        data=data,
+        collector=collector,
+        cfg=run_cfg,
+    )
+    computer.run_with_collector_hooks()
+
+    assert processor.hessians, "no hessians accumulated"
+    for name, raw in collector.raw_grams.items():
+        torch.testing.assert_close(
+            processor.hessians[name].to(raw.device),
+            raw / expected_rows,
+        )


### PR DESCRIPTION
Follow-up to #322. Under attribute_tokens the autocorrelation Gram accumulates one gradient row per gradient-carrying token, but is still normalized by the document count. Add HookCollectorBase.num_gram_rows() and use it at every process_autocorrelation_matrices call site so the normalized matrix is a second moment over the matching unit.

Also rename the masks for clarity: pad_and_tensor's valid_mask becomes shift_loss_mask (marks input positions whose next-token prediction is supervised) and collection_mask becomes position_mask (every real position except each sequence's last, independent of label masking), with matching docstring updates. Add a regression test for the Gram normalization and the total_processed position count.