### PR TITLE
Fix/update projection dim zero errors/warnings

### DIFF
--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -16,7 +16,6 @@ from ..config.config import (
     HessianConfig,
     HessianPipelineConfig,
     IndexConfig,
-    TrackstarIndexConfig,
     MetasmoothnessConfig,
     MixConfig,
     PreprocessConfig,
@@ -24,6 +23,7 @@ from ..config.config import (
     RecallConfig,
     ScoreConfig,
     TrackstarConfig,
+    TrackstarIndexConfig,
     TrainingConfig,
     ValidationConfig,
 )

--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -16,6 +16,7 @@ from ..config.config import (
     HessianConfig,
     HessianPipelineConfig,
     IndexConfig,
+    TrackstarIndexConfig,
     MetasmoothnessConfig,
     MixConfig,
     PreprocessConfig,
@@ -228,7 +229,9 @@ class Score(Serializable):
 class Trackstar(Serializable):
     """Run hessians, build, and score as a single pipeline."""
 
-    index_cfg: IndexConfig
+    # Trackstar uses random-projection compression, so override the default
+    # projection_dim of 0.
+    index_cfg: TrackstarIndexConfig
 
     trackstar_cfg: TrackstarConfig
 

--- a/bergson/cli/trackstar.py
+++ b/bergson/cli/trackstar.py
@@ -42,6 +42,14 @@ def _step_complete(path: str, resume: bool) -> bool:
 
 def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
     """Run the full trackstar pipeline: hessians -> mix -> build -> score."""
+    if index_cfg.projection_dim == 0:
+        raise ValueError(
+            "Trackstar scores via compressed random-projected gradients and "
+            "requires a nonzero index_cfg.projection_dim; got 0. Leave "
+            "projection_dim unset to use TrackstarIndexConfig's default of "
+            "16, or set it explicitly."
+        )
+
     run_path = index_cfg.run_path
     value_hess_path = f"{run_path}/value_hessian"
     query_hess_path = f"{run_path}/query_hessian"

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -223,9 +223,10 @@ class HookCollectorBase(ContextDecorator, ABC):
 
     @property
     def per_module_projection_dim(self) -> int | None:
+        """Per-module projection dimension, or None if projection is disabled."""
         if self.processor.projection_target == "global":
             return None
-        return self.processor.projection_dim
+        return self.processor.projection_dim or None
 
     def shapes(self) -> Mapping[str, torch.Size]:
         """Return the shapes of the gradients collected by this collector."""
@@ -235,7 +236,7 @@ class HookCollectorBase(ContextDecorator, ABC):
 
         proj_shape = (
             torch.Size((p_dim, p_dim))
-            if (p_dim := self.processor.projection_dim) is not None
+            if (p_dim := self.per_module_projection_dim) is not None
             else None
         )
 

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -492,7 +492,7 @@ class AttentionConfig:
 class IndexConfig(AttributionConfig, Serializable):
     """Config for building the index and running the model/dataset pipeline."""
 
-    projection_dim: int = 16
+    projection_dim: int = 0
     """Dimension of the random projection for the index, or 0 to disable it."""
 
     include_bias: bool = False
@@ -576,6 +576,14 @@ class IndexConfig(AttributionConfig, Serializable):
     def partial_run_path(self) -> Path:
         """Temporary path to use while writing build artifacts."""
         return Path(self.run_path + ".part")
+
+
+@dataclass
+class TrackstarIndexConfig(IndexConfig):
+    """IndexConfig for the Trackstar command, which uses random-projection
+    compression and so defaults ``projection_dim`` to 16."""
+
+    projection_dim: int = 16
 
 
 @dataclass

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -72,6 +72,13 @@ def approximate_hessians(
     str
         Path to the directory containing the computed Hessian approximations.
     """
+    if hessian_cfg.ev_correction and index_cfg.projection_dim != 0:
+        raise ValueError(
+            "EK-FAC (ev_correction=True) does not support gradient "
+            f"projection; got index_cfg.projection_dim={index_cfg.projection_dim}. "
+            "Set projection_dim=0."
+        )
+
     if hessian_cfg.method == "autocorrelation" and index_cfg.projection_dim == 0:
         warnings.warn(
             "Computing an autocorrelation (dense) Hessian with "

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import warnings
 
 import torch
 import torch.distributed as dist
@@ -71,6 +72,15 @@ def approximate_hessians(
     str
         Path to the directory containing the computed Hessian approximations.
     """
+    if hessian_cfg.method == "autocorrelation" and index_cfg.projection_dim == 0:
+        warnings.warn(
+            "Computing an autocorrelation (dense) Hessian with "
+            "index_cfg.projection_dim=0 (uncompressed gradients); this scales "
+            "quadratically with the (possibly large) uncompressed gradient "
+            "dimension. Set projection_dim (e.g. 16) unless this is "
+            "intentional."
+        )
+
     if index_cfg.debug:
         setup_reproducibility()
     index_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)

--- a/tests/ekfac_tests/compute_ekfac_ground_truth.py
+++ b/tests/ekfac_tests/compute_ekfac_ground_truth.py
@@ -130,7 +130,7 @@ def setup_paths_and_config(
     parent_path = os.path.join(current_path, "test_files", f"pile_{n_samples}_examples")
 
     # Configuration
-    cfg = IndexConfig(run_path="", loss_reduction="sum")
+    cfg = IndexConfig(run_path="", loss_reduction="sum", projection_dim=0)
     cfg.model = model_name
     cfg.precision = precision  # type: ignore[assignment]
     cfg.fsdp = False

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -18,6 +18,7 @@ def test_build_consistency(tmp_path: Path, model, dataset):
         run_path=str(tmp_path),
         token_batch_size=1024,
         loss_reduction="mean",
+        projection_dim=16,
     )
     collect_gradients(
         model=model,

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -5,6 +5,18 @@ import pytest
 import torch
 
 from bergson import GradientProcessor
+from bergson.config import HessianConfig, IndexConfig
+from bergson.hessians.hessian_approximations import approximate_hessians
+
+
+def test_ekfac_rejects_nonzero_projection_dim(tmp_path: Path):
+    """EK-FAC fitting doesn't support gradient projection, so a nonzero
+    projection_dim must fail fast."""
+    index_cfg = IndexConfig(run_path=str(tmp_path), projection_dim=16)
+    hessian_cfg = HessianConfig(method="kfac", ev_correction=True)
+
+    with pytest.raises(ValueError, match="projection_dim=0"):
+        approximate_hessians(index_cfg, hessian_cfg)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
Give TrackStar a more friendly custom projection dim default of 16, and keep defaulting to the more Schelling point-like 0 everywhere else