### PR TITLE
Fix recall SOURCE score orientation

### DIFF
--- a/bergson/builder.py
+++ b/bergson/builder.py
@@ -79,6 +79,7 @@ class Builder:
             preprocess_cfg.hessian_path,
             inversion_cfg=preprocess_cfg.inversion_cfg,
             power=-0.5 if preprocess_cfg.unit_normalize else -1.0,
+            ev_correction=preprocess_cfg.ev_correction,
             device=device,
         )
 

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -469,9 +469,12 @@ class RecallConfig(Serializable):
     k: int = 10
     """Cutoff for Recall@k."""
 
-    higher_is_better: bool = True
+    higher_is_better: bool | None = None
     """True when a higher score means a stronger proponent of the query
-    (e.g. influence functions). False for unrolled differentiation."""
+    (e.g. influence functions). False for unrolled differentiation.
+
+    ``None`` reads the orientation from the ``score_cfg`` saved in the
+    ``scores`` directory."""
 
 
 @dataclass
@@ -678,6 +681,11 @@ class PreprocessConfig(Serializable):
 
     hessian_path: str | None = None
     """Path to a precomputed gradient processor. Set to apply Hessian approx."""
+
+    ev_correction: bool = False
+    """Use the corrected eigenvalues of a factored (EK-FAC) Hessian at
+    ``hessian_path``, which must have been fit with
+    ``HessianConfig.ev_correction=True``."""
 
     inversion_cfg: InversionConfig = field(default_factory=InversionConfig)
     """How to invert the (dense autocorrelation) Hessian at ``hessian_path``."""

--- a/bergson/recall/recall.py
+++ b/bergson/recall/recall.py
@@ -13,7 +13,8 @@ from pathlib import Path
 import numpy as np
 from datasets import Dataset, load_from_disk
 
-from bergson.config.config import RecallConfig
+from bergson.config.config import RecallConfig, ScoreConfig
+from bergson.config.config_io import load_subconfig
 from bergson.data import load_scores
 from bergson.recall.generate import ensure_recall_datasets
 from bergson.utils.csv_writer import CSVWriter
@@ -30,6 +31,30 @@ def gold_ranks(scores_col: np.ndarray, gold_idx: np.ndarray) -> np.ndarray:
         ranks[j] = higher + tied_before + 1
 
     return ranks
+
+
+def resolve_higher_is_better(scores_path: str, explicit: bool | None) -> bool:
+    """Score orientation to use when ranking ``scores_path``.
+
+    ``explicit`` wins when set. Otherwise use the ``score_cfg.higher_is_better``
+    recorded in the score directory.
+    """
+    if explicit is not None:
+        return explicit
+
+    score_cfg = (
+        load_subconfig(scores_path, "score_cfg", ScoreConfig)
+        if scores_path and os.path.isdir(scores_path)
+        else None
+    )
+    if score_cfg is None:
+        return True
+
+    print(
+        f"Using higher_is_better={score_cfg.higher_is_better} recorded in "
+        f"{scores_path}; set recall_cfg.higher_is_better to override."
+    )
+    return score_cfg.higher_is_better
 
 
 def run_recall(recall_cfg: RecallConfig) -> dict[str, float]:
@@ -67,6 +92,10 @@ def run_recall(recall_cfg: RecallConfig) -> dict[str, float]:
     ):
         gold[(identifier, fact_field)].append(i)
 
+    higher_is_better = resolve_higher_is_better(
+        recall_cfg.scores, recall_cfg.higher_is_better
+    )
+
     k = recall_cfg.k
     os.makedirs(recall_cfg.run_path, exist_ok=True)
     recall_csv_path = os.path.join(recall_cfg.run_path, "recall.csv")
@@ -94,7 +123,7 @@ def run_recall(recall_cfg: RecallConfig) -> dict[str, float]:
     strict_recalls = []
     for q_idx in range(len(questions)):
         col = np.asarray(scores.get(slice(None), q_idx), dtype=np.float64)
-        if not recall_cfg.higher_is_better:
+        if not higher_is_better:
             col = -col
 
         gold_idx = np.asarray(gold[(identifiers[q_idx], fields[q_idx])])

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -169,6 +169,7 @@ def create_scorer(
         preprocess_cfg.hessian_path,
         inversion_cfg=preprocess_cfg.inversion_cfg,
         power=-0.5 if preprocess_cfg.unit_normalize else -1.0,
+        ev_correction=preprocess_cfg.ev_correction,
         device=device,
     )
 

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -2,7 +2,15 @@ import numpy as np
 import pytest
 from datasets import Dataset, load_from_disk
 
-from bergson.config.config import RecallConfig, RecallDataConfig
+from bergson.cli.commands import Score
+from bergson.config.config import (
+    IndexConfig,
+    PreprocessConfig,
+    RecallConfig,
+    RecallDataConfig,
+    ScoreConfig,
+)
+from bergson.config.config_io import save_run_config
 from bergson.recall import recall as recall_mod
 from bergson.recall.generate import (
     NUM_FIELDS,
@@ -169,6 +177,83 @@ def test_run_recall_higher_is_better_false_flips_sign(tmp_path, monkeypatch):
 
     assert metrics["mrr"] == pytest.approx(1.0)
     assert metrics["recall_at_2"] == pytest.approx(1.0)
+
+
+def _write_score_dir(tmp_path, higher_is_better: bool) -> str:
+    """A score directory whose ``config.yaml`` records ``higher_is_better``."""
+    score_dir = tmp_path / "scores"
+    score_dir.mkdir()
+    save_run_config(
+        Score(
+            ScoreConfig(query_path="q", higher_is_better=higher_is_better),
+            IndexConfig(run_path=str(score_dir)),
+            PreprocessConfig(),
+        ),
+        score_dir,
+    )
+    return str(score_dir)
+
+
+def test_run_recall_reads_higher_is_better_from_score_dir(tmp_path, monkeypatch):
+    """Regression: recall must honour the orientation the scoring run recorded.
+
+    SOURCE (approx unrolling) writes ``score_cfg.higher_is_better=False``. With
+    ``RecallConfig.higher_is_better`` left unset, recall used to default to
+    True and rank the true proponent last.
+    """
+    s_path, q_path = _write_datasets(tmp_path)
+    # Loss-diff convention: the most negative score is the best proponent.
+    matrix = np.array(
+        [
+            [-1.0, 0.0],  # gold Q0
+            [-0.9, 0.0],  # gold Q0
+            [0.0, -1.0],  # gold Q1
+            [0.0, -0.9],  # gold Q1
+        ]
+    )
+    _patch_io(monkeypatch, s_path, q_path, matrix)
+
+    cfg = _cfg(tmp_path)
+    cfg.scores = _write_score_dir(tmp_path, higher_is_better=False)
+    # cfg.higher_is_better is left at its default: the score dir decides.
+
+    metrics = run_recall(cfg)
+
+    assert metrics["mrr"] == pytest.approx(1.0)
+    assert metrics["recall_at_2"] == pytest.approx(1.0)
+
+
+def test_run_recall_explicit_higher_is_better_overrides_score_dir(
+    tmp_path, monkeypatch
+):
+    """An explicitly set config value still wins over the saved score_cfg."""
+    s_path, q_path = _write_datasets(tmp_path)
+    matrix = np.array(
+        [
+            [-1.0, 0.0],
+            [-0.9, 0.0],
+            [0.0, -1.0],
+            [0.0, -0.9],
+        ]
+    )
+    _patch_io(monkeypatch, s_path, q_path, matrix)
+
+    cfg = _cfg(tmp_path)
+    cfg.scores = _write_score_dir(tmp_path, higher_is_better=False)
+    cfg.higher_is_better = True  # explicit: do not negate
+
+    metrics = run_recall(cfg)
+
+    # Gold rows are the most negative, so ranking descending puts them last:
+    # Q0 gold ranks 3 and 4, Q1 gold ranks 3 and 4 -> no hits at k=2.
+    assert metrics["recall_at_2"] == pytest.approx(0.0)
+
+
+def test_resolve_higher_is_better_defaults_true_without_score_cfg(tmp_path):
+    """No score directory / no saved score_cfg -> default True."""
+    resolve = recall_mod.resolve_higher_is_better
+    assert resolve(str(tmp_path / "missing"), None) is True
+    assert resolve("", None) is True
 
 
 def test_run_recall_statement_count_mismatch_raises(tmp_path, monkeypatch):

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -526,12 +526,18 @@ def _write_factored_hessian(
     ``[I, I]``), ``eigen_gradient_sharded`` (Q_G ``[O, O]``), and
     ``eigenvalue_sharded`` (λ grid ``[O, I]``), plus the ``factor_eig_a``/
     ``factor_eig_g`` vectors used by factored-Tikhonov.
+
+    Also writes ``eigenvalue_correction_sharded``, the EK-FAC-corrected grid a
+    Hessian fit with ``HessianConfig.ev_correction=True`` carries. It is
+    deliberately different from the K-FAC grid so tests can tell which one a
+    preconditioner actually used.
     """
     g = torch.Generator().manual_seed(seed)
     subdirs = [
         "eigen_activation_sharded",
         "eigen_gradient_sharded",
         "eigenvalue_sharded",
+        "eigenvalue_correction_sharded",
         "factor_eig_a",
         "factor_eig_g",
     ]
