### PR TITLE
Add per-token LDS

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -103,6 +103,15 @@ def compute_query_gradients(
     return grad_accum, float(loss_accum)
 
 
+def scores_are_per_token(score_path: str) -> bool:
+    if os.path.isdir(score_path):
+        return os.path.isfile(os.path.join(score_path, "token_scores.bin"))
+    if score_path.endswith(".npy"):
+        return False
+    scores = torch.load(score_path, map_location="cpu")
+    return isinstance(scores, torch.Tensor) and scores.ndim == 2 and scores.shape[1] > 1
+
+
 def attach_doc_ids_if_missing(dataset: Dataset) -> Dataset:
     """Ensure the dataset has a ``doc_ids`` column.
 
@@ -172,7 +181,11 @@ def worker(
         )
     )
 
-    if getattr(run_cfg, "per_token", False):
+    # Plain magic runs enter with score_path="" (scores are computed below).
+    per_token = getattr(run_cfg, "per_token", False) or (
+        score_path and scores_are_per_token(score_path)
+    )
+    if per_token:
         seq_len = run_cfg.data.chunk_length
         if seq_len <= 0:
             seq_len = max(train_dataset["length"])

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -37,19 +37,55 @@ from .utils.utils import get_device
 from .utils.worker_utils import setup_data_pipeline
 
 
+def _load_token_grid(path: str) -> torch.Tensor:
+    """Unpack a packed per-token score directory into a zero-padded
+    ``[docs, seq_len]`` grid, so token ``t`` of doc ``d`` lands at
+    ``grid[d, t]`` (the per-token training weight layout)."""
+    score_dir = Path(path)
+    info = json.loads((score_dir / "info.json").read_text())
+    num_docs, num_scores = info["num_items"], info["num_scores"]
+
+    offsets = np.load(score_dir / "offsets.npy")
+    tokens_per_doc = np.diff(offsets).astype(np.int64)
+    packed = np.memmap(
+        score_dir / "token_scores.bin",
+        dtype=info["dtype"],
+        mode="r",
+        shape=(info["total_tokens"], num_scores),
+    )
+
+    # A doc of length L stores L-1 rows (nothing is predicted at the last
+    # position), so the weight-grid width is one more than the widest doc.
+    seq_len = int(tokens_per_doc.max()) + 1
+    grid = np.zeros((num_docs, seq_len, num_scores), dtype=np.float32)
+    for doc in range(num_docs):
+        grid[doc, : tokens_per_doc[doc]] = packed[offsets[doc] : offsets[doc + 1]]
+
+    scores = torch.from_numpy(grid)
+    return scores[..., 0] if num_scores == 1 else scores
+
+
 def load_attribution_scores(score_path: str) -> tuple[torch.Tensor, bool]:
     """Load attribution scores from a score directory, ``.npy``, or ``.pt`` file.
 
-    Returns ``(scores, multi_query)``. ``multi_query`` is True when the scores
-    hold one column per query (score directories and ``.npy`` arrays with a
-    second dimension > 1). 2D tensors in ``.pt`` files are per-token MAGIC
-    scores, never multi-query, so callers should load those themselves.
+    Returns ``(scores, multi_query)``. Token score directories are per-token,
+    with a query dimension when ``num_scores > 1`` (``[docs, seq_len,
+    queries]``); plain score directories and ``.npy`` arrays are per-document,
+    with one column per query; 2-D ``.pt`` tensors are per-token MAGIC scores
+    (``[docs, seq_len]``, single-query).
 
     Score directories are negated when their ``score_cfg.higher_is_better`` is
-    set, aligning them with the loss-diff convention. ``.npy`` files (e.g. the
-    summed approximate-unrolling scores) carry no ``score_cfg`` and are loaded
-    as-is.
+    set, aligning them with the loss-diff convention. ``.npy`` files carry no
+    ``score_cfg`` and are loaded as-is.
     """
+    if os.path.isdir(score_path) and os.path.isfile(
+        os.path.join(score_path, "token_scores.bin")
+    ):
+        scores = _load_token_grid(score_path)
+        score_cfg = load_subconfig(score_path, "score_cfg", ScoreConfig)
+        if score_cfg is not None and score_cfg.higher_is_better:
+            scores = -scores
+        return scores, scores.ndim == 3
     if os.path.isdir(score_path):
         scores = torch.from_numpy(load_scores(Path(score_path))[:])
         score_cfg = load_subconfig(score_path, "score_cfg", ScoreConfig)
@@ -217,9 +253,9 @@ def validate_scores(
     num_real_query_docs = num_query_docs - query_weight_pad_count
     baseline_per_doc = torch.zeros(num_real_query_docs)
     if multi_query:
-        if scores.shape[1] != num_real_query_docs:
+        if scores.shape[-1] != num_real_query_docs:
             raise ValueError(
-                f"scores has {scores.shape[1]} query columns but the query "
+                f"scores has {scores.shape[-1]} query columns but the query "
                 f"dataset has {num_real_query_docs} documents; multi-query "
                 "validation requires one score column per query document"
             )
@@ -227,15 +263,21 @@ def validate_scores(
             baseline_per_doc = per_doc_query_losses(
                 model, query_stream, num_query_docs
             )[:num_real_query_docs].cpu()
+    elif scores.ndim == 2 and scores.shape[1] > 1:
+        pass  # Per-token [docs, seq_len]; kept 2-D.
     else:
         assert scores.ndim == 1 or scores.shape[1] == 1
         scores = scores.flatten()
 
+    # flat_scores rows are the leave-out units: documents, or
+    # doc * seq_len + token positions for per-token scores.
+    num_queries = scores.shape[-1] if multi_query else 1
+    flat_scores = scores.reshape(-1, num_queries)
+
     if run_cfg.exclude_zero_scores:
-        nonzero = scores != 0 if scores.ndim == 1 else (scores != 0).any(dim=1)
-        valid_indices = torch.nonzero(nonzero, as_tuple=True)[0]
+        valid_indices = torch.nonzero((flat_scores != 0).any(dim=1), as_tuple=True)[0]
     else:
-        valid_indices = torch.arange(len(scores))
+        valid_indices = torch.arange(flat_scores.shape[0])
 
     if run_cfg.subset_strategy == "random":
         rng = torch.Generator().manual_seed(run_cfg.seed)
@@ -302,7 +344,7 @@ def validate_scores(
                 stream.weights.data[-weight_pad_count:] = 0.0
             else:
                 stream.weights.data[-pad_count:] = 0.0
-        stream.weights[subset] = 0.0
+        stream.weights.view(-1)[subset] = 0.0
 
         for x in stream:
             fwd_state = trainer.step(fwd_state, x, inplace=True, fsdp=run_cfg.fsdp)
@@ -319,7 +361,7 @@ def validate_scores(
             with fwd_state.activate(model):
                 per_doc = per_doc_query_losses(model, query_stream, num_query_docs)
             diff_vec = baseline_per_doc - per_doc[:num_real_query_docs].cpu()
-            score_sum_vec = scores[subset].sum(dim=0)
+            score_sum_vec = flat_scores[subset].sum(dim=0)
             for q in range(num_real_query_docs):
                 val_csv_writer.writerow(
                     i, q, diff_vec[q].item(), score_sum_vec[q].item()
@@ -353,7 +395,7 @@ def validate_scores(
             dist.all_reduce(loss, op=dist.ReduceOp.AVG)
 
         diff = baseline - loss.item()
-        score_sum = scores[subset].sum().item()
+        score_sum = flat_scores[subset].sum().item()
         val_csv_writer.writerow(i, diff, score_sum)
 
         if global_rank == 0:

--- a/tests/test_per_token_lds.py
+++ b/tests/test_per_token_lds.py
@@ -1,0 +1,242 @@
+"""Per-token leave-k-out re-weighting in ``validate_scores``.
+
+The re-weighting is method-agnostic: it acts on the ``scores`` tensor and the
+training ``stream.weights`` via flat indexing, so it works for any attribution
+method that emits per-token scores in the ``[docs, seq_len]`` grid layout
+(matching the per-token training weight shape). These tests cover the flat
+indexing invariants -- that a flat subset re-weights exactly the intended token
+positions, that whole-document subsets reduce to the per-document behaviour, and
+that the per-document (1-D) path is unchanged.
+"""
+
+import torch
+from datasets import Dataset
+
+from bergson.magic.data_stream import DataStream
+from bergson.validate import load_attribution_scores
+
+
+def test_flat_reweight_per_doc_matches_direct_indexing():
+    """1-D (per-doc) weights: ``view(-1)[subset]`` equals direct indexing, so
+    the per-document leave-k-out path is unchanged by the flat generalization."""
+    weights = torch.ones(8)
+    subset = torch.tensor([1, 4, 6])
+
+    flat = weights.clone()
+    flat.view(-1)[subset] = 0.0
+    direct = torch.ones(8)
+    direct[subset] = 0.0
+
+    torch.testing.assert_close(flat, direct)
+
+
+def test_flat_reweight_per_token_hits_grid_positions():
+    """2-D (per-token) weights: a flat subset re-weights exactly the intended
+    ``doc * seq_len + token`` grid positions and nothing else."""
+    n_docs, seq_len = 4, 5
+    weights = torch.ones(n_docs, seq_len)
+    # doc 1 token 2, doc 3 token 0, doc 3 token 4
+    positions = [(1, 2), (3, 0), (3, 4)]
+    subset = torch.tensor([d * seq_len + t for d, t in positions])
+
+    weights.view(-1)[subset] = 2.0
+
+    expected = torch.ones(n_docs, seq_len)
+    for d, t in positions:
+        expected[d, t] = 2.0
+    torch.testing.assert_close(weights, expected)
+
+
+def test_whole_doc_token_subset_reweights_full_row():
+    """Selecting every token position of a document is equivalent to selecting
+    that document in the per-document formulation (its whole row is set)."""
+    n_docs, seq_len = 3, 6
+    weights = torch.ones(n_docs, seq_len)
+    doc = 1
+    subset = torch.arange(doc * seq_len, (doc + 1) * seq_len)
+
+    weights.view(-1)[subset] = 0.0
+
+    expected = torch.ones(n_docs, seq_len)
+    expected[doc] = 0.0
+    torch.testing.assert_close(weights, expected)
+
+
+def test_reweight_sequence_preserves_padding_rows():
+    """The retrain loop's exact sequence -- fill with 1.0, zero the padding
+    rows, then flat-reweight the subset -- leaves padding rows at zero, so
+    batch-size padding docs never re-enter training."""
+    n_docs, seq_len, pad_count = 4, 5, 1
+    weights = torch.ones(n_docs, seq_len)
+    weights.data[-pad_count:] = 0.0
+    subset = torch.tensor([0 * seq_len + 2, 1 * seq_len + 4])
+
+    weights.view(-1)[subset] = 0.0
+
+    assert weights[-pad_count:].eq(0).all()
+    expected_real = torch.ones(n_docs - pad_count, seq_len)
+    expected_real[0, 2] = 0.0
+    expected_real[1, 4] = 0.0
+    torch.testing.assert_close(weights[:-pad_count], expected_real)
+
+
+def test_score_sum_flat_per_token():
+    """``scores.reshape(-1)[subset].sum()`` sums the selected per-token scores
+    regardless of the score tensor's shape (1-D per doc or 2-D per token)."""
+    scores = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    subset = torch.tensor([0 * 4 + 1, 2 * 4 + 3])  # scores 1 and 11
+
+    got = scores.reshape(-1)[subset].sum()
+
+    torch.testing.assert_close(got, torch.tensor(12.0))
+    # Same expression on a flat (per-doc) score vector.
+    flat = torch.arange(6, dtype=torch.float32)
+    torch.testing.assert_close(
+        flat.reshape(-1)[torch.tensor([0, 5])].sum(), torch.tensor(5.0)
+    )
+
+
+def test_score_sum_flat_multi_query_per_token():
+    """``scores.reshape(-1, num_queries)[subset].sum(dim=0)`` sums each query's
+    scores over the selected token positions of a ``[docs, seq_len, queries]``
+    grid -- the same expression that serves per-doc multi-query scores."""
+    n_docs, seq_len, num_queries = 2, 3, 2
+    scores = torch.arange(12, dtype=torch.float32).reshape(n_docs, seq_len, num_queries)
+    # doc 0 token 1, doc 1 token 2
+    subset = torch.tensor([0 * seq_len + 1, 1 * seq_len + 2])
+
+    got = scores.reshape(-1, num_queries)[subset].sum(dim=0)
+
+    torch.testing.assert_close(got, scores[0, 1] + scores[1, 2])
+    # Per-doc multi-query [docs, queries] is served by the same expression.
+    per_doc = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    torch.testing.assert_close(
+        per_doc.reshape(-1, 2)[torch.tensor([1, 3])].sum(dim=0), per_doc[1] + per_doc[3]
+    )
+
+
+def test_load_attribution_scores_per_token_pt(tmp_path):
+    """A 2-D ``.pt`` tensor is treated as per-token MAGIC scores, never
+    multi-query -- so ``validate_scores`` keeps it 2-D for token re-weighting."""
+    scores = torch.randn(6, 5)
+    path = tmp_path / "scores.pt"
+    torch.save(scores, path)
+
+    loaded, multi_query = load_attribution_scores(str(path))
+
+    assert not multi_query
+    assert loaded.shape == (6, 5)
+    torch.testing.assert_close(loaded, scores)
+
+
+def test_datastream_serves_reweighted_per_token_weights():
+    """End of the pipeline: after a flat per-token re-weight, the DataStream
+    serves the updated per-token ``example_weight`` for each batch, so the
+    retrain actually sees the re-weighted tokens."""
+    input_ids = [[1, 2, 3, 4], [5, 6, 7, 8]]
+    data = Dataset.from_dict({"input_ids": input_ids})
+    n_docs, seq_len = 2, 4
+    stream = DataStream(data, batch_size=2, weight_shape=(n_docs, seq_len))
+    # Retrains hold weights fixed, exactly as validate_scores does before
+    # re-weighting a subset.
+    stream.requires_grad = False
+
+    # Down-weight doc 0's token 2 and doc 1's token 0 to zero.
+    subset = torch.tensor([0 * seq_len + 2, 1 * seq_len + 0])
+    stream.weights.view(-1)[subset] = 0.0
+
+    batch = stream[0]
+    ew = batch["example_weight"]
+    assert ew.shape == (n_docs, seq_len)
+    expected = torch.ones(n_docs, seq_len)
+    expected[0, 2] = 0.0
+    expected[1, 0] = 0.0
+    torch.testing.assert_close(ew.cpu(), expected)
+
+
+def _write_token_dir(path, ntg, values, num_scores=1):
+    import json
+
+    import numpy as np
+
+    offsets = np.zeros(len(ntg) + 1, dtype=np.int64)
+    np.cumsum(ntg, out=offsets[1:])
+    total = int(offsets[-1])
+    mm = np.memmap(
+        path / "token_scores.bin", dtype="float32", mode="w+", shape=(total, num_scores)
+    )
+    mm[:] = np.asarray(values, dtype=np.float32).reshape(total, num_scores)
+    mm.flush()
+    np.save(path / "offsets.npy", offsets)
+    (path / "info.json").write_text(
+        json.dumps(
+            {
+                "attribute_tokens": True,
+                "total_tokens": total,
+                "num_items": len(ntg),
+                "num_scores": num_scores,
+                "dtype": "float32",
+            }
+        )
+    )
+
+
+def test_load_token_dir_scatters_packed_to_grid(tmp_path):
+    """A packed EK-FAC/TrackStar/SOURCE token dir loads as the same
+    ``[docs, seq_len]`` grid as MAGIC, with tokens at positions 0..len-2."""
+    _write_token_dir(tmp_path, ntg=[3, 2], values=[1, 2, 3, 4, 5])
+
+    scores, multi_query = load_attribution_scores(str(tmp_path))
+
+    assert not multi_query
+    assert scores.shape == (2, 4)  # width = max(len-1)+1
+    expected = torch.tensor([[1.0, 2.0, 3.0, 0.0], [4.0, 5.0, 0.0, 0.0]])
+    torch.testing.assert_close(scores, expected)
+
+
+def test_scores_are_per_token_inference(tmp_path):
+    """``bergson validate`` infers per-token-ness from the scores themselves:
+    token dirs and 2-D ``.pt`` tensors are per-token; 1-D ``.pt``, ``.npy``,
+    and plain score dirs are per-document."""
+    from bergson.magic.cli import scores_are_per_token
+
+    token_dir = tmp_path / "token_dir"
+    token_dir.mkdir()
+    _write_token_dir(token_dir, ntg=[3, 2], values=[1, 2, 3, 4, 5])
+    assert scores_are_per_token(str(token_dir))
+
+    pt_2d = tmp_path / "per_token.pt"
+    torch.save(torch.randn(6, 5), pt_2d)
+    assert scores_are_per_token(str(pt_2d))
+
+    pt_1d = tmp_path / "per_doc.pt"
+    torch.save(torch.randn(6), pt_1d)
+    assert not scores_are_per_token(str(pt_1d))
+
+    pt_col = tmp_path / "per_doc_col.pt"
+    torch.save(torch.randn(6, 1), pt_col)
+    assert not scores_are_per_token(str(pt_col))
+
+    import numpy as np
+
+    npy = tmp_path / "multi_query.npy"
+    np.save(npy, np.random.randn(6, 5))
+    assert not scores_are_per_token(str(npy))
+
+    plain_dir = tmp_path / "plain_dir"
+    plain_dir.mkdir()
+    assert not scores_are_per_token(str(plain_dir))
+
+
+def test_load_token_dir_keeps_query_dim_when_multiscore(tmp_path):
+    _write_token_dir(
+        tmp_path, ntg=[2, 1], values=[[1, 2], [3, 4], [5, 6]], num_scores=2
+    )
+
+    scores, multi_query = load_attribution_scores(str(tmp_path))
+
+    assert multi_query
+    assert scores.shape == (2, 3, 2)
+    torch.testing.assert_close(scores[0, 0], torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(scores[1, 0], torch.tensor([5.0, 6.0]))
+    torch.testing.assert_close(scores[1, 1], torch.tensor([0.0, 0.0]))


### PR DESCRIPTION
Handle per-token scores in validate

Per-token-ness is inferred from the scores files (token score directories, or 2-D .pt tensors with >1 columns). 

load_attribution_scores loads per-token score directories (token_scores.bin + offsets.npy) into a dense zero-padded [docs, seq_len] grid matching the training weight layout.