### PR TITLE
Forward model_kwargs to bank-eval and diagnose model loads

### DIFF
--- a/bergson/diagnose.py
+++ b/bergson/diagnose.py
@@ -16,6 +16,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from bergson.config import DataConfig
 from bergson.data import pad_and_tensor, tokenize
+from bergson.utils.utils import simple_parse_kwargs_string
 
 
 @dataclass
@@ -53,6 +54,10 @@ class DiagnoseConfig:
 
     threshold: float = 0.99
     """Cosine similarity below this is flagged as problematic."""
+
+    model_kwargs: str = ""
+    """Extra kwargs forwarded to ``from_pretrained`` as ``a=b,c=d`` (e.g.
+    ``trust_remote_code=True`` for custom model architectures)."""
 
 
 DTYPE_MAP = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
@@ -380,6 +385,7 @@ def diagnose(diagnose_cfg: DiagnoseConfig):
         torch_dtype=base_dtype,
         attn_implementation="sdpa",
         device_map={"": device},
+        **simple_parse_kwargs_string(diagnose_cfg.model_kwargs),
     )
     eq_model.eval()
 
@@ -420,6 +426,7 @@ def diagnose(diagnose_cfg: DiagnoseConfig):
             torch_dtype=dtype,
             attn_implementation="sdpa",
             device_map={"": device},
+            **simple_parse_kwargs_string(diagnose_cfg.model_kwargs),
         )
         model.eval()
 

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -33,7 +33,7 @@ from .data import load_scores, pad_and_tensor
 from .magic.data_stream import DataStream, pad_dataset_to_batch_size
 from .magic.trainer import TrainerState, prepare_trainer
 from .utils.csv_writer import CSVWriter
-from .utils.utils import get_device
+from .utils.utils import get_device, simple_parse_kwargs_string
 from .utils.worker_utils import setup_data_pipeline
 
 
@@ -104,17 +104,15 @@ def _load_banked_model(
     run_cfg: ValidationConfig, out_dir: str, device: torch.device | str
 ) -> torch.nn.Module:
     """Load a banked ``save_retrained_models`` checkpoint into a ready model."""
+    load_kwargs = {"dtype": torch.float32, "attn_implementation": "eager"}
+    load_kwargs.update(simple_parse_kwargs_string(run_cfg.model_kwargs))
     if os.path.isfile(os.path.join(out_dir, "adapter_config.json")):
         from peft import PeftModel
 
-        base = AutoModelForCausalLM.from_pretrained(
-            run_cfg.model, dtype=torch.float32, attn_implementation="eager"
-        )
+        base = AutoModelForCausalLM.from_pretrained(run_cfg.model, **load_kwargs)
         model = PeftModel.from_pretrained(base, out_dir)
     else:
-        model = AutoModelForCausalLM.from_pretrained(
-            out_dir, dtype=torch.float32, attn_implementation="eager"
-        )
+        model = AutoModelForCausalLM.from_pretrained(out_dir, **load_kwargs)
     return model.to(device)  # type: ignore
 
 


### PR DESCRIPTION
`worker_utils.setup_model_and_peft` forwards `model_kwargs` to `from_pretrained`, but two other model-load sites hardcoded their kwargs: `_load_banked_model` (used by `evaluate_retrained` to load the base + every leave-k-out checkpoint) and the `diagnose` gradient-consistency tool. Thread `model_kwargs` through both sites.