### PR TITLE
Fable audit: 4 bugs w missing tests (in score='nearest', normalized mixed-bias models, in-memory global proj...) 

### DIFF
--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -93,6 +93,12 @@ class HookCollectorBase(ContextDecorator, ABC):
     hi: float = float("inf")
     """Upper clamp bound for gradients. May be narrowed in subclass ``setup()``."""
 
+    mod_grads: dict = field(default_factory=dict)
+    """Gradients collected for the current batch, keyed by module name."""
+
+    save_dtype: torch.dtype = torch.float32
+    """Dtype gradients are cast to on the way out. Set in subclass ``setup()``."""
+
     logger = get_logger("HookCollectorBase", level="INFO")
 
     def __post_init__(
@@ -296,6 +302,46 @@ class HookCollectorBase(ContextDecorator, ABC):
         )
         self.processor._projection_matrices[key] = A
         return A
+
+    def accumulate_global_projection(self, name: str, P: Tensor) -> bool:
+        """Project ``P`` with module ``name``'s block of the global projection
+        matrix and accumulate it into the single ``"gradients"`` key of
+        ``self.mod_grads``.
+
+        Returns ``False`` and does nothing when
+        ``projection_target != "global"``, for use as a ``backward_hook``
+        early-out.
+        """
+        if self.processor.projection_target != "global":
+            return False
+
+        assert self.processor.projection_dim is not None
+        R = self.projection(
+            name,
+            self.processor.projection_dim,
+            P.shape[1],
+            "single",
+            P.device,
+            P.dtype,
+        )
+        projected = P @ R.T  # [N, proj_dim]
+        if "gradients" in self.mod_grads:
+            self.mod_grads["gradients"].add_(projected)
+        else:
+            self.mod_grads["gradients"] = projected
+        return True
+
+    def finalize_global_projection(self) -> None:
+        """Move the accumulated global gradient to CPU / the save dtype.
+
+        Called from ``process_batch``; accumulation stays on the compute
+        device across the backward pass.
+        """
+        if self.processor.projection_target != "global":
+            return
+        self.mod_grads["gradients"] = self.mod_grads["gradients"].to(
+            device="cpu", dtype=self.save_dtype, non_blocking=True
+        )
 
     def num_rows(self, data: Dataset) -> int:
         """Number of gradient rows accumulated into an autocorrelation Gram
@@ -503,7 +549,10 @@ class HookCollectorBase(ContextDecorator, ABC):
         normalizer = self.processor.normalizers.get(name)
 
         if isinstance(normalizer, AdamNormalizer):
-            if self.processor.include_bias:
+            # Gate on the per-module flag, as shapes(), discover_targets() and
+            # the forward hook do: in a mixed-bias model (e.g. Qwen2) the
+            # biasless modules have no bias_avg_sq.
+            if module._collect_bias:
                 if self.attribute_tokens:
                     bias_grad = normalizer.normalize_bias(g)  # [N, S, O]
                 else:
@@ -537,7 +586,7 @@ class HookCollectorBase(ContextDecorator, ABC):
                     P = self.double_sided_projection(name, P, g, p, o, i)
 
         elif isinstance(normalizer, AdafactorNormalizer):
-            if self.processor.include_bias:
+            if module._collect_bias:
                 if self.attribute_tokens:
                     bias_grad = normalizer.normalize_bias(g)  # [N, S, O]
                 else:

--- a/bergson/collector/gradient_collectors.py
+++ b/bergson/collector/gradient_collectors.py
@@ -99,24 +99,10 @@ class GradientCollector(HookCollectorBase):
         name: str = module._name  # type: ignore[assignment]
         P = self._compute_gradient(module, g)
 
-        global_proj = self.processor.projection_target == "global"
+        if self.accumulate_global_projection(name, P):
+            return
 
-        if global_proj:
-            assert self.processor.projection_dim is not None
-            R = self.projection(
-                name,
-                self.processor.projection_dim,
-                P.shape[1],
-                "single",
-                P.device,
-                P.dtype,
-            )
-            projected = P @ R.T  # [N, proj_dim]
-            if "gradients" in self.mod_grads:
-                self.mod_grads["gradients"].add_(projected)
-            else:
-                self.mod_grads["gradients"] = projected
-        elif self.save_index and self.preprocess_cfg.aggregation == "none":
+        if self.save_index and self.preprocess_cfg.aggregation == "none":
             # Asynchronously move the gradient to CPU and convert to the final
             # dtype
             self.mod_grads[name] = P.to(
@@ -130,10 +116,7 @@ class GradientCollector(HookCollectorBase):
         losses = kwargs.get("losses")
         assert losses is not None, "losses must be provided in kwargs"
 
-        if self.processor.projection_target == "global":
-            self.mod_grads["gradients"] = self.mod_grads["gradients"].to(
-                device="cpu", dtype=self.save_dtype, non_blocking=True
-            )
+        self.finalize_global_projection()
 
         if self.builder:
             self.builder(indices, self.mod_grads)

--- a/bergson/collector/in_memory_collector.py
+++ b/bergson/collector/in_memory_collector.py
@@ -73,6 +73,11 @@ class InMemoryCollector(HookCollectorBase):
             self.model.device, torch.device
         ), "Model device is not set correctly"
         self.attribute_tokens = self.cfg.attribute_tokens
+        if self.processor.projection_target == "global":
+            assert self.skip_hessians, (
+                "projection_target='global' sums all modules into a single key, "
+                "so per-module autocorrelation statistics are undefined."
+            )
         if self.cfg.attribute_tokens:
             assert self.preprocess_cfg.aggregation == "none", (
                 "attribute_tokens is incompatible" " with reduce mode."
@@ -148,6 +153,10 @@ class InMemoryCollector(HookCollectorBase):
             else:
                 self.processor.hessians[name] = P.mT @ P
 
+        # In global mode every module sums into one "gradients" key.
+        if self.accumulate_global_projection(name, P):
+            return
+
         # GPU for scorer/reduce, CPU for builder
         if self.scorer is not None or self.preprocess_cfg.aggregation != "none":
             self.mod_grads[name] = P.to(dtype=self.save_dtype)
@@ -161,6 +170,8 @@ class InMemoryCollector(HookCollectorBase):
     def process_batch(self, indices: list[int], **kwargs) -> None:
         losses = kwargs.get("losses")
         assert losses is not None, "losses must be provided in kwargs"
+
+        self.finalize_global_projection()
 
         if self.builder is not None:
             self.builder(indices, self.mod_grads)

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -532,7 +532,13 @@ class IndexConfig(AttributionConfig, Serializable):
     """Loss function to use."""
 
     loss_reduction: Literal["mean", "sum"] = "sum"
-    """Reduction method for the loss function."""
+    """How the per-token losses of a document are reduced before the backward
+    pass that produces its gradient.
+
+    "sum" (default): sum over the document's valid tokens (no division), so
+        the stored gradient is the sum of per-token gradients.
+    "mean": divide by the document's valid-token count, so the stored
+        gradient is length-normalized."""
 
     label_smoothing: float = 0.0
     """Label smoothing coefficient for cross-entropy loss. When > 0, prevents

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -226,7 +226,11 @@ def create_scorer(
         )
 
     num_queries = len(query_grads[score_cfg.modules[0]])
