### PR TITLE
Feat: shuffle each training epoch independently

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import torch
 import torch.distributed as dist
-from datasets import Dataset
+from datasets import Dataset, concatenate_datasets
 from scipy.stats import describe
 from simple_parsing import ArgumentParser
 from torch.distributed._functional_collectives import (
@@ -143,6 +143,18 @@ def attach_doc_ids_if_missing(dataset: Dataset) -> Dataset:
     )
 
 
+def shuffled_epochs(dataset: Dataset, seed: int, num_epochs: int) -> Dataset:
+    """Concatenate `num_epochs` independently shuffled copies of `dataset`.
+
+    Each epoch is seeded off `seed`, so the full sequence is reproducible:
+    MAGIC's backward pass replays these exact steps.
+    """
+    assert num_epochs >= 1, f"num_epochs must be >= 1, got {num_epochs}"
+    return concatenate_datasets(
+        [dataset.shuffle(seed=seed + epoch) for epoch in range(num_epochs)]
+    )
+
+
 def worker(
     global_rank: int,  # global
     rank: int,  # local
@@ -172,9 +184,6 @@ def worker(
             rank=global_rank,
             world_size=world_size,
         )
-
-    if run_cfg.num_epochs > 1:
-        train_dataset = train_dataset.repeat(run_cfg.num_epochs)
 
     # Ensure total effective batch size is divisible by world size
     assert run_cfg.batch_size % world_size == 0
@@ -418,8 +427,7 @@ def run_magic(run_cfg: TrainingConfig, *, score_path: str = ""):
     train_ds, train_n = setup_data_pipeline(run_cfg)
     train_ds = attach_doc_ids_if_missing(train_ds)
 
-    # Shuffle the train_ds with the seed.
-    train_ds = train_ds.shuffle(seed=run_cfg.seed)
+    train_ds = shuffled_epochs(train_ds, run_cfg.seed, max(1, run_cfg.num_epochs))
 
     if isinstance(run_cfg, ValidationConfig):
         query_ds, query_n = setup_data_pipeline(run_cfg, run_cfg.query)

--- a/tests/test_epoch_shuffle.py
+++ b/tests/test_epoch_shuffle.py
@@ -1,0 +1,49 @@
+"""Per-epoch shuffling of the MAGIC training stream."""
+
+from collections import Counter
+
+from datasets import Dataset
+
+from bergson.magic.cli import shuffled_epochs
+
+N = 12
+
+
+def _ds() -> Dataset:
+    return Dataset.from_dict({"doc_ids": list(range(N))})
+
+
+def _order(ds: Dataset) -> list[int]:
+    return list(ds["doc_ids"])
+
+
+def test_each_epoch_is_shuffled_independently():
+    out = _order(shuffled_epochs(_ds(), seed=0, num_epochs=3))
+
+    epochs = [out[i * N : (i + 1) * N] for i in range(3)]
+    assert len(out) == 3 * N
+    for epoch in epochs:
+        assert sorted(epoch) == list(range(N))
+    assert epochs[0] != epochs[1]
+    assert epochs[1] != epochs[2]
+
+
+def test_deterministic_for_a_given_seed():
+    a = _order(shuffled_epochs(_ds(), seed=7, num_epochs=3))
+    b = _order(shuffled_epochs(_ds(), seed=7, num_epochs=3))
+    assert a == b
+
+    c = _order(shuffled_epochs(_ds(), seed=8, num_epochs=3))
+    assert a != c
+
+
+def test_multiset_is_preserved():
+    """Every document appears exactly `num_epochs` times."""
+    out = _order(shuffled_epochs(_ds(), seed=1, num_epochs=4))
+    assert Counter(out) == Counter({i: 4 for i in range(N)})
+
+
+def test_single_epoch_still_shuffles():
+    out = _order(shuffled_epochs(_ds(), seed=3, num_epochs=1))
+    assert sorted(out) == list(range(N))
+    assert out != list(range(N))


### PR DESCRIPTION
run_magic shuffled the training set once and worker() then was repeating it num_epochs times, so every epoch saw an identical order. 

Shuffle each epoch separately, using run_cfg.seed so the full sequence stays reproducible. This is standard in trainers. We won't be able to exactly reproduce old MAGIC runs without disabling the multi shuffle but possibly LDS will increase.

cc @davidoj 