### PR TITLE
Seed RNG before model init for reproducible runs

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -203,6 +203,8 @@ def worker(
         dist.barrier()
 
     schedule = run_cfg.lr_schedule.get_schedule(len(stream))
+    torch.manual_seed(run_cfg.seed)
+    torch.cuda.manual_seed_all(run_cfg.seed)
     trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
 
     ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")

--- a/bergson/magic/metasmoothness.py
+++ b/bergson/magic/metasmoothness.py
@@ -103,6 +103,9 @@ def metasmoothness_worker(
             weights[-weight_pad_count:] = 0.0
         stream.weights.data.copy_(weights.to(stream.weights.device))
 
+        torch.manual_seed(run_cfg.seed)
+        torch.cuda.manual_seed_all(run_cfg.seed)
+
         trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
         fwd_state.detach_()
         fwd_state = trainer.train(fwd_state, stream, inplace=True, fsdp=run_cfg.fsdp)


### PR DESCRIPTION
Seed torch's RNG from run_cfg.seed immediately before prepare_trainer in both the MAGIC worker and each of the three metasmoothness trainings. Required for a meaningful metasmoothness score with LoRA.


Claude-Session: https://claude.ai/code/session_01SF71RwHMSoNZhGEj16v2nM