### PR TITLE
Claude code repo review

### DIFF
--- a/bergson/gradients.py
+++ b/bergson/gradients.py
@@ -327,8 +327,8 @@ class AdafactorNormalizer(Normalizer):
         b = c.rsqrt_()
 
         # Implicitly do the Hadamard product
-        grad *= a[:, None]  # [N, O] * [O] → [N, O]
-        grad *= b[None, :]
+        grad *= a[:, None]  # [O, I] * [O, 1] → [O, I]
+        grad *= b[None, :]  # [O, I] * [1, I] → [O, I]
 
         return grad
 

--- a/bergson/utils/load_from_optimizer.py
+++ b/bergson/utils/load_from_optimizer.py
@@ -243,9 +243,7 @@ def get_normalizers(
             if row.ndim != 1 or col is None:
                 continue
             if model is not None:
-                row, col = _orient_factored_second_moment(
-                    row, col, model, layer_name
-                )
+                row, col = _orient_factored_second_moment(row, col, model, layer_name)
             normalizers[module_name] = AdafactorNormalizer(
                 row=row.to(device),
                 col=col.to(device),

--- a/bergson/utils/load_from_optimizer.py
+++ b/bergson/utils/load_from_optimizer.py
@@ -154,6 +154,28 @@ def _orient_weight_second_moment(exp_avg_sq, model, layer_name):
     return exp_avg_sq if oriented is None else oriented
 
 
+def _orient_factored_second_moment(row, col, model, layer_name):
+    """Return ``(row, col)`` in the collector's ``[out, in]`` orientation.
+
+    A factored optimizer reduces over the parameter *as stored*, so a module
+    storing ``[in, out]`` (HF Conv1D) yields a ``row`` indexed by in-features
+    and a ``col`` indexed by out-features — the transpose of what
+    :class:`AdafactorNormalizer` expects. Shapes cannot settle this on their
+    own for square weights, so the module's storage convention decides.
+    Unknown modules pass through unchanged.
+    """
+    try:
+        module = model.get_submodule(layer_name)
+    except (AttributeError, ValueError):
+        return row, col  # unknown module; leave as-is
+
+    if isinstance(module, LayerAdapter.supported_modules) and (
+        LayerAdapter.weight_transposed(module)
+    ):
+        return col, row
+    return row, col
+
+
 def get_normalizers(
     optimizer_state,
     target_param_index_to_name,
@@ -220,6 +242,10 @@ def get_normalizers(
             col = state.get("exp_avg_sq_col")
             if row.ndim != 1 or col is None:
                 continue
+            if model is not None:
+                row, col = _orient_factored_second_moment(
+                    row, col, model, layer_name
+                )
             normalizers[module_name] = AdafactorNormalizer(
                 row=row.to(device),
                 col=col.to(device),

--- a/bergson/utils/math.py
+++ b/bergson/utils/math.py
@@ -82,9 +82,16 @@ def weighted_causal_lm_ce(
         row_loss = (tok_loss * w).sum(dim=1) / row_counts  # [B]
         return row_loss.sum()
 
+    # Mean over every valid token in the batch, matching the unweighted branch's
+    # F.cross_entropy(reduction="mean"). The count runs over the whole [B, T-1]
+    # block.
     # The mask's last column is always False, so no [:, :-1] slice is needed.
-    denom = shift_loss_mask.sum() if shift_loss_mask is not None else T - 1
-    return (tok_loss * w).sum() / denom
+    denom = (
+        shift_loss_mask.sum()
+        if shift_loss_mask is not None
+        else (shift_labels != ignore_index).sum()
+    )
+    return (tok_loss * w).sum() / denom.clamp_min(1)
 
 
 def reshape_to_nearest_square(a: Tensor) -> Tensor:

--- a/tests/test_adam_state_loading.py
+++ b/tests/test_adam_state_loading.py
@@ -226,6 +226,69 @@ def test_load_from_gpt2_conv1d_base_relative_keys(tmp_path):
         assert norm.weight_avg_sq.shape == (out_f, in_f)
 
 
+def _create_fake_factored_optimizer_state(model, lr=1e-3):
+    """An Adafactor-style state: 2D params factored into row/col means.
+
+    Adafactor reduces over the parameter *as stored*, so for a Conv1D whose
+    weight is ``[in, out]`` the row means are indexed by in-features.
+    """
+    state = {}
+    param_groups = [{"lr": lr, "params": []}]
+
+    for idx, (_, param) in enumerate(model.named_parameters()):
+        param_groups[0]["params"].append(idx)
+        sq = torch.rand_like(param) * 0.01 + 1e-4
+        if param.ndim == 2:
+            state[idx] = {
+                "step": torch.tensor(100),
+                "exp_avg_sq_row": sq.mean(dim=-1),
+                "exp_avg_sq_col": sq.mean(dim=0),
+            }
+        else:
+            state[idx] = {"step": torch.tensor(100), "exp_avg_sq": sq}
+
+    return {"state": state, "param_groups": param_groups}
+
+
+def test_load_factored_gpt2_conv1d_orientation(tmp_path):
+    """Factored (Adafactor) states need the same Conv1D orientation fix as Adam.
+
+    GPT-2's Conv1D stores ``[in, out]``, so Adafactor's row means are indexed by
+    in-features while AdafactorNormalizer expects ``row`` over out-features.
+    Without reorienting, non-square layers raise on the Hadamard product and
+    square ones are silently normalized by the transposed statistics.
+    """
+    from transformers.pytorch_utils import Conv1D
+
+    model = AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2")
+    opt_state = _create_fake_factored_optimizer_state(model)
+    opt_path = tmp_path / "optimizer.pt"
+    torch.save(opt_state, opt_path)
+
+    base = model.base_model
+    conv_names = sorted(n for n, m in base.named_modules() if isinstance(m, Conv1D))
+    assert conv_names, "expected Conv1D layers in GPT-2"
+    subset = set(conv_names[:2])
+
+    normalizers = load_from_optimizer(model, str(opt_path), target_modules=subset)
+
+    assert set(normalizers.keys()) == subset
+    for name, norm in normalizers.items():
+        assert isinstance(norm, AdafactorNormalizer)
+        module = base.get_submodule(name)
+        out_f = module.nf  # Conv1D output features
+        in_f = module.weight.shape[0]  # Conv1D param is [in, out]
+
+        # row indexes out-features and col in-features, matching the
+        # collector's [out, in] gradient layout.
+        assert norm.row.shape == (out_f,), f"{name}: row must be over out-features"
+        assert norm.col.shape == (in_f,), f"{name}: col must be over in-features"
+
+        # The normalizer must accept a [out, in] gradient without broadcasting
+        # against the wrong axis.
+        norm.normalize_weight(torch.randn(out_f, in_f))
+
+
 def test_missing_optimizer_file(tmp_path):
     """Error when directory has no optimizer.pt."""
     model = _create_model()

--- a/tests/test_multi_query_validate.py
+++ b/tests/test_multi_query_validate.py
@@ -113,9 +113,11 @@ def test_weighted_ce_sum_of_means_reduction():
     )
     torch.testing.assert_close(ss, ((tok * w[:, None]).sum(1) / counts).sum())
 
-    # Default mean reduction path is unchanged.
+    # Default mean reduction divides by the batch's valid-token count, so it
+    # agrees with F.cross_entropy(reduction="mean") when the weights are ones.
     tm = weighted_causal_lm_ce(logits, labels, example_weight=w)
-    torch.testing.assert_close(tm, (tok * w[:, None]).sum() / (T - 1))
+    valid = (labels[:, 1:] != -100).sum()
+    torch.testing.assert_close(tm, (tok * w[:, None]).sum() / valid)
 
 
 def test_metasmoothness_score():

--- a/tests/test_query_batching_invariance.py
+++ b/tests/test_query_batching_invariance.py
@@ -1,0 +1,109 @@
+"""Scoring the query set in row slices must equal scoring it in one pass.
+
+``query_batch_size`` (ScoreConfig) bounds GPU memory by scoring a slice of the
+queries at a time and writing each slice's columns at ``query_offset``. That is
+purely an execution strategy, so the resulting score matrix must be identical
+to the unchunked one — this file pins that equivalence.
+"""
+
+import pytest
+import torch
+
+from bergson.score.score_writer import InMemorySequenceScoreWriter
+from bergson.score.scorer import Scorer
+
+MODULES = {"mod_a": 6, "mod_b": 4}
+NUM_QUERIES = 5
+NUM_INDEX = 7
+
+
+def _query_grads(generator):
+    return {
+        m: torch.randn(NUM_QUERIES, dim, generator=generator)
+        for m, dim in MODULES.items()
+    }
+
+
+def _index_grads(generator):
+    return {
+        m: torch.randn(NUM_INDEX, dim, generator=generator)
+        for m, dim in MODULES.items()
+    }
+
+
+def _score_in_slices(query_grads, index_grads, slices, *, unit_normalize):
+    """Score `slices` of the query set, writing each at its column offset."""
+    writer = InMemorySequenceScoreWriter(NUM_INDEX, NUM_QUERIES, dtype=torch.float32)
+    for start, stop in slices:
+        scorer = Scorer(
+            query_grads={m: g[start:stop] for m, g in query_grads.items()},
+            modules=list(MODULES),
+            writer=writer,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            unit_normalize=unit_normalize,
+            query_offset=start,
+        )
+        scorer(list(range(NUM_INDEX)), index_grads)
+    return writer.scores
+
+
+@pytest.mark.parametrize("unit_normalize", [False, True])
+@pytest.mark.parametrize("slices", [[(0, 2), (2, 5)], [(0, 1), (1, 3), (3, 5)]])
+def test_query_batching_matches_single_pass(slices, unit_normalize):
+    """Chunked scoring reproduces the unchunked score matrix exactly."""
+    g = torch.Generator().manual_seed(0)
+    query_grads = _query_grads(g)
+    index_grads = _index_grads(g)
+
+    whole = _score_in_slices(
+        query_grads, index_grads, [(0, NUM_QUERIES)], unit_normalize=unit_normalize
+    )
+    chunked = _score_in_slices(
+        query_grads, index_grads, slices, unit_normalize=unit_normalize
+    )
+
+    torch.testing.assert_close(chunked, whole)
+
+
+def test_query_offset_writes_the_right_columns():
+    """A slice's scores land at its own columns, not column zero."""
+    g = torch.Generator().manual_seed(1)
+    query_grads = _query_grads(g)
+    index_grads = _index_grads(g)
+
+    whole = _score_in_slices(
+        query_grads, index_grads, [(0, NUM_QUERIES)], unit_normalize=False
+    )
+    tail = _score_in_slices(query_grads, index_grads, [(3, 5)], unit_normalize=False)
+
+    # Columns 3:5 carry the slice; the untouched columns stay zero.
+    torch.testing.assert_close(tail[:, 3:5], whole[:, 3:5])
+    assert torch.all(tail[:, :3] == 0), "slice wrote into columns it does not own"
+
+
+def test_unit_normalize_is_not_computed_per_slice():
+    """Normalization divides by the index gradient's full norm.
+
+    ``unit_normalize`` scales each row by ||g|| over *all* modules. That norm is
+    a property of the index gradient, not of the query slice, so it must not
+    change when the query set is chunked.
+    """
+    g = torch.Generator().manual_seed(2)
+    query_grads = _query_grads(g)
+    index_grads = _index_grads(g)
+
+    whole = _score_in_slices(
+        query_grads, index_grads, [(0, NUM_QUERIES)], unit_normalize=True
+    )
+    chunked = _score_in_slices(
+        query_grads, index_grads, [(0, 2), (2, 5)], unit_normalize=True
+    )
+
+    torch.testing.assert_close(chunked, whole)
+
+    # Non-triviality: normalization actually changed the scores.
+    raw = _score_in_slices(
+        query_grads, index_grads, [(0, NUM_QUERIES)], unit_normalize=False
+    )
+    assert not torch.allclose(whole, raw), "unit_normalize had no effect"

--- a/tests/test_weighted_ce.py
+++ b/tests/test_weighted_ce.py
@@ -1,0 +1,99 @@
+"""Reduction semantics of :func:`weighted_causal_lm_ce`.
+
+The ``"mean"`` reduction is documented as the mean over every valid token in
+the batch. The weighted and unweighted branches compute it separately, so the
+tests below pin them to each other and to an explicit reference.
+"""
+
+import pytest
+import torch
+
+from bergson.utils.math import weighted_causal_lm_ce
+
+IGNORE = -100
+
+
+def _batch(B: int, T: int, V: int, seed: int = 0):
+    g = torch.Generator().manual_seed(seed)
+    logits = torch.randn(B, T, V, generator=g)
+    labels = torch.randint(0, V, (B, T), generator=g)
+    return logits, labels
+
+
+def _reference_mean(logits, labels, ignore_index=IGNORE):
+    """Mean CE over all valid shifted tokens, computed the obvious way."""
+    shift_logits = logits[:, :-1, :].float().reshape(-1, logits.shape[-1])
+    shift_labels = labels[:, 1:].reshape(-1)
+    return torch.nn.functional.cross_entropy(
+        shift_logits, shift_labels, ignore_index=ignore_index, reduction="mean"
+    )
+
+
+@pytest.mark.parametrize("B", [1, 2, 4, 8])
+def test_unit_weights_are_a_noop(B):
+    """``example_weight`` of all ones must not change the loss.
+
+    The unweighted branch returns F.cross_entropy(reduction="mean"); the
+    weighted branch divides by its own denominator. If that denominator misses
+    the batch dimension the two disagree by exactly ``B``.
+    """
+    logits, labels = _batch(B, 8, 50)
+
+    unweighted = weighted_causal_lm_ce(logits, labels)
+    weighted = weighted_causal_lm_ce(logits, labels, example_weight=torch.ones(B))
+
+    torch.testing.assert_close(weighted, unweighted)
+
+
+@pytest.mark.parametrize("B", [1, 2, 4])
+def test_mean_matches_reference(B):
+    """Both branches equal an explicit token-mean over the batch."""
+    logits, labels = _batch(B, 8, 50, seed=1)
+    expected = _reference_mean(logits, labels)
+
+    torch.testing.assert_close(weighted_causal_lm_ce(logits, labels), expected)
+    torch.testing.assert_close(
+        weighted_causal_lm_ce(logits, labels, example_weight=torch.ones(B)), expected
+    )
+
+
+def test_ignored_tokens_excluded_from_denominator():
+    """Padding must not dilute the mean: the denominator counts valid tokens."""
+    logits, labels = _batch(4, 8, 50, seed=2)
+    labels[1, 3:] = IGNORE
+    labels[2, :] = IGNORE  # a fully-padded row, as empty documents produce
+
+    expected = _reference_mean(logits, labels)
+
+    torch.testing.assert_close(weighted_causal_lm_ce(logits, labels), expected)
+    torch.testing.assert_close(
+        weighted_causal_lm_ce(logits, labels, example_weight=torch.ones(4)), expected
+    )
+
+
+def test_all_tokens_ignored_does_not_divide_by_zero():
+    """An entirely-padded batch yields a finite (zero) loss, not NaN."""
+    logits, labels = _batch(2, 8, 50, seed=3)
+    labels[:] = IGNORE
+
+    loss = weighted_causal_lm_ce(logits, labels, example_weight=torch.ones(2))
+
+    assert torch.isfinite(loss), f"expected a finite loss, got {loss}"
+    torch.testing.assert_close(loss, torch.zeros(()))
+
+
+def test_weights_scale_their_own_rows():
+    """Doubling one row's weight adds that row's contribution once more."""
+    logits, labels = _batch(2, 8, 50, seed=4)
+
+    base = weighted_causal_lm_ce(logits, labels, example_weight=torch.ones(2))
+    bumped = weighted_causal_lm_ce(
+        logits, labels, example_weight=torch.tensor([2.0, 1.0])
+    )
+    row0 = weighted_causal_lm_ce(
+        logits, labels, example_weight=torch.tensor([1.0, 0.0])
+    )
+
+    # Denominator is shared (it counts valid tokens, not weight mass), so the
+    # difference is exactly row 0's weighted contribution.
+    torch.testing.assert_close(bumped - base, row0)


### PR DESCRIPTION
**Fix: weighted loss reduction**

The "mean" reduction is the mean over every valid token in the batch, and the unweighted branch implements that via F.cross_entropy(reduction="mean"). The weighted branch divides a batch-wide sum by `T - 1` — a single row's length — so the two disagree by a factor of the batch size:

    B=1  no_weight 4.162602   weight=ones 4.162602   ratio 1.000
    B=2  no_weight 4.212400   weight=ones 8.424800   ratio 2.000
    B=4  no_weight 4.039095   weight=ones 16.156380  ratio 4.000

Use (shift_labels != ignore_index).sum() instead

**Fix: factored optimizer orientation (GPT-2 conv layers)**