### PR TITLE
Fix -h/--help collision in `bergson metasmoothness`

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -381,7 +381,7 @@ class MetasmoothnessConfig(TrainingConfig):
     space. Costs three trainings; no retraining bank. The metagradients
     authors select eps_root and lr by maximizing this metric."""
 
-    h: float = 0.1
+    fd_step: float = 0.1
     """Finite-difference step size for the data-weight perturbation."""
 
     direction_seed: int = 0

--- a/bergson/magic/metasmoothness.py
+++ b/bergson/magic/metasmoothness.py
@@ -98,7 +98,7 @@ def metasmoothness_worker(
 
     thetas: list[torch.Tensor] = []
     for k in range(3):
-        weights = 1.0 + run_cfg.h * k * v
+        weights = 1.0 + run_cfg.fd_step * k * v
         if pad_count:
             weights[-weight_pad_count:] = 0.0
         stream.weights.data.copy_(weights.to(stream.weights.device))
@@ -123,11 +123,11 @@ def metasmoothness_worker(
         movement = float((thetas[2] - thetas[0]).abs().sum())
         result = {
             "score": score,
-            "h": run_cfg.h,
+            "fd_step": run_cfg.fd_step,
             "direction_seed": run_cfg.direction_seed,
             "total_movement_l1": movement,
         }
-        print(f"[metasmoothness] score = {score:.4f} (h={run_cfg.h})")
+        print(f"[metasmoothness] score = {score:.4f} (h={run_cfg.fd_step})")
         os.makedirs(run_cfg.run_path, exist_ok=True)
         with open(os.path.join(run_cfg.run_path, "metasmoothness.json"), "w") as f:
             json.dump(result, f, indent=2)

--- a/tests/test_metasmoothness.py
+++ b/tests/test_metasmoothness.py
@@ -1,0 +1,53 @@
+"""Unit tests for the metasmoothness command.
+
+These tests exercise CLI parsing and the scoring function only — they never
+call `.execute()`, so they need no GPU and no model downloads.
+"""
+
+import torch
+from simple_parsing import ArgumentParser, ConflictResolution
+
+from bergson.__main__ import Main
+from bergson.magic.metasmoothness import metasmoothness_score
+
+
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser(conflict_resolution=ConflictResolution.EXPLICIT)
+    parser.add_arguments(Main, dest="prog")
+    return parser
+
+
+def test_cli_parser_constructs_with_metasmoothness():
+    """A single-character field name (``h``) makes simple_parsing derive a ``-h``
+    short flag that collides with argparse's ``-h/--help``, which raises while the
+    parser is still being built and takes down *every* subcommand, not just this
+    one. Guard the whole-parser construction path."""
+    build_parser()
+
+
+def test_fd_step_and_direction_seed_parse():
+    args = build_parser().parse_args(
+        ["metasmoothness", "run/path", "--fd_step", "0.25", "--direction_seed", "7"]
+    )
+    assert args.prog.command.fd_step == 0.25
+    assert args.prog.command.direction_seed == 7
+
+
+def test_score_is_one_for_perfectly_linear_response():
+    """Equal consecutive steps => both finite differences share a sign everywhere."""
+    theta0 = torch.zeros(8)
+    delta = torch.tensor([1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0])
+    assert metasmoothness_score(theta0, theta0 + delta, theta0 + 2 * delta) == 1.0
+
+
+def test_score_is_negative_when_response_reverses():
+    """Second step undoes the first => signs disagree on every moved coordinate."""
+    theta0 = torch.zeros(4)
+    theta_h = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    theta_2h = torch.tensor([0.5, 1.0, 1.5, 2.0])
+    assert metasmoothness_score(theta0, theta_h, theta_2h) == -1.0
+
+
+def test_score_is_one_when_nothing_moves():
+    theta = torch.zeros(4)
+    assert metasmoothness_score(theta, theta, theta) == 1.0


### PR DESCRIPTION
`MetasmoothnessConfig.h` makes simple_parsing derive a `-h` short flag from the single-character field name, colliding with argparse's built-in `-h/--help`. 

After renaming, `bergson metasmoothness --help` works.

Tests: `tests/test_metasmoothness.py` — 5 passed (includes a regression test for the parser construction, CLI parsing of the renamed flags, and the score function's sign conventions).