### PR TITLE
Run the bergson CLI from tests via sys.executable -m

### DIFF
--- a/tests/cli_command.py
+++ b/tests/cli_command.py
@@ -1,0 +1,30 @@
+"""Running the ``bergson`` CLI from tests against the checkout under test.
+
+The bare ``bergson`` console script imports from its own interpreter's
+site-packages, so without an editable install it raises ``ModuleNotFoundError``
+— and with a stale one it tests the wrong code.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def bergson_cmd(*args: str) -> list[str]:
+    """The argv for running ``bergson <args>`` against this checkout."""
+    return [sys.executable, "-m", "bergson", *args]
+
+
+def bergson_env(env: dict[str, str] | None = None) -> dict[str, str]:
+    """``env`` (default: the current one) with this checkout on ``PYTHONPATH``.
+
+    ``python -m`` only adds the *current directory*, and several tests run with
+    ``cwd=tmp_path``.
+    """
+    env = dict(os.environ if env is None else env)
+    existing = env.get("PYTHONPATH", "")
+    parts = [str(REPO_ROOT)] + ([existing] if existing else [])
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+    return env

--- a/tests/test_batch_size_invariance.py
+++ b/tests/test_batch_size_invariance.py
@@ -13,6 +13,8 @@ from datasets import Dataset
 
 from bergson.data import load_gradients
 
+from .cli_command import bergson_cmd, bergson_env
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("batch_size_a,batch_size_b", [(100, 100), (50, 150)])
@@ -53,8 +55,7 @@ def test_gradient_scale_invariance(tmp_path, batch_size_a, batch_size_b):
 
     def start_bergson_build(index_name: str, dataset_path: str):
         index_path = index_dir / index_name
-        cmd = [
-            "bergson",
+        cmd = bergson_cmd(
             "build",
             str(index_path),
             "--model",
@@ -69,9 +70,13 @@ def test_gradient_scale_invariance(tmp_path, batch_size_a, batch_size_b):
             "1000",
             "--nproc_per_node",
             "1",
-        ]
+        )
         proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=bergson_env(),
         )
         return index_path, proc
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,8 @@ import subprocess
 
 import pytest
 
+from .cli_command import bergson_cmd, bergson_env
+
 SUBCOMMANDS = [
     "build",
     "ekfac",
@@ -26,10 +28,11 @@ def help_results() -> dict[str, subprocess.CompletedProcess]:
     """
     procs = {
         cmd: subprocess.Popen(
-            ["bergson", cmd, "--help"],
+            bergson_cmd(cmd, "--help"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=bergson_env(),
         )
         for cmd in SUBCOMMANDS
     }

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -8,6 +8,8 @@ from bergson import GradientProcessor
 from bergson.config import HessianConfig, IndexConfig
 from bergson.hessians.hessian_approximations import approximate_hessians
 
+from .cli_command import bergson_cmd, bergson_env
+
 
 def test_ekfac_rejects_nonzero_projection_dim(tmp_path: Path):
     """EK-FAC fitting doesn't support gradient projection, so a nonzero
@@ -22,10 +24,7 @@ def test_ekfac_rejects_nonzero_projection_dim(tmp_path: Path):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_autocorrelation_hessian_e2e(tmp_path: Path):
     result = subprocess.run(
-        [
-            "python",
-            "-m",
-            "bergson",
+        bergson_cmd(
             "hessian",
             "test_e2e",
             "--model",
@@ -43,8 +42,9 @@ def test_autocorrelation_hessian_e2e(tmp_path: Path):
             "bf16",
             "--method",
             "autocorrelation",
-        ],
+        ),
         cwd=tmp_path,
+        env=bergson_env(),
         capture_output=True,
         text=True,
     )

--- a/tests/test_multinode.py
+++ b/tests/test_multinode.py
@@ -12,7 +12,6 @@ breaks the per-node NCCL handshake, or only one node's data ever reaches disk),
 this test either times out or fails the gradient-count assertion.
 """
 
-import os
 import socket
 import subprocess
 from pathlib import Path
@@ -21,6 +20,8 @@ import pytest
 import torch
 
 from bergson.data import load_gradients
+
+from .cli_command import bergson_cmd, bergson_env
 
 
 def free_port() -> int:
@@ -38,8 +39,7 @@ def test_multinode_build_two_nodes_one_gpu_each(tmp_path: Path):
     n_examples = 32
     port = free_port()
 
-    common_args = [
-        "bergson",
+    common_args = bergson_cmd(
         "build",
         str(run_path),
         "--model",
@@ -58,10 +58,10 @@ def test_multinode_build_two_nodes_one_gpu_each(tmp_path: Path):
         "--nproc_per_node",
         "1",
         "--overwrite",
-    ]
+    )
 
     base_env = {
-        **os.environ,
+        **bergson_env(),
         "MASTER_ADDR": "localhost",
         "MASTER_PORT": str(port),
     }

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -17,14 +17,13 @@ from bergson.build import build
 from bergson.data import load_gradient_dataset
 from bergson.hessians.autocorrelation import AutocorrelationCollector
 
+from .cli_command import bergson_cmd, bergson_env
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_reduce_cli(tmp_path: Path):
     result = subprocess.run(
-        [
-            "python",
-            "-m",
-            "bergson",
+        bergson_cmd(
             "reduce",
             "test_reduce_e2e",
             "--model",
@@ -39,8 +38,9 @@ def test_reduce_cli(tmp_path: Path):
             "--unit_normalize",
             "--token_batch_size",
             "1024",
-        ],
+        ),
         cwd=tmp_path,
+        env=bergson_env(),
         capture_output=True,
         # Get strings instead of bytes
         text=True,

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,7 +1,6 @@
 import json
 import math
 import subprocess
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -47,6 +46,8 @@ from bergson.utils.utils import (
     tensor_to_numpy,
 )
 
+from .cli_command import bergson_cmd, bergson_env
+
 
 def _h_inv(path, device, power):
     """The dense inverse-Hessian matrices for a saved processor at ``path``."""
@@ -77,10 +78,7 @@ def test_large_gradients_query(tmp_path: Path, dataset):
     )
 
     result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "bergson",
+        bergson_cmd(
             "score",
             "test_score_e2e",
             "--projection_dim",
@@ -96,8 +94,9 @@ def test_large_gradients_query(tmp_path: Path, dataset):
             "--truncation",
             "--token_batch_size",
             "256",
-        ],
+        ),
         cwd=tmp_path,
+        env=bergson_env(),
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
Tests that shell out were invoking the bare `bergson` console script, which resolves against PATH and imports from that interpreter's site-packages. If the user doesn't run an editable install the subprocess dies with `ModuleNotFoundError: No module named 'bergson'`; with a stale install it silently exercises the wrong code.