### PR TITLE
Fix: use _orient_weight_second_moment in HF callback

### DIFF
--- a/bergson/huggingface.py
+++ b/bergson/huggingface.py
@@ -41,6 +41,7 @@ class GradientCollectorCallback(TrainerCallback):
         dtype: np.dtype = np.dtype(np.float16),
         accumulate_grads: bool = False,
         use_optimizer_state: bool = True,
+        scale_by_lr: bool = True,
         track_order: bool = False,
     ):
         """
@@ -55,6 +56,11 @@ class GradientCollectorCallback(TrainerCallback):
             use_optimizer_state: Whether to use the optimizer state to
                 normalize the gradients. If `False`, no normalization is
                 applied.
+            scale_by_lr: Scale the normalizer so the stored gradient is the
+                update the optimizer applied, ``lr * g / sqrt(v)``. Each example
+                is captured at the step it was trained on, so this weights it by
+                that step's learning rate. Set False for ``g / sqrt(v)``, which
+                matches ``load_from_optimizer``.
             track_order: Whether to record the shuffled order of training data.
         attention_cfgs: Information used to split matrix-valued parameters into
             per-head matrices before down projection.
@@ -72,6 +78,7 @@ class GradientCollectorCallback(TrainerCallback):
         self.projection_dim = projection_dim
         self.include_bias = include_bias
         self.use_optimizer_state = use_optimizer_state
+        self.scale_by_lr = scale_by_lr
         self.order: list[dict] | None = [] if track_order else None
 
         self.mod_grads = {}
@@ -264,6 +271,8 @@ class GradientCollectorCallback(TrainerCallback):
         layer_second_moments: dict[str, dict[str, Tensor]] = {}
 
         for group in optimizer.param_groups:
+            group_lr = group["lr"]
+
             for param in group["params"]:
                 # The optimizer owns the full model's parameters; anything
                 # outside base_model (e.g. lm_head) is never a target module.
@@ -288,7 +297,7 @@ class GradientCollectorCallback(TrainerCallback):
 
                 # Initialize layer dict if needed, storing this group's learning rate
                 if layer_name not in layer_second_moments:
-                    layer_second_moments[layer_name] = {}
+                    layer_second_moments[layer_name] = {"lr": group_lr}
 
                 # Check for Adafactor FIRST (more specific than Adam)
                 # Adafactor-like optimizer: weights have factorized moments
@@ -309,12 +318,18 @@ class GradientCollectorCallback(TrainerCallback):
 
         # Build normalizers from collected second moments
         for layer_name, moments in layer_second_moments.items():
+            # Dividing the second moment by lr^2 makes normalize_weight compute
+            # lr * g / sqrt(v), the update the optimizer applied.
+            scale = moments["lr"] ** 2 if self.scale_by_lr else 1.0
+
             # Adam-like: has weight exp_avg_sq
             if "weight" in moments:
                 weight_eas = _orient_weight_second_moment(
                     moments["weight"], model, layer_name
                 )
+                weight_eas = weight_eas / scale
                 bias_eas = moments.get("bias")
+                bias_eas = bias_eas / scale if bias_eas is not None else None
 
                 norm = AdamNormalizer(weight_eas, bias_eas)
 
@@ -323,7 +338,9 @@ class GradientCollectorCallback(TrainerCallback):
                 row, col = _orient_factored_second_moment(
                     moments["row"], moments["col"], model, layer_name
                 )
+                row, col = row / scale, col / scale
                 bias_eas = moments.get("bias")
+                bias_eas = bias_eas / scale if bias_eas is not None else None
 
                 norm = AdafactorNormalizer(row, col, bias_eas)
             else:

--- a/bergson/huggingface.py
+++ b/bergson/huggingface.py
@@ -20,6 +20,10 @@ from bergson import AttentionConfig, GradientProcessor
 from bergson.collector.gradient_collectors import StreamingGradientCollector
 from bergson.data import column_offsets, create_index
 from bergson.gradients import AdafactorNormalizer, AdamNormalizer
+from bergson.utils.load_from_optimizer import (
+    _orient_factored_second_moment,
+    _orient_weight_second_moment,
+)
 from bergson.utils.peft import detect_peft_modules
 from bergson.utils.utils import convert_dtype_to_torch
 
@@ -260,10 +264,12 @@ class GradientCollectorCallback(TrainerCallback):
         layer_second_moments: dict[str, dict[str, Tensor]] = {}
 
         for group in optimizer.param_groups:
-            group_lr = group["lr"]
-
             for param in group["params"]:
-                param_name = param_to_name[param]
+                # The optimizer owns the full model's parameters; anything
+                # outside base_model (e.g. lm_head) is never a target module.
+                param_name = param_to_name.get(param)
+                if param_name is None:
+                    continue
 
                 # Extract layer name (remove .weight or .bias suffix)
                 if param_name.endswith(".weight"):
@@ -282,7 +288,7 @@ class GradientCollectorCallback(TrainerCallback):
 
                 # Initialize layer dict if needed, storing this group's learning rate
                 if layer_name not in layer_second_moments:
-                    layer_second_moments[layer_name] = {"lr": group_lr}
+                    layer_second_moments[layer_name] = {}
 
                 # Check for Adafactor FIRST (more specific than Adam)
                 # Adafactor-like optimizer: weights have factorized moments
@@ -301,33 +307,30 @@ class GradientCollectorCallback(TrainerCallback):
                 elif (eas := p_state.get("exp_avg_sq")) is not None:
                     layer_second_moments[layer_name][param_type] = eas
 
-                # Build normalizers from collected second moments
-                for layer_name, moments in layer_second_moments.items():
-                    lr = moments["lr"]
+        # Build normalizers from collected second moments
+        for layer_name, moments in layer_second_moments.items():
+            # Adam-like: has weight exp_avg_sq
+            if "weight" in moments:
+                weight_eas = _orient_weight_second_moment(
+                    moments["weight"], model, layer_name
+                )
+                bias_eas = moments.get("bias")
 
-                    lr_sq = lr**2
+                norm = AdamNormalizer(weight_eas, bias_eas)
 
-                    # Adam-like: has weight exp_avg_sq
-                    if "weight" in moments:
-                        weight_eas = moments["weight"] / lr_sq
-                        bias_eas = moments.get("bias")
-                        bias_eas = bias_eas / lr_sq if bias_eas is not None else None
+            # Adafactor-like: has row/col factorization
+            elif "row" in moments and "col" in moments:
+                row, col = _orient_factored_second_moment(
+                    moments["row"], moments["col"], model, layer_name
+                )
+                bias_eas = moments.get("bias")
 
-                        norm = AdamNormalizer(weight_eas, bias_eas)
+                norm = AdafactorNormalizer(row, col, bias_eas)
+            else:
+                # No weight moments found - skip this layer
+                continue
 
-                    # Adafactor-like: has row/col factorization
-                    elif "row" in moments and "col" in moments:
-                        row = moments["row"] / lr_sq
-                        col = moments["col"] / lr_sq
-                        bias_eas = moments.get("bias")
-                        bias_eas = bias_eas / lr_sq if bias_eas is not None else None
-
-                        norm = AdafactorNormalizer(row, col, bias_eas)
-                    else:
-                        # No weight moments found - skip this layer
-                        continue
-
-                    normalizers[layer_name] = norm
+            normalizers[layer_name] = norm
 
         proc.normalizers = normalizers
 

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -396,13 +396,17 @@ class TestGradientCollectorCallback:
 
             # Get raw state from optimizer
             weight_state = optimizer.state[layer.weight]
+            lr = optimizer.param_groups[0]["lr"]
+
+            lr_sq = lr**2
 
             if optimizer_name == "adam":
                 # Check normalizer type
                 assert isinstance(norm, AdamNormalizer)
 
-                # Ground truth: Adam stores the full exp_avg_sq
-                expected_avg_sq = weight_state["exp_avg_sq"]
+                # Ground truth: Adam stores full exp_avg_sq, scaled by 1/lr²
+                raw_exp_avg_sq = weight_state["exp_avg_sq"]
+                expected_avg_sq = raw_exp_avg_sq / lr_sq
 
                 torch.testing.assert_close(norm.weight_avg_sq, expected_avg_sq)
 
@@ -410,9 +414,12 @@ class TestGradientCollectorCallback:
                 # Check normalizer type
                 assert isinstance(norm, AdafactorNormalizer)
 
-                # Ground truth: Adafactor row/col
-                expected_row = weight_state["exp_avg_sq_row"]
-                expected_col = weight_state["exp_avg_sq_col"]
+                # Ground truth: Adafactor row/col, scaled by 1/lr²
+                raw_row = weight_state["exp_avg_sq_row"]
+                raw_col = weight_state["exp_avg_sq_col"]
+
+                expected_row = raw_row / lr_sq
+                expected_col = raw_col / lr_sq
 
                 torch.testing.assert_close(norm.row, expected_row)
                 torch.testing.assert_close(norm.col, expected_col)
@@ -420,7 +427,8 @@ class TestGradientCollectorCallback:
             # Verify bias handling
             if include_bias and layer.bias is not None:
                 bias_state = optimizer.state[layer.bias]  # type: ignore
-                expected_bias = bias_state["exp_avg_sq"]
+                raw_bias_exp_avg_sq = bias_state["exp_avg_sq"]
+                expected_bias = raw_bias_exp_avg_sq / lr_sq
 
                 assert (
                     norm.bias_avg_sq is not None
@@ -432,6 +440,7 @@ class TestGradientCollectorCallback:
                 ), f"Unexpected bias_avg_sq for {layer_name}"
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize(
     "model_name",
     ["trl-internal-testing/tiny-Phi3ForCausalLM", "sshleifer/tiny-gpt2"],
@@ -472,6 +481,7 @@ def test_callback_with_optimizer_state_trains(tmp_path: Path, model_name: str):
     assert callback.collector.processor.normalizers, "no normalizers were built"
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_callback_normalizers_match_offline_orientation(tmp_path: Path):
     """Live-callback normalizers use the same ``[out, in]`` orientation as
     ``load_from_optimizer``, which matters for HF ``Conv1D`` (stored
@@ -523,3 +533,52 @@ def test_callback_normalizers_match_offline_orientation(tmp_path: Path):
         checked += 1
 
     assert checked, "no Conv1D normalizers were produced"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_scale_by_lr_matches_adam_update(tmp_path: Path):
+    """``scale_by_lr`` makes the normalizer produce ``lr * g / sqrt(v)``."""
+    model = AutoModelForCausalLM.from_pretrained(
+        "sshleifer/tiny-gpt2", dtype=torch.float32
+    )
+    data = {"input_ids": [[1, 2, 3, 4, 5]] * 4}
+    data["labels"] = data["input_ids"]
+    dataset = Dataset.from_dict(data)
+
+    def run(scale_by_lr: bool):
+        torch.manual_seed(0)
+        m = AutoModelForCausalLM.from_pretrained(
+            "sshleifer/tiny-gpt2", dtype=torch.float32
+        )
+        args = TrainingArguments(
+            output_dir=str(tmp_path / f"out_{scale_by_lr}"),
+            num_train_epochs=1,
+            per_device_train_batch_size=2,
+            save_strategy="no",
+            logging_strategy="no",
+            remove_unused_columns=False,
+            report_to=[],
+            lr_scheduler_type="constant",
+        )
+        cb = GradientCollectorCallback(
+            path=tmp_path / f"grads_{scale_by_lr}", scale_by_lr=scale_by_lr
+        )
+        trainer = Trainer(model=m, args=args, train_dataset=dataset, callbacks=[cb])
+        trainer = prepare_for_gradient_collection(trainer)
+        trainer.train()
+        assert cb.collector is not None
+        lr = trainer.optimizer.param_groups[0]["lr"]
+        return cb.collector.processor.normalizers, lr
+
+    plain, _ = run(False)
+    scaled, lr = run(True)
+
+    assert plain and scaled
+    for name, norm in scaled.items():
+        assert isinstance(norm, AdamNormalizer)
+        # second moment divided by lr^2 -> normalize_weight multiplies by lr
+        torch.testing.assert_close(
+            norm.weight_avg_sq * lr**2,
+            assert_type(AdamNormalizer, plain[name]).weight_avg_sq,
+        )
+    del model

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -396,17 +396,13 @@ class TestGradientCollectorCallback:
 
             # Get raw state from optimizer
             weight_state = optimizer.state[layer.weight]
-            lr = optimizer.param_groups[0]["lr"]
-
-            lr_sq = lr**2
 
             if optimizer_name == "adam":
                 # Check normalizer type
                 assert isinstance(norm, AdamNormalizer)
 
-                # Ground truth: Adam stores full exp_avg_sq, scaled by 1/lr²
-                raw_exp_avg_sq = weight_state["exp_avg_sq"]
-                expected_avg_sq = raw_exp_avg_sq / lr_sq
+                # Ground truth: Adam stores the full exp_avg_sq
+                expected_avg_sq = weight_state["exp_avg_sq"]
 
                 torch.testing.assert_close(norm.weight_avg_sq, expected_avg_sq)
 
@@ -414,12 +410,9 @@ class TestGradientCollectorCallback:
                 # Check normalizer type
                 assert isinstance(norm, AdafactorNormalizer)
 
-                # Ground truth: Adafactor row/col, scaled by 1/lr²
-                raw_row = weight_state["exp_avg_sq_row"]
-                raw_col = weight_state["exp_avg_sq_col"]
-
-                expected_row = raw_row / lr_sq
-                expected_col = raw_col / lr_sq
+                # Ground truth: Adafactor row/col
+                expected_row = weight_state["exp_avg_sq_row"]
+                expected_col = weight_state["exp_avg_sq_col"]
 
                 torch.testing.assert_close(norm.row, expected_row)
                 torch.testing.assert_close(norm.col, expected_col)
@@ -427,8 +420,7 @@ class TestGradientCollectorCallback:
             # Verify bias handling
             if include_bias and layer.bias is not None:
                 bias_state = optimizer.state[layer.bias]  # type: ignore
-                raw_bias_exp_avg_sq = bias_state["exp_avg_sq"]
-                expected_bias = raw_bias_exp_avg_sq / lr_sq
+                expected_bias = bias_state["exp_avg_sq"]
 
                 assert (
                     norm.bias_avg_sq is not None
@@ -438,3 +430,96 @@ class TestGradientCollectorCallback:
                 assert (
                     norm.bias_avg_sq is None
                 ), f"Unexpected bias_avg_sq for {layer_name}"
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["trl-internal-testing/tiny-Phi3ForCausalLM", "sshleifer/tiny-gpt2"],
+)
+def test_callback_with_optimizer_state_trains(tmp_path: Path, model_name: str):
+    """``use_optimizer_state=True`` (the default) must work on a real CausalLM.
+
+    The optimizer owns every parameter, including ``lm_head.weight``, which
+    lives outside ``base_model`` for both tied and untied models.
+    """
+    model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.float32)
+    data = {"input_ids": [[1, 2, 3, 4, 5]] * 4}
+    data["labels"] = data["input_ids"]
+    dataset = Dataset.from_dict(data)
+
+    training_args = TrainingArguments(
+        output_dir=str(tmp_path / "output"),
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        save_strategy="no",
+        logging_strategy="no",
+        remove_unused_columns=False,
+        report_to=[],
+    )
+    callback = GradientCollectorCallback(path=tmp_path / "gradients")
+    assert callback.use_optimizer_state, "this test is about the default"
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        callbacks=[callback],
+    )
+    trainer = prepare_for_gradient_collection(trainer)
+    trainer.train()
+
+    assert callback.collector is not None
+    assert callback.collector.processor.normalizers, "no normalizers were built"
+
+
+def test_callback_normalizers_match_offline_orientation(tmp_path: Path):
+    """Live-callback normalizers use the same ``[out, in]`` orientation as
+    ``load_from_optimizer``, which matters for HF ``Conv1D`` (stored
+    ``[in, out]``)."""
+    from transformers.pytorch_utils import Conv1D
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "sshleifer/tiny-gpt2", dtype=torch.float32
+    )
+    data = {"input_ids": [[1, 2, 3, 4, 5]] * 4}
+    data["labels"] = data["input_ids"]
+    dataset = Dataset.from_dict(data)
+
+    training_args = TrainingArguments(
+        output_dir=str(tmp_path / "output"),
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        save_strategy="no",
+        logging_strategy="no",
+        remove_unused_columns=False,
+        report_to=[],
+    )
+    callback = GradientCollectorCallback(path=tmp_path / "gradients")
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        callbacks=[callback],
+    )
+    trainer = prepare_for_gradient_collection(trainer)
+    trainer.train()
+
+    assert callback.collector is not None
+    base = model.base_model
+    checked = 0
+    for name, norm in callback.collector.processor.normalizers.items():
+        module = base.get_submodule(name)
+        if not isinstance(module, Conv1D):
+            continue
+        out_f, in_f = module.nf, module.weight.shape[0]
+        assert isinstance(norm, AdamNormalizer)
+        assert norm.weight_avg_sq.shape == (out_f, in_f), (
+            f"{name}: normalizer is {tuple(norm.weight_avg_sq.shape)}, "
+            f"expected {(out_f, in_f)}"
+        )
+        # The normalizer must accept a gradient in the collector's layout.
+        dev = norm.weight_avg_sq.device
+        norm.normalize_weight(torch.randn(out_f, in_f, device=dev))
+        checked += 1
+
+    assert checked, "no Conv1D normalizers were produced"


### PR DESCRIPTION
Make `scale_by_lr` optional, use _orient_weight_second_moment helper