### PR TITLE
fix: harden optimizer-state saving/loading — Conv1D, HF param groups, FSDP

### DIFF
--- a/bergson/gradients.py
+++ b/bergson/gradients.py
@@ -261,6 +261,12 @@ class LayerAdapter:
             case _:
                 raise ValueError(f"Unsupported layer type: {type(layer)}")
 
+    @staticmethod
+    def weight_transposed(layer: nn.Module) -> bool:
+        """Whether the layer stores its weight ``[in, out]`` (HF Conv1D)
+        rather than ``[out, in]``."""
+        return isinstance(layer, HFConv1D)
+
 
 @dataclass
 class AdafactorNormalizer(Normalizer):

--- a/bergson/utils/load_from_optimizer.py
+++ b/bergson/utils/load_from_optimizer.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from pathlib import Path
 
@@ -5,7 +6,10 @@ import torch
 from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import parse_hf_uri
 from peft import PeftModel, get_peft_model_state_dict
+from torch import nn
 from transformers import PreTrainedModel
+from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
+from transformers.trainer_pt_utils import get_parameter_names
 
 from bergson.gradients import (
     AdafactorNormalizer,
@@ -111,26 +115,43 @@ def _base_model_prefix(model) -> str:
     return ""
 
 
-def _orient_weight_second_moment(exp_avg_sq, model, layer_name):
-    """Return ``exp_avg_sq`` in the collector's ``[out, in]`` orientation.
+def orient_second_moment(
+    t: torch.Tensor, out_dim: int, in_dim: int, layer=None
+) -> torch.Tensor | None:
+    """Return ``t`` in ``[out, in]`` orientation.
 
-    The optimizer stores the second moment in the parameter's own layout, which
-    is ``[out, in]`` for ``nn.Linear`` but ``[in, out]`` for HF ``Conv1D`` (GPT-2
-    attn/mlp). The collector always feeds ``AdamNormalizer`` a ``[out, in]``
-    gradient, so a Conv1D moment must be transposed or the divide broadcasts
-    against the wrong axis. Orient by matching the module's out/in sizes.
+    When ``layer`` is a supported module its class decides the storage
+    convention (``LayerAdapter.weight_transposed``; HF Conv1D stores
+    ``[in, out]``) — required for square weights, where shapes cannot
+    distinguish the orientations. Otherwise fall back to shape matching.
+    ``None`` when the (oriented) shape does not match ``(out_dim, in_dim)``.
     """
+    if layer is not None and isinstance(layer, LayerAdapter.supported_modules):
+        oriented = t.T if LayerAdapter.weight_transposed(layer) else t
+        return (
+            oriented.contiguous()
+            if tuple(oriented.shape) == (out_dim, in_dim)
+            else None
+        )
+    if tuple(t.shape) == (out_dim, in_dim):
+        return t.contiguous()
+    if tuple(t.shape) == (in_dim, out_dim):
+        return t.T.contiguous()
+    return None
+
+
+def _orient_weight_second_moment(exp_avg_sq, model, layer_name):
+    """Return ``exp_avg_sq`` in the collector's ``[out, in]`` orientation,
+    per the module's storage convention; unknown modules or shapes pass
+    through unchanged."""
     try:
         module = model.get_submodule(layer_name)
         o = getattr(module, LayerAdapter.out_attr(module))
         i = getattr(module, LayerAdapter.in_attr(module))
     except (AttributeError, ValueError):
         return exp_avg_sq  # unknown module; leave as-is
-    if tuple(exp_avg_sq.shape) == (o, i):
-        return exp_avg_sq
-    if tuple(exp_avg_sq.shape) == (i, o):
-        return exp_avg_sq.T.contiguous()
-    return exp_avg_sq
+    oriented = orient_second_moment(exp_avg_sq, o, i, layer=module)
+    return exp_avg_sq if oriented is None else oriented
 
 
 def get_normalizers(
@@ -146,10 +167,15 @@ def get_normalizers(
     normalizers: dict[str, Normalizer] = {}
     for param_idx, state in optimizer_state["state"].items():
         param_idx = int(param_idx)
-        if param_idx not in target_param_index_to_name:
+        # Prefer the recorded param_name when the file carries one: positional
+        # indices written from an FSDP-wrapped model do not match a fresh
+        # model's enumeration.
+        param_name = (
+            state.get("param_name") if isinstance(state, dict) else None
+        ) or target_param_index_to_name.get(param_idx)
+        if param_name is None:
             continue
 
-        param_name = target_param_index_to_name[param_idx]
         if not param_name.endswith(".weight"):
             continue
 
@@ -203,6 +229,59 @@ def get_normalizers(
     return normalizers
 
 
+def optimizer_param_index_to_name(optimizer_pt: dict, model) -> dict[int, str]:
+    """Map ``optimizer.pt`` state indices to param names for a non-PEFT model.
+
+    With a single param group the indices follow ``model.named_parameters()``
+    order. With multiple groups, assume HF Trainer's decay/no-decay split and
+    reconstruct it with transformers' own utilities. Entries that record a
+    ``param_name`` (bergson snapshot exports) should take precedence over
+    this mapping in consumers; remaining second-moment shapes are verified
+    against the mapped params.
+    """
+    groups = optimizer_pt.get("param_groups", [])
+    if len(groups) <= 1:
+        mapping = {idx: name for idx, (name, _) in enumerate(model.named_parameters())}
+    else:
+        decay = {
+            n
+            for n in get_parameter_names(model, ALL_LAYERNORM_LAYERS)
+            if "bias" not in n
+        }
+        named = [(n, p) for n, p in model.named_parameters() if p.requires_grad]
+        ordered = [n for n, _ in named if n in decay] + [
+            n for n, _ in named if n not in decay
+        ]
+        group_sizes = [len(g.get("params", [])) for g in groups]
+        expected = [len([n for n, _ in named if n in decay])]
+        expected.append(len(named) - expected[0])
+        if len(groups) != 2 or group_sizes != expected:
+            raise ValueError(
+                f"Cannot map optimizer.pt state indices to params: "
+                f"{len(groups)} param groups of sizes {group_sizes} do not "
+                f"match HF Trainer's decay/no-decay split {expected} for this "
+                f"model."
+            )
+        flat_indices = [i for g in groups for i in g["params"]]
+        mapping = dict(zip(flat_indices, ordered))
+
+    shapes = {n: tuple(p.shape) for n, p in model.named_parameters()}
+    for idx, entry in optimizer_pt.get("state", {}).items():
+        if not isinstance(entry, dict) or "param_name" in entry:
+            continue
+        name = mapping.get(int(idx))
+        if name is None or "exp_avg_sq" not in entry:
+            continue
+        if tuple(entry["exp_avg_sq"].shape) != shapes.get(name):
+            raise ValueError(
+                f"optimizer.pt state entry {idx} has second-moment shape "
+                f"{tuple(entry['exp_avg_sq'].shape)} but maps to {name!r} of "
+                f"shape {shapes.get(name)}; the index layout is not the "
+                f"expected one."
+            )
+    return mapping
+
+
 def load_from_optimizer(
     model: PreTrainedModel | PeftModel,
     optimizer_state: str,
@@ -248,15 +327,27 @@ def load_from_optimizer(
         adapters = list(model.peft_config.keys())
         if len(adapters) == 1:
             adapter_suffix = "." + adapters[0]
+        if len(optimizer_state_dict.get("param_groups", [])) > 1:
+            # HF Trainer applies its decay/no-decay split to PEFT params too;
+            # map group-aware over named_parameters, then translate to the
+            # serialized (adapter-stripped) naming the module lookups expect.
+            target_param_index_to_name = {
+                idx: name.replace(f"{adapter_suffix}.", ".")
+                for idx, name in optimizer_param_index_to_name(
+                    optimizer_state_dict, model
+                ).items()
+            }
+        else:
+            target_param_index_to_name = {
+                idx: name for idx, (name, _param) in enumerate(params_for_index)
+            }
     else:
-        params_for_index = list(model.named_parameters())
         # Collection runs on ``model.base_model``, so normalizer keys must be
         # relative to it (e.g. drop GPT-2's "transformer." prefix).
         base_prefix = _base_model_prefix(model)
-
-    target_param_index_to_name: dict[int, str] = {}
-    for idx, (name, _param) in enumerate(params_for_index):
-        target_param_index_to_name[idx] = name
+        target_param_index_to_name = optimizer_param_index_to_name(
+            optimizer_state_dict, model
+        )
 
     device = next(model.parameters()).device
 
@@ -283,17 +374,31 @@ def load_from_optimizer(
     return normalizers
 
 
+def _canonical_param_name(name: str) -> str:
+    """Undo parametrization renaming: ``X.parametrizations.weight.original``
+    (what e.g. the simple_fsdp wrapper registers) -> ``X.weight``."""
+    return re.sub(r"\.parametrizations\.([^.]+)\.original$", r".\1", name)
+
+
 def save_second_moments_as_optimizer_pt(
-    model: PreTrainedModel | PeftModel,
+    model: nn.Module,
     opt_state,
     path: str | Path,
+    step: int | None = None,
+    betas: tuple[float, float] | None = None,
+    eps: float | None = None,
+    eps_root: float | None = None,
 ) -> int:
     """Export a torchopt AdamW ``opt_state`` to a PyTorch ``optimizer.pt``.
 
     Writes ``{"state": {idx: {"exp_avg_sq": nu}}, "param_groups": [...]}`` where
     ``idx`` indexes ``model.named_parameters()`` (deduplicated) exactly as
     :func:`load_from_optimizer` reads it, so the file round-trips into
-    attribution normalizers.
+    attribution normalizers. When given, ``step`` (per entry) and ``betas`` /
+    ``eps`` / ``eps_root`` (param_groups) are stored in the standard
+    locations, making the file self-describing for consumers that
+    bias-correct and damp the raw moments. Call from every rank — gathering sharded
+    (DTensor) moments is a collective; only rank 0 writes the file.
 
     The mapping is done **by name**, not by position, because torchopt stores
     ``nu`` as a flat list in optree's sorted-key order of the params dict passed
@@ -327,9 +432,11 @@ def save_second_moments_as_optimizer_pt(
     )
 
     def _to_cpu(t):
+        # FSDP: gather the sharded moment (a collective — all ranks reach it).
         t = t.full_tensor() if hasattr(t, "full_tensor") else t
         return t.detach().to("cpu")
 
+    main = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
     name_to_nu = {}
     for name, moment in zip(ordered_names, nu):
         if moment is None:  # e.g. Muon leaves 2D params without a second moment
@@ -338,16 +445,40 @@ def save_second_moments_as_optimizer_pt(
             f"second-moment shape {tuple(moment.shape)} != param shape "
             f"{tuple(params[name].shape)} for '{name}' -- nu/name misalignment."
         )
-        name_to_nu[name] = _to_cpu(moment)
+        moment = _to_cpu(moment)
+        if main:
+            name_to_nu[name] = moment
 
+    # Each entry also records its param_name: FSDP wrapping re-registers
+    # params through parametrizations, renaming them
+    # (``X.parametrizations.weight.original``) and reordering
+    # named_parameters(), so positional indices from a wrapped model do not
+    # match a fresh model's. The recorded name is canonicalized back to the
+    # fresh-model form; readers prefer it and fall back to index mapping for
+    # older files.
     state: dict[int, dict] = {}
     param_ids: list[int] = []
     for idx, (name, _param) in enumerate(model.named_parameters()):
         if name in name_to_nu:
-            state[idx] = {"exp_avg_sq": name_to_nu[name]}
+            state[idx] = {
+                "exp_avg_sq": name_to_nu[name],
+                "param_name": _canonical_param_name(name),
+            }
+            if step is not None:
+                state[idx]["step"] = torch.tensor(step)
             param_ids.append(idx)
 
-    optimizer_pt = {"state": state, "param_groups": [{"params": param_ids}]}
+    if not main:
+        return len(param_ids)
+
+    param_group: dict = {"params": param_ids}
+    if betas is not None:
+        param_group["betas"] = tuple(betas)
+    if eps is not None:
+        param_group["eps"] = eps
+    if eps_root is not None:
+        param_group["eps_root"] = eps_root
+    optimizer_pt = {"state": state, "param_groups": [param_group]}
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(optimizer_pt, path)
@@ -366,6 +497,16 @@ def _get_bias_second_moment(
         return None
 
     bias_name = layer_name + ".bias"
+    # Prefer entries that record their param_name (see get_normalizers).
+    for bias_state in optimizer_state["state"].values():
+        if isinstance(bias_state, dict) and bias_state.get("param_name") == bias_name:
+            if (
+                get_optimizer_state_format(bias_state)
+                == OptimizerStateFormat.UNFACTORED
+            ):
+                return get_unfactored_second_moment(bias_state)
+            return None
+
     for idx, name in param_index_to_name.items():
         if name == bias_name:
             bias_state = optimizer_state["state"].get(idx)

--- a/tests/test_adam_state_loading.py
+++ b/tests/test_adam_state_loading.py
@@ -13,6 +13,8 @@ from transformers import (
     Trainer,
     TrainingArguments,
 )
+from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
+from transformers.trainer_pt_utils import get_parameter_names
 
 from bergson.gradients import AdafactorNormalizer, AdamNormalizer
 from bergson.utils.load_from_optimizer import (
@@ -20,6 +22,7 @@ from bergson.utils.load_from_optimizer import (
     get_optimizer_state_format,
     get_unfactored_second_moment,
     load_from_optimizer,
+    optimizer_param_index_to_name,
     save_second_moments_as_optimizer_pt,
 )
 from bergson.utils.worker_utils import extract_peft_target_modules
@@ -565,9 +568,19 @@ def test_load_adam_checkpoint():
     for norm in normalizers.values():
         assert isinstance(norm, AdamNormalizer)
 
-    # Verify loaded values match the raw checkpoint
-    params = list(model.named_parameters())
-    for idx, (name, _param) in enumerate(params):
+    # Verify loaded values match the raw checkpoint, looking entries up via
+    # the group-aware index mapping (HF Trainer writes two param groups).
+    index_to_name = optimizer_param_index_to_name(opt_state, model)
+    shapes = {n: tuple(p.shape) for n, p in model.named_parameters()}
+    name_to_idx = {n: i for i, n in index_to_name.items()}
+    for name, idx in name_to_idx.items():
+        entry = opt_state["state"].get(idx)
+        if (
+            entry is not None
+            and "exp_avg_sq" in entry
+            and entry["exp_avg_sq"].ndim == 2
+        ):
+            assert tuple(entry["exp_avg_sq"].shape) == shapes[name]
         if not name.endswith(".weight"):
             continue
         module_name = name.removesuffix(".weight")
@@ -594,9 +607,19 @@ def test_load_adafactor_checkpoint():
     for norm in normalizers.values():
         assert isinstance(norm, AdafactorNormalizer)
 
-    # Verify loaded values match the raw checkpoint
-    params = list(model.named_parameters())
-    for idx, (name, _param) in enumerate(params):
+    # Verify loaded values match the raw checkpoint, looking entries up via
+    # the group-aware index mapping (HF Trainer writes two param groups).
+    index_to_name = optimizer_param_index_to_name(opt_state, model)
+    shapes = {n: tuple(p.shape) for n, p in model.named_parameters()}
+    name_to_idx = {n: i for i, n in index_to_name.items()}
+    for name, idx in name_to_idx.items():
+        entry = opt_state["state"].get(idx)
+        if (
+            entry is not None
+            and "exp_avg_sq" in entry
+            and entry["exp_avg_sq"].ndim == 2
+        ):
+            assert tuple(entry["exp_avg_sq"].shape) == shapes[name]
         if not name.endswith(".weight"):
             continue
         module_name = name.removesuffix(".weight")
@@ -625,9 +648,19 @@ def test_load_8bit_adam_checkpoint():
     for norm in normalizers.values():
         assert isinstance(norm, AdamNormalizer)
 
-    # Verify loaded values match the raw checkpoint
-    params = list(model.named_parameters())
-    for idx, (name, _param) in enumerate(params):
+    # Verify loaded values match the raw checkpoint, looking entries up via
+    # the group-aware index mapping (HF Trainer writes two param groups).
+    index_to_name = optimizer_param_index_to_name(opt_state, model)
+    shapes = {n: tuple(p.shape) for n, p in model.named_parameters()}
+    name_to_idx = {n: i for i, n in index_to_name.items()}
+    for name, idx in name_to_idx.items():
+        entry = opt_state["state"].get(idx)
+        if (
+            entry is not None
+            and "exp_avg_sq" in entry
+            and entry["exp_avg_sq"].ndim == 2
+        ):
+            assert tuple(entry["exp_avg_sq"].shape) == shapes[name]
         if not name.endswith(".weight"):
             continue
         module_name = name.removesuffix(".weight")
@@ -638,3 +671,117 @@ def test_load_8bit_adam_checkpoint():
         norm = normalizers[module_name]
         assert isinstance(norm, AdamNormalizer)
         torch.testing.assert_close(norm.weight_avg_sq.cpu(), raw)
+
+
+def test_optimizer_index_mapping_hf_decay_groups():
+    """The two-group (HF Trainer decay/no-decay) index reconstruction maps
+    every state entry back to the right param — verified by tensor identity
+    against a real torch AdamW built the way HF Trainer builds it."""
+    model = _create_model()
+    decay_names = {
+        n for n in get_parameter_names(model, ALL_LAYERNORM_LAYERS) if "bias" not in n
+    }
+    named = [(n, p) for n, p in model.named_parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": [p for n, p in named if n in decay_names], "weight_decay": 0.01},
+            {
+                "params": [p for n, p in named if n not in decay_names],
+                "weight_decay": 0.0,
+            },
+        ],
+        lr=1e-3,
+    )
+    # One step so every param has state.
+    for _, p in named:
+        p.grad = torch.rand_like(p)
+    optimizer.step()
+
+    opt_state = optimizer.state_dict()
+    mapping = optimizer_param_index_to_name(opt_state, model)
+
+    params_by_name = dict(named)
+    assert len(mapping) == len(named)
+    for idx, name in mapping.items():
+        expected = optimizer.state[params_by_name[name]]["exp_avg_sq"]
+        torch.testing.assert_close(opt_state["state"][idx]["exp_avg_sq"], expected)
+
+
+def test_square_conv1d_moment_is_transposed(tmp_path):
+    """A SQUARE HF Conv1D weight is stored ``[in, out]`` but its shape cannot
+    reveal that — orientation must come from the module class (LayerAdapter),
+    or the moment is silently used transposed."""
+    from transformers.pytorch_utils import Conv1D
+
+    class SquareConvModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.proj = Conv1D(4, 4)  # weight [in=4, out=4]
+            self.fc = nn.Linear(4, 6)
+
+    model = SquareConvModel()
+    opt_state = _create_fake_optimizer_state(model)
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    normalizers = load_from_optimizer(model, str(opt_path))
+    names = [n for n, _ in model.named_parameters()]
+    proj_moment = opt_state["state"][names.index("proj.weight")]["exp_avg_sq"]
+    fc_moment = opt_state["state"][names.index("fc.weight")]["exp_avg_sq"]
+
+    # Conv1D: stored [in, out] -> normalizer holds the transpose; Linear: as-is.
+    torch.testing.assert_close(normalizers["proj"].weight_avg_sq, proj_moment.T)
+    torch.testing.assert_close(normalizers["fc"].weight_avg_sq, fc_moment)
+
+
+def test_load_peft_hf_two_group_checkpoint(tmp_path):
+    """PEFT + HF Trainer checkpoints: the optimizer's decay/no-decay groups
+    reorder state indices relative to the serialized PEFT param list, so the
+    mapping must be reconstructed group-aware. bias="lora_only" interleaves
+    trainable (no-decay) biases with the (decay) LoRA weights, which breaks
+    the old positional convention."""
+    # tiny-gpt2's Conv1D layers have biases, so bias="lora_only" yields
+    # trainable (no-decay) bias params.
+    base = AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2")
+    model = get_peft_model(
+        base,
+        LoraConfig(
+            r=4,
+            lora_alpha=8,
+            target_modules=["c_attn"],
+            fan_in_fan_out=True,
+            bias="lora_only",
+            task_type="CAUSAL_LM",
+        ),
+    )
+
+    # Build the optimizer exactly as HF Trainer does: [decay, no_decay].
+    decay_names = {
+        n for n in get_parameter_names(model, ALL_LAYERNORM_LAYERS) if "bias" not in n
+    }
+    named = [(n, p) for n, p in model.named_parameters() if p.requires_grad]
+    assert any(n not in decay_names for n, _ in named), "need no-decay params"
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": [p for n, p in named if n in decay_names], "weight_decay": 0.01},
+            {
+                "params": [p for n, p in named if n not in decay_names],
+                "weight_decay": 0.0,
+            },
+        ],
+        lr=1e-3,
+    )
+    for _, p in named:
+        p.grad = torch.rand_like(p)
+    optimizer.step()
+
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(optimizer.state_dict(), opt_path)
+
+    normalizers = load_from_optimizer(model, str(opt_path))
+    assert normalizers, "expected LoRA normalizers"
+    for module_name, norm in normalizers.items():
+        assert isinstance(norm, AdamNormalizer)
+        weight = model.get_submodule(f"base_model.{module_name}").weight
+        expected = optimizer.state[weight]["exp_avg_sq"]
+        torch.testing.assert_close(norm.weight_avg_sq, expected)


### PR DESCRIPTION
Four fixes to the optimizer.pt loading used for attribution normalizers + export hardening:

- Orient second moments by module class (LayerAdapter.weight_transposed: HF Conv1D stores [in, out]) instead of shape matching, which cannot detect transposed storage for square weights like GPT-2's attn.c_proj.
- Make  state indices map group-aware: HF Trainer writes two decay/no-decay param groups whose index order differs from named_parameters(); the old positional mapping assigned moments to the wrong modules. Reconstructed with transformers' own utilities and verified.
- Apply the group-aware mapping to PEFT checkpoints too.
- Make save_second_moments_as_optimizer_pt collective-safe (FSDP DTensor moments are gathered by every rank; rank 0 writes) and record each entry's canonical param_name, since FSDP wrapping renames and reorders parameters; readers prefer the recorded name. Optional standard step/betas/eps fields for SOURCE. Model type widened to nn.Module.

Tests: square-Conv1D orientation, decay-split identity vs a real two-group AdamW, PEFT + two-group checkpoint, and the real-checkpoint round-trips now look entries up group-aware with shape assertions the old convention fails.