### PR TITLE
Fable audit: Fix MAGIC in-memory checkpoints and resumed-run checkpoint schedule

### DIFF
--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -107,6 +107,33 @@ class SaveFuture:
         return result
 
 
+def next_save_index(current: int, n: int, save_mode: MagicSaveMode) -> int:
+    """Index of the checkpoint following the one saved at step `current`.
+
+    `n` is the total number of training steps. The result is always strictly
+    greater than `current`, so iterating this function enumerates the full
+    checkpoint schedule for a run of `n` steps starting from step 0.
+    """
+    match save_mode:
+        case "all":
+            # Save every step
+            return current + 1
+        case "sqrt":
+            chunk_size = math.isqrt(n)
+
+            # If we're in the last chunk, save every step
+            if current >= n - chunk_size:
+                return current + 1
+
+            # Otherwise, save sqrt(n) steps from now
+            return current + chunk_size
+        case "log":
+            # Cut the remaining steps in half to get to the next save point
+            return max(1, (n - current) // 2) + current
+        case other:
+            raise ValueError(f"Unsupported save mode: {other}")
+
+
 @dataclass
 class BackwardState:
     param_grads: dict[str, torch.Tensor]
@@ -135,17 +162,43 @@ class TrainerState:
             self.params[k].copy_(other.params[k])
         for k in self.buffers.keys():
             self.buffers[k].copy_(other.buffers[k])
+
+        # `opt_state` is a PyTree; copy it leaf by leaf into the existing tensors
+        # to keep this method in-place. Non-tensor leaves are taken from `other`.
+        def _copy_leaf(dst, src):
+            if isinstance(dst, torch.Tensor):
+                assert isinstance(src, torch.Tensor), "opt_state structure mismatch"
+                dst.copy_(src)
+                return dst
+
+            return src
+
+        self.opt_state = tree_map(_copy_leaf, self.opt_state, other.opt_state)
+
         self.batch_index = other.batch_index
         self.cuda_rng_state.copy_(other.cuda_rng_state)
         self.cpu_rng_state.copy_(other.cpu_rng_state)
 
     def to(self, device: torch.device | str) -> "TrainerState":
-        params = {k: p.to(device) for k, p in self.params.items()}
-        buffers = {k: b.to(device) for k, b in self.buffers.items()}
+        """Snapshot this state onto `device`.
+
+        Uses copy=True to enforce copy for CPU-to-CPU transfers, so stashed
+        checkpoints survive in-place training steps.
+        """
+        params = {k: p.to(device, copy=True) for k, p in self.params.items()}
+        buffers = {k: b.to(device, copy=True) for k, b in self.buffers.items()}
         opt_state = tree_map(
-            lambda t: t.to(device) if isinstance(t, torch.Tensor) else t, self.opt_state
+            lambda t: t.to(device, copy=True) if isinstance(t, torch.Tensor) else t,
+            self.opt_state,
         )
-        return TrainerState(params, opt_state, buffers, self.batch_index)
+        return TrainerState(
+            params,
+            opt_state,
+            buffers,
+            self.batch_index,
+            self.cuda_rng_state.clone(),
+            self.cpu_rng_state.clone(),
+        )
 
     def load(self, path: str):
         """Load state from a checkpoint file."""
@@ -486,6 +539,10 @@ class Trainer:
             state = self.resume(state, save_dir)
             start = state.batch_index
 
+            # Fast-forward the checkpoint schedule to where we're resuming from.
+            while next_save < start:
+                next_save = next_save_index(next_save, n, save_mode)
+
         pending_save: SaveFuture | None = None
 
         main = not dist.is_initialized() or dist.get_rank() == 0
@@ -504,25 +561,7 @@ class Trainer:
                 p = os.path.join(save_dir, f"step_{i}.ckpt")
                 pending_save = state.save(p, debug_pbar=pbar if debug else None)
 
-                match save_mode:
-                    case "all":
-                        # Save next step
-                        next_save += 1
-                    case "sqrt":
-                        chunk_size = math.isqrt(n)
-
-                        # If we're in the last chunk, save every step
-                        if i >= n - chunk_size:
-                            next_save += 1
-
-                        # Otherwise, save sqrt(n) steps from now
-                        else:
-                            next_save += chunk_size
-                    case "log":
-                        # Cut the remaining steps in half to get to the next save point
-                        next_save = max(1, (n - next_save) // 2) + next_save
-                    case other:
-                        raise ValueError(f"Unsupported save mode: {other}")
+                next_save = next_save_index(next_save, n, save_mode)
 
             x = data[i]
             state = self.step(

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -639,6 +639,231 @@ def test_magic_packed_cli_aggregation_with_shuffle(model_name):
     torch.testing.assert_close(agg, per_doc.to(torch.float64), atol=1e-5, rtol=1e-4)
 
 
+TINY_MODEL = "trl-internal-testing/tiny-Phi3ForCausalLM"
+
+
+def _multi_step_stream(n_steps: int, device: str = "cpu") -> DataStream:
+    """A dataset of `n_steps` single-row batches, so training takes `n_steps` steps."""
+    from datasets import Dataset
+
+    ds = Dataset.from_dict(
+        {
+            "input_ids": [[1 + 5 * i + j for j in range(5)] for i in range(n_steps)],
+            "labels": [[1 + 5 * i + j for j in range(5)] for i in range(n_steps)],
+            "attention_mask": [[1] * 5] * n_steps,
+        }
+    )
+    return DataStream(ds, batch_size=1, device=device)
+
+
+def _fresh_trainer(seed: int = 42):
+    """Build a fresh model/trainer/state, as a new process would."""
+    torch.manual_seed(seed)
+    config = AutoConfig.from_pretrained(TINY_MODEL)
+    model = AutoModelForCausalLM.from_config(
+        config, torch_dtype=torch.float32, attn_implementation="eager"
+    )
+    model.loss_function = weighted_causal_lm_ce
+    model.requires_grad_(True)
+
+    optimizer = torchopt.adamw(1e-4, betas=(0.95, 0.975), eps_root=1e-2)
+    trainer, fwd_state = Trainer.initialize(model, optimizer)
+    return trainer, fwd_state, model
+
+
+def _magic_scores(trainer, model, fwd_state, stream, ckpt_dir) -> torch.Tensor:
+    """Query gradients on batch 0, then MAGIC backward through the trajectory."""
+    with fwd_state.activate(model) as params:
+        batch = stream[0]
+        del batch["example_weight"]
+        loss = model(**batch).loss
+        query_grads = {
+            k: g.detach().clone() for k, g in grad_tree(loss, params).items()
+        }
+        opt_grads = [
+            torch.zeros_like(buf)
+            for buf in tree_iter(fwd_state.opt_state)
+            if isinstance(buf, torch.Tensor) and buf.is_floating_point()
+        ]
+        bwd_state = BackwardState(
+            query_grads, opt_grads, torch.zeros_like(stream.weights)
+        )
+
+    stream.requires_grad = True
+    bwd_state = trainer.backward(
+        ckpt_dir,
+        stream,
+        bwd_state,
+        fwd_state,
+        inplace=True,
+        cleanup=True,
+    )
+    return bwd_state.weight_grads.detach().cpu()
+
+
+def _saved_steps(ckpt_dir: str) -> list[int]:
+    from bergson.data import sorted_checkpoints
+
+    return [idx for idx, _ in sorted_checkpoints(ckpt_dir)]
+
+
+def test_trainer_state_in_memory_checkpoint_roundtrip():
+    """`state.to(...)` then `copy_` must round-trip the *whole* state.
+
+    This is the in-RAM checkpoint path in `Trainer.backward`. Two ways it used
+    to lose information: `copy_` ignored `opt_state` entirely, and `to("cpu")`
+    was a no-op for a state already on the CPU, so the snapshot aliased the live
+    tensors and was clobbered by the next in-place step.
+    """
+    trainer, state, _ = _fresh_trainer()
+    stream = _multi_step_stream(2)
+
+    snapshot = state.to("cpu").detach_()
+    before = [t.clone() for t in tree_iter(snapshot.opt_state)]
+
+    # Two in-place steps: the snapshot must survive them untouched...
+    for _ in range(2):
+        state = trainer.step(state, stream[state.batch_index], inplace=True)
+
+    for saved, now in zip(before, tree_iter(snapshot.opt_state)):
+        assert torch.equal(saved, now), "in-memory checkpoint aliased the live state"
+
+    moved = [t for t in tree_iter(state.opt_state)]
+    assert any(
+        not torch.equal(a, b) for a, b in zip(before, moved)
+    ), "optimizer state didn't change; test is degenerate"
+
+    # ...and copying it back must restore the optimizer state, not just params.
+    state.detach_()
+    state.copy_(snapshot)
+    for saved, now in zip(before, tree_iter(state.opt_state)):
+        assert torch.equal(saved, now), "copy_ dropped part of the optimizer state"
+
+
+@pytest.mark.parametrize("save_mode", ["sqrt", "log"])
+def test_magic_backward_matches_across_save_modes(save_mode, monkeypatch):
+    """Sparse checkpointing must not change MAGIC scores.
+
+    With save_mode != "all" the backward pass rematerializes intermediate states
+    and stashes them in RAM as `TrainerState`s, restoring them via
+    `TrainerState.copy_`. `copy_` used to copy the parameters but *not* the
+    optimizer state, so every traced step at or below the first in-RAM checkpoint
+    was differentiated against Adam moments belonging to a *later* step.
+    Regression guard: scores must be identical to the dense ("all") schedule.
+    """
+    import types
+
+    from bergson.magic import trainer as trainer_mod
+
+    n = 9
+
+    # Force the in-RAM checkpoint branch so the test doesn't depend on how much
+    # memory psutil happens to report on the machine running it.
+    monkeypatch.setattr(
+        trainer_mod.psutil,
+        "virtual_memory",
+        lambda: types.SimpleNamespace(available=1 << 60),
+    )
+
+    # Spy on copy_ to assert the in-RAM checkpoint path was actually taken.
+    copy_calls = []
+    orig_copy = trainer_mod.TrainerState.copy_
+
+    def spy_copy(self, other):
+        copy_calls.append(other.batch_index)
+        return orig_copy(self, other)
+
+    monkeypatch.setattr(trainer_mod.TrainerState, "copy_", spy_copy)
+
+    scores = {}
+    for mode in ("all", save_mode):
+        trainer, fwd_state, model = _fresh_trainer()
+        stream = _multi_step_stream(n)
+        assert len(stream) == n
+
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            fwd_state = trainer.train(
+                fwd_state, stream, inplace=True, save_dir=ckpt_dir, save_mode=mode
+            )
+            scores[mode] = _magic_scores(trainer, model, fwd_state, stream, ckpt_dir)
+
+    assert copy_calls, "no in-RAM checkpoints were used; test is degenerate"
+    assert scores["all"].abs().sum() > 0, "scores are all zero; test is degenerate"
+
+    torch.testing.assert_close(scores[save_mode], scores["all"], atol=1e-12, rtol=1e-6)
+
+
+@pytest.mark.parametrize("save_mode", ["all", "sqrt", "log"])
+def test_magic_resume_preserves_checkpoint_schedule(save_mode):
+    """A resumed forward run must keep saving checkpoints on schedule.
+
+    `next_save` was initialized to 0 before the resume branch set `start =
+    state.batch_index`, so with `start > 0` the `i == next_save` condition never
+    fired again and a resumed run saved nothing. Final parameters still matched a
+    fresh run exactly, so the damage only showed up in the backward pass, which
+    started from the last surviving checkpoint and emitted zero scores for every
+    step past it.
+    """
+    n = 9
+    crash_at = 5
+
+    # Reference: an uninterrupted run.
+    trainer, fwd_state, model = _fresh_trainer()
+    stream = _multi_step_stream(n)
+    with tempfile.TemporaryDirectory() as ckpt_dir:
+        fwd_state = trainer.train(
+            fwd_state, stream, inplace=True, save_dir=ckpt_dir, save_mode=save_mode
+        )
+        fresh_steps = _saved_steps(ckpt_dir)
+        fresh_params = {k: v.detach().clone() for k, v in fwd_state.params.items()}
+        fresh_scores = _magic_scores(trainer, model, fwd_state, stream, ckpt_dir)
+
+    with tempfile.TemporaryDirectory() as ckpt_dir:
+        # Interrupted run: blow up partway through training.
+        def boom(i, loss):
+            if i == crash_at:
+                raise RuntimeError("simulated crash")
+
+        trainer, fwd_state, model = _fresh_trainer()
+        stream = _multi_step_stream(n)
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            trainer.train(
+                fwd_state,
+                stream,
+                inplace=True,
+                save_dir=ckpt_dir,
+                save_mode=save_mode,
+                log_fn=boom,
+            )
+
+        # Resume in a fresh process-like context.
+        trainer, fwd_state, model = _fresh_trainer()
+        stream = _multi_step_stream(n)
+        fwd_state = trainer.train(
+            fwd_state,
+            stream,
+            inplace=True,
+            save_dir=ckpt_dir,
+            save_mode=save_mode,
+            resume=True,
+        )
+        resumed_steps = _saved_steps(ckpt_dir)
+        # Capture before the backward pass, which walks `fwd_state` back down
+        # the trajectory in place.
+        resumed_params = {k: v.detach().clone() for k, v in fwd_state.params.items()}
+        resumed_scores = _magic_scores(trainer, model, fwd_state, stream, ckpt_dir)
+
+    assert resumed_steps == fresh_steps, (
+        f"resumed run saved checkpoints {resumed_steps}, "
+        f"uninterrupted run saved {fresh_steps}"
+    )
+    for k, v in fresh_params.items():
+        torch.testing.assert_close(resumed_params[k], v)
+
+    assert fresh_scores.abs().sum() > 0, "scores are all zero; test is degenerate"
+    torch.testing.assert_close(resumed_scores, fresh_scores, atol=1e-12, rtol=1e-6)
+
+
 def test_magic_resume(dataset):
     """Resume from a checkpoint mid-training and verify identical final state."""
     device = "cpu"


### PR DESCRIPTION
cc @davidoj 

1. Optimizer state wasn't copied when restoring a checkpoint, so replayed steps used Adam moments from the wrong step.
  2. Checkpoints stashed in RAM aliased the live tensors instead of copying them, so the next training step overwrote them.

Together these made scores wrong by up to ~8% on the default save_mode="sqrt", and only when checkpoints went to RAM rather than disk, so the answer depended on how much free memory the machine had. Probably didn't catch this on our runs cause our machines have a quite amazing amount of RAM