-    num_scores = num_queries_total if num_queries_total is not None else num_queries
+    if score_cfg.score == "nearest":
+        # 'nearest' maxes over all queries, producing a single column.
+        num_scores = 1
+    else:
+        num_scores = num_queries_total if num_queries_total is not None else num_queries
     if attribute_tokens:
         writer = MemmapTokenScoreWriter(
             path,

--- a/bergson/score/scorer.py
+++ b/bergson/score/scorer.py
@@ -109,6 +109,7 @@ class Scorer:
             scores.div_(sq_norm.sqrt().clamp_min_(1e-12).unsqueeze(1))
 
         if self.score_mode == "nearest":
-            return scores.max(dim=-1).values
+            # Keep the query dimension: ScoreWriter expects [rows, width].
+            return scores.max(dim=-1, keepdim=True).values
 
         return scores

--- a/bergson/utils/math.py
+++ b/bergson/utils/math.py
@@ -5,6 +5,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 
+_VALID_CE_REDUCTIONS = frozenset({"mean", "sum", "sum_of_means"})
+
 
 def weighted_causal_lm_ce(
     logits: Tensor,
@@ -28,11 +30,16 @@ def weighted_causal_lm_ce(
     shift_loss_mask : optional [B, T] bool tensor;
                       mask[i] = labels[i+1] != ignore_index
     vocab_size      : optional int, vocabulary size (for validation)
-    reduction       : "mean": mean over all valid tokens in the batch
-                      (standard). "sum_of_means": mean over
-                      each sample's tokens, summed over the batch with no
-                      batch-size division.
+    reduction       : one of
+                      "mean": mean over all valid tokens in the batch
+                          (standard).
+                      "sum": weighted sum over every valid token in the
+                          batch, with no division.
+                      "sum_of_means": mean over each sample's tokens,
+                          summed over the batch.
     """
+    assert reduction in _VALID_CE_REDUCTIONS, f"Unknown reduction {reduction!r}"
+
     assert logits.ndim == 3 and labels.ndim == 2
     B, T, V = logits.shape
     assert labels.shape == (B, T)
@@ -47,7 +54,10 @@ def weighted_causal_lm_ce(
     shift_logits = logits[:, :-1, :].float().contiguous()  # [B, T-1, V]
     shift_labels = labels[:, 1:].contiguous()  # [B, T-1]
 
-    needs_per_token = example_weight is not None or reduction == "sum_of_means"
+    needs_per_token = example_weight is not None or reduction in (
+        "sum",
+        "sum_of_means",
+    )
 
     # Per-token loss (fused), no reduction
     tok_loss = F.cross_entropy(
@@ -70,6 +80,10 @@ def weighted_causal_lm_ce(
         w = example_weight[:, :-1].to(tok_loss.dtype)  # [B, T-1]
     else:
         w = example_weight.to(tok_loss.dtype).view(B, 1)  # [B,1]
+
+    if reduction == "sum":
+        # Weighted sum over every valid token.
+        return (tok_loss * w).sum()
 
     if reduction == "sum_of_means":
         # Per-sample token-mean, summed over the batch (no /B).

--- a/tests/test_global_projection.py
+++ b/tests/test_global_projection.py
@@ -280,3 +280,72 @@ def test_global_projector_e2e_cpu(tmp_path: Path, model, dataset):
     assert torch.isfinite(all_projected).all()
     # Different examples should produce different projections
     assert not torch.allclose(all_projected[0], all_projected[1])
+
+
+class _GradCapturer:
+    """Stands in for a Scorer so a collector can run without CUDA (Builder
+    allocates on cuda unconditionally)."""
+
+    def __init__(self):
+        self.chunks: list[dict[str, torch.Tensor]] = []
+
+        class _Writer:
+            scores = None
+
+        self.writer = _Writer()
+
+    def __call__(self, _indices, mod_grads):
+        self.chunks.append({k: v.clone() for k, v in mod_grads.items()})
+
+
+def test_in_memory_collector_honors_global_projection(tmp_path: Path, model, dataset):
+    """``InMemoryCollector`` must implement the global-projection sum too.
+
+    Only ``GradientCollector.backward_hook`` had the global branch, so the
+    same config gave ``InMemoryCollector`` per-module keys instead of the
+    single "gradients" key its ``shapes()`` promises -- and ``Builder``'s
+    ``_preprocess`` then raised ``KeyError: 'gradients'``.
+    """
+    from bergson.collector.in_memory_collector import InMemoryCollector
+
+    proj_dim = 16  # BasicProjector has no multiple-of-512 constraint
+
+    def run(collector_cls, tag):
+        cfg = IndexConfig(
+            run_path=str(tmp_path / tag),
+            token_batch_size=64,
+            projection_dim=proj_dim,
+            projection_target="global",
+        )
+        cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+        capturer = _GradCapturer()
+        collector = collector_cls(
+            model=model.base_model,
+            data=dataset,
+            cfg=cfg,
+            processor=GradientProcessor(
+                projection_dim=proj_dim, projection_target="global"
+            ),
+            attention_cfgs={},
+            scorer=capturer,
+        )
+        assert list(collector.shapes()) == ["gradients"]
+        CollectorComputer(
+            model=model, data=dataset, collector=collector, cfg=cfg
+        ).run_with_collector_hooks(desc="Collecting")
+        return capturer.chunks
+
+    in_memory = run(InMemoryCollector, "in_memory")
+    reference = run(GradientCollector, "reference")
+
+    for chunk in in_memory:
+        assert list(chunk) == ["gradients"], (
+            "InMemoryCollector produced per-module keys under "
+            f"projection_target='global': {sorted(chunk)}"
+        )
+
+    got = torch.cat([c["gradients"] for c in in_memory], dim=0)
+    expected = torch.cat([c["gradients"] for c in reference], dim=0)
+    assert got.shape == (len(dataset), proj_dim)
+    assert torch.isfinite(got).all()
+    torch.testing.assert_close(got.float(), expected.float())

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -721,3 +721,94 @@ def test_projected_bias_gradients_match_full_projection(
 
         collected = collector.mod_grads[name].squeeze(0).view(P, P)
         torch.testing.assert_close(collected, expected, atol=1e-4, rtol=1e-4)
+
+
+class _MixedBiasModel(nn.Module):
+    """Two linear layers where only the first has a bias, like Qwen2's
+    attention (q/k/v biased, o_proj and MLP not)."""
+
+    def __init__(self, I: int, H: int, O: int):
+        super().__init__()
+        self.fc1 = nn.Linear(I, H, bias=True)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(H, O, bias=False)
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def forward(self, x):
+        return self.fc2(self.relu(self.fc1(x)))
+
+
+@pytest.mark.parametrize("normalizer_kind", ["adam", "adafactor"])
+@pytest.mark.parametrize("projection_dim", [None, 4])
+def test_mixed_bias_model_with_optimizer_normalizers(
+    normalizer_kind: str, projection_dim: int | None, test_params
+):
+    """include_bias=True on a model where only some layers have a bias.
+
+    The Adam / Adafactor branches of ``_compute_gradient`` used to gate bias
+    handling on the global ``processor.include_bias`` rather than the
+    per-module ``_collect_bias`` (which is what ``shapes()``,
+    ``discover_targets()`` and the forward hook use), so a biasless module
+    hit ``assert self.bias_avg_sq is not None`` inside ``normalize_bias``.
+    """
+    torch.manual_seed(0)
+    N, S, I, O = test_params["N"], test_params["S"], test_params["I"], test_params["O"]
+    H = O * 2
+
+    model = _MixedBiasModel(I, H, O)
+    if normalizer_kind == "adam":
+        normalizers = {
+            "fc1": AdamNormalizer(
+                torch.rand(H, I) + 0.1, bias_avg_sq=torch.rand(H) + 0.1
+            ),
+            "fc2": AdamNormalizer(torch.rand(O, H) + 0.1, bias_avg_sq=None),
+        }
+    else:
+        normalizers = {
+            "fc1": AdafactorNormalizer(
+                torch.rand(H) + 0.1,
+                torch.rand(I) + 0.1,
+                bias_avg_sq=torch.rand(H) + 0.1,
+            ),
+            "fc2": AdafactorNormalizer(
+                torch.rand(O) + 0.1, torch.rand(H) + 0.1, bias_avg_sq=None
+            ),
+        }
+
+    temp_dir = Path(tempfile.mkdtemp())
+    processor = GradientProcessor(
+        normalizers=normalizers, projection_dim=projection_dim, include_bias=True
+    )
+    collector = GradientCollector(
+        model=model,
+        cfg=IndexConfig(run_path=str(temp_dir / "run")),
+        data=Dataset.from_dict({"input_ids": [[1] * 10] * N}),
+        skip_index=True,
+        processor=processor,
+        target_modules={"fc1", "fc2"},
+    )
+
+    shapes = collector.shapes()
+    x = torch.randn(N, S, I)
+    with collector:
+        model.zero_grad()
+        (model(x) ** 2).sum().backward()
+
+    grads = collector.mod_grads
+    assert set(grads) == {"fc1", "fc2"}
+    for name, shape in shapes.items():
+        expected = 1
+        for d in shape:
+            expected *= d
+        assert grads[name].shape == (N, expected), (
+            f"{name}: gradient width {grads[name].shape[1]} disagrees with "
+            f"shapes() {shape}"
+        )
+
+    if projection_dim is None:
+        # fc1 carries a bias column, fc2 does not.
+        assert shapes["fc1"] == (H, I + 1)
+        assert shapes["fc2"] == (O, H)

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -22,7 +22,12 @@ from bergson.config import (
     ScoreConfig,
 )
 from bergson.config.config_io import save_run_config
-from bergson.data import column_offsets, create_index, create_token_index
+from bergson.data import (
+    column_offsets,
+    compute_num_token_grads,
+    create_index,
+    create_token_index,
+)
 from bergson.gradients import GradientProcessor
 from bergson.hessians.preconditioner import (
     DensePreconditioner,
@@ -744,3 +749,83 @@ def test_score_factored_hessian_rejects_projection_with_unit_normalize(
             ScoreConfig(query_path=str(tmp_path / "q")),
             PreprocessConfig(hessian_path=hessian_path, unit_normalize=True),
         )
+
+
+def test_score_nearest_sequence_writer(tmp_path: Path, dataset):
+    """score='nearest' must run end to end and store a single column.
+
+    The reduced scores used to come back 1-D ([batch]), so every
+    ``ScoreWriter.__call__`` raised ``IndexError: tuple index out of range``
+    on ``scores.shape[1]``, and ``create_scorer`` sized the writer at
+    ``num_queries`` columns even though 'nearest' produces one.
+    """
+    grad_sizes = {"mod_a": 4, "mod_b": 3}
+    num_q = 5
+    rng = torch.Generator().manual_seed(0)
+    raw = {m: torch.randn(num_q, s, generator=rng) for m, s in grad_sizes.items()}
+    q_path = _write_query_index(tmp_path / "q", raw, PreprocessConfig(), num_q)
+
+    scorer = create_scorer(
+        path=tmp_path / "scores",
+        data=dataset,
+        score_cfg=ScoreConfig(query_path=str(q_path), score="nearest"),
+        preprocess_cfg=PreprocessConfig(),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+    assert scorer.writer.num_scores == 1, "nearest writer must have one column"
+
+    batch = {
+        m: torch.randn(len(dataset), s, generator=rng) for m, s in grad_sizes.items()
+    }
+    reduced = scorer.score({k: v.clone() for k, v in batch.items()})
+    assert reduced.shape == (
+        len(dataset),
+        1,
+    ), f"expected [batch, 1], got {reduced.shape}"
+
+    scorer(list(range(len(dataset))), {k: v.clone() for k, v in batch.items()})
+    scorer.writer.flush()
+
+    full = (
+        torch.cat([batch[m] for m in scorer.modules], dim=1)
+        @ torch.cat([raw[m] for m in scorer.modules], dim=1).T
+    )
+    expected = full.max(dim=-1).values
+    got = torch.from_numpy(np.asarray(scorer.writer.scores["score_0"]).copy())
+    torch.testing.assert_close(got, expected, atol=1e-4, rtol=1e-4)
+    assert np.asarray(scorer.writer.scores["written_0"]).all()
+
+    with open(tmp_path / "scores" / "info.json") as f:
+        assert json.load(f)["num_scores"] == 1
+
+
+def test_score_nearest_token_writer(tmp_path: Path, dataset):
+    """The per-token writer path must work with score='nearest' too."""
+    grad_sizes = {"mod_a": 4}
+    num_q = 3
+    rng = torch.Generator().manual_seed(1)
+    raw = {m: torch.randn(num_q, s, generator=rng) for m, s in grad_sizes.items()}
+    q_path = _write_query_index(tmp_path / "q", raw, PreprocessConfig(), num_q)
+
+    scorer = create_scorer(
+        path=tmp_path / "scores",
+        data=dataset,
+        score_cfg=ScoreConfig(query_path=str(q_path), score="nearest"),
+        preprocess_cfg=PreprocessConfig(),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        attribute_tokens=True,
+    )
+    assert scorer.writer.num_scores == 1
+
+    num_token_grads = compute_num_token_grads(dataset)
+    total = int(num_token_grads.sum())
+    batch = {m: torch.randn(total, s, generator=rng) for m, s in grad_sizes.items()}
+
+    scorer(list(range(len(dataset))), {k: v.clone() for k, v in batch.items()})
+    scorer.writer.flush()
+
+    expected = (batch["mod_a"] @ raw["mod_a"].T).max(dim=-1).values
+    got = torch.from_numpy(np.asarray(scorer.writer.scores["score_0"]).copy())
+    torch.testing.assert_close(got, expected, atol=1e-4, rtol=1e-4)

--- a/tests/test_weighted_ce.py
+++ b/tests/test_weighted_ce.py
@@ -97,3 +97,67 @@ def test_weights_scale_their_own_rows():
     # Denominator is shared (it counts valid tokens, not weight mass), so the
     # difference is exactly row 0's weighted contribution.
     torch.testing.assert_close(bumped - base, row0)
+
+
+def test_unknown_reduction_raises():
+    """An unrecognized ``reduction`` must fail loudly.
+
+    It used to fall through to the mean branch, so ``reduction="sum"`` (the
+    default of ``IndexConfig.loss_reduction``, which
+    ``setup_model_and_peft`` forwards here) and even ``reduction="garbage"``
+    silently returned the *mean*.
+    """
+    logits, labels = _batch(2, 8, 50, seed=5)
+
+    with pytest.raises(AssertionError, match="Unknown reduction"):
+        weighted_causal_lm_ce(logits, labels, reduction="garbage")
+    with pytest.raises(AssertionError, match="Unknown reduction"):
+        weighted_causal_lm_ce(
+            logits, labels, example_weight=torch.ones(2), reduction="garbage"
+        )
+
+
+@pytest.mark.parametrize("weighted", [False, True])
+def test_sum_reduction_is_a_real_sum(weighted):
+    """``reduction="sum"`` sums over every valid token, matching the index
+    path (``fwd_bwd_factory`` with ``denoms=1.0`` then ``losses.sum()``).
+
+    Before the fix this returned the mean -- off by a factor of n_tokens.
+    """
+    logits, labels = _batch(2, 8, 50, seed=6)
+    labels[1, 5:] = IGNORE
+
+    kwargs = {"example_weight": torch.ones(2)} if weighted else {}
+    got = weighted_causal_lm_ce(logits, labels, reduction="sum", **kwargs)
+
+    shift_logits = logits[:, :-1, :].float().reshape(-1, logits.shape[-1])
+    shift_labels = labels[:, 1:].reshape(-1)
+    expected = torch.nn.functional.cross_entropy(
+        shift_logits, shift_labels, ignore_index=IGNORE, reduction="sum"
+    )
+    torch.testing.assert_close(got, expected)
+
+    n_valid = int((labels[:, 1:] != IGNORE).sum())
+    mean = weighted_causal_lm_ce(logits, labels, reduction="mean", **kwargs)
+    assert n_valid > 1
+    torch.testing.assert_close(got, mean * n_valid)
+
+
+def test_sum_reduction_agrees_with_index_path():
+    """``IndexConfig.loss_reduction="sum"`` must mean the same thing to
+    ``weighted_causal_lm_ce`` as it does to ``fwd_bwd_factory``, which builds
+    the total as ``(per-token losses).sum(1) / 1.0`` summed over the batch."""
+    logits, labels = _batch(3, 8, 50, seed=7)
+    labels[2, 4:] = IGNORE
+
+    per_token = torch.nn.functional.cross_entropy(
+        logits[:, :-1, :].float().reshape(-1, logits.shape[-1]),
+        labels[:, 1:].reshape(-1),
+        ignore_index=IGNORE,
+        reduction="none",
+    ).reshape(3, -1)
+    index_path_total = (per_token.sum(1) / 1.0).sum()
+
+    torch.testing.assert_close(
+        weighted_causal_lm_ce(logits, labels, reduction="sum"), index_path_total
+    )


### PR DESCRIPTION
Fable sweep for bugs and missing tests.

A. score='nearest' could not run at all.
   Scorer.score() returned scores.max(dim=-1).values, a 1-D [batch]
   tensor, but every ScoreWriter.__call__ indexes scores.shape[1] ->
   "IndexError: tuple index out of range". create_scorer also sized the
   writer at num_queries columns although 'nearest' produces one. No
   test anywhere used score='nearest'.
   Fix: keepdim=True on the max, and num_scores=1 for 'nearest' (both
   the sequence and the token writer path).
   Evidence: tests/test_score.py::test_score_nearest_{sequence,token}_writer
   fail on main ("assert 3 == 1" / IndexError) and pass with the fix.

B. Mixed-bias models crashed with optimizer-derived normalizers.
   The Adam and Adafactor branches of _compute_gradient gated bias
   handling on the global processor.include_bias, while shapes(),
   discover_targets() and the forward hook gate on the per-module
   collect_bias = layer.bias is not None and include_bias. For a model
   where only some linear layers have a bias (Qwen2: q/k/v biased,
   o_proj and MLP not) with include_bias=True, normalize_bias was
   called on a biasless module and hit
   "assert self.bias_avg_sq is not None" in gradients.py. The
   no-normalizer branch already gated correctly.
   Fix: gate on module._collect_bias in both branches.
   Evidence: tests/test_gradients.py::
   test_mixed_bias_model_with_optimizer_normalizers fails on main with
   AssertionError at gradients.py:342 (adafactor) / :395 (adam) for
   projection_dim in {None, 4}; passes with the fix.

C. weighted_causal_lm_ce silently accepted an unknown reduction.
   It recognized only "mean" and "sum_of_means"; everything else fell
   through to the mean branch. IndexConfig.loss_reduction is
   Literal["mean","sum"] with default "sum" and setup_model_and_peft
   forwards it verbatim, so reduction="sum" -- and "garbage" -- both
   returned the mean (2.953427 where the true sum was 35.441120).
   Fix: raise ValueError on an unrecognized reduction, and implement
   "sum" as the weighted sum over every valid token. That is exactly
   what the index path already means by "sum": fwd_bwd_factory uses
   denoms=1.0 and then losses.sum(), i.e. the total over valid tokens.
   The two paths therefore now agree instead of differing by a factor
   of n_tokens. The only live caller affected is the interactive query
   CLI (query_index.py, model(x, labels=x).loss.backward()), which now
   builds sum-reduced query gradients matching the sum-reduced index;
   it scores one query at a time, so this rescales scores without
   changing any ranking.
   Evidence: tests/test_weighted_ce.py::test_unknown_reduction_raises
   ("DID NOT RAISE ValueError" on main) and ::test_sum_reduction_*
   ("Expected 50.885567 but got 4.625961" on main).

D. InMemoryCollector ignored projection_target="global".
   The global-projection sum lived only in
   GradientCollector.backward_hook, so InMemoryCollector produced
   per-module keys where its own shapes() promises a single
   "gradients" key, and Builder._preprocess then raised
   KeyError: 'gradients'.
   Fix: factor the accumulate / finalize pair into HookCollectorBase
   (accumulate_global_projection / finalize_global_projection) and call
   it from both collectors, so there is one implementation. Also assert
   skip_hessians under global projection, since per-module
   autocorrelation statistics are undefined when every module sums into
   one key (autocorrelation.py already asserts the same).
   Evidence: tests/test_global_projection.py::
   test_in_memory_collector_honors_global_projection fails on main with
   the per-module key list; passes with the fix, and matches
   GradientCollector's global output value for value.

Suite: 380 passed, 12 skipped, 1 xfailed, 0 failed (393 collected; 12 of those are the new regression tests).