@@ -544,12 +550,17 @@ def _write_factored_hessian(
         lam_a = torch.rand(i, generator=g) + 0.1
         lam_g = torch.rand(o, generator=g) + 0.1
         grid = torch.outer(lam_g, lam_a)  # [O, I]
+        # Corrected (EK-FAC) eigenvalues: a distinct positive grid.
+        corrected = grid * (1.0 + 4.0 * torch.rand(o, i, generator=g))
         for r in range(num_shards):
             ia, ib = shard_bounds(i, r, num_shards)
             oa, ob = shard_bounds(o, r, num_shards)
             per_shard["eigen_activation_sharded"][r][name] = q_a[ia:ib].contiguous()
             per_shard["eigen_gradient_sharded"][r][name] = q_g[oa:ob].contiguous()
             per_shard["eigenvalue_sharded"][r][name] = grid[oa:ob].contiguous()
+            per_shard["eigenvalue_correction_sharded"][r][name] = corrected[
+                oa:ob
+            ].contiguous()
             per_shard["factor_eig_g"][r][name] = lam_g[oa:ob].contiguous()
             per_shard["factor_eig_a"][r][name] = lam_a.contiguous()  # replicated
 
@@ -666,6 +677,66 @@ def test_score_factored_hessian_query_preconditioning(tmp_path: Path, dataset):
     assert torch.allclose(
         from_reduce, from_score, atol=1e-4, rtol=1e-4
     ), "reduce-time vs score-time factored preconditioning differ"
+
+
+def test_score_uses_ev_correction(tmp_path: Path, dataset):
+    """Regression: ``score`` must honour ``PreprocessConfig.ev_correction``.
+
+    ``score.create_scorer`` used to call ``load_preconditioner`` without
+    ``ev_correction``, so an EK-FAC Hessian fit with corrected eigenvalues was
+    silently scored with the plain K-FAC eigenvalues.
+    """
+    device = torch.device("cpu")
+    dtype = torch.float32
+    modules = {"mod_a": (4, 6), "mod_b": (5, 3)}  # (O, I)
+    grad_sizes = {m: o * i for m, (o, i) in modules.items()}
+    num_q = 3
+
+    hessian_path = str(tmp_path / "hessian")
+    _write_factored_hessian(Path(hessian_path), modules)
+
+    rng = torch.Generator().manual_seed(2)
+    raw = {m: torch.randn(num_q, s, generator=rng) for m, s in grad_sizes.items()}
+    q_raw = _write_query_index(tmp_path / "q_raw", raw, PreprocessConfig(), num_q)
+
+    def scored_query_grads(tag: str, ev_correction: bool) -> torch.Tensor:
+        scorer = create_scorer(
+            path=tmp_path / f"scores_{tag}",
+            data=dataset,
+            score_cfg=ScoreConfig(query_path=str(q_raw)),
+            preprocess_cfg=PreprocessConfig(
+                hessian_path=hessian_path, ev_correction=ev_correction
+            ),
+            device=device,
+            dtype=dtype,
+        )
+        return torch.cat([scorer.query_grads_t[m] for m in scorer.modules], dim=0)
+
+    corrected = scored_query_grads("corrected", True)
+    uncorrected = scored_query_grads("uncorrected", False)
+
+    # The two eigenvalue grids differ, so the preconditioned queries must too —
+    # otherwise the check below would be vacuous.
+    assert not torch.allclose(corrected, uncorrected, atol=1e-4), (
+        "corrected and uncorrected eigenvalues give the same result; "
+        "the synthetic Hessian makes this test vacuous"
+    )
+
+    # ev_correction=True must match the corrected preconditioner exactly.
+    ref_pre = FactoredPreconditioner.from_path(
+        hessian_path,
+        inversion_cfg=InversionConfig(),
+        power=-1.0,
+        ev_correction=True,
+        device="cpu",
+    )
+    ref = ref_pre.apply({k: v.clone() for k, v in raw.items()})
+    expected = torch.cat(
+        [ref[m].T.contiguous() for m in sorted(grad_sizes)], dim=0
+    ).float()
+    assert torch.allclose(
+        corrected, expected, atol=1e-4, rtol=1e-4
+    ), "score ignored ev_correction: plain K-FAC eigenvalues were used"
 
 
 def test_score_factored_hessian_index_transform(tmp_path: Path, dataset):


### PR DESCRIPTION
- Add support to EK-FAC through score path (documented path is through `bergson ekfac` but we will eventually move to unify)
- Fix `recall` to respect the orientation recorded by the scoring run to avoid sign flips in SOURCE results:`validate` reads `score_cfg.higher_is_better` from the score directory's own `config.yaml` (validate.py:57-61), but `run_recall` only looked at `RecallConfig.higher_is_better`, which defaulted to True.`RecallConfig.higher_is_better` is now `bool | None = None`. When left as None, `resolve_higher_is_better` reads the orientation from the score directory's saved `score_cfg` (falling back to True when there is none, e.g. a bare .npy), so an explicitly configured value still wins and existing configs are unaffected.