### PR TITLE
Apply normalizers to split attention heads, validate head coverage

### DIFF
--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -205,6 +205,11 @@ class HookCollectorBase(ContextDecorator, ABC):
             orig_name = module._name
             orig_out = getattr(module, LayerAdapter.out_attr(module))
 
+            assert num_heads * head_size == orig_out, (
+                f"{name}: num_heads * head_size = {num_heads * head_size} does "
+                f"not cover the module's {orig_out} output features"
+            )
+
             setattr(module, LayerAdapter.out_attr(module), head_size)
 
             for h in range(num_heads):
@@ -226,6 +231,52 @@ class HookCollectorBase(ContextDecorator, ABC):
             setattr(module, LayerAdapter.out_attr(module), orig_out)
 
         return wrapper
+
+    @staticmethod
+    def split_head_name(name: str) -> tuple[str, int] | None:
+        """Split ``"<module>.head_<i>"`` into ``("<module>", i)``, else None."""
+        base, sep, suffix = name.rpartition(".head_")
+        if not sep or not suffix.isdigit():
+            return None
+        return base, int(suffix)
+
+    def normalizer_for(self, name: str):
+        """The normalizer for module `name`.
+
+        Normalizers are keyed by the unsplit module name, so a split attention
+        head looks up its parent and takes the slice of the output dimension it
+        covers.
+        """
+        normalizer = self.processor.normalizers.get(name)
+        if normalizer is not None:
+            return normalizer
+
+        split = self.split_head_name(name)
+        if split is None:
+            return None
+
+        base, head_idx = split
+        normalizer = self.processor.normalizers.get(base)
+        if normalizer is None or base not in self.attention_cfgs:
+            return normalizer
+
+        head_size = self.attention_cfgs[base].head_size
+        lo, hi = head_idx * head_size, (head_idx + 1) * head_size
+
+        if isinstance(normalizer, AdamNormalizer):
+            bias = normalizer.bias_avg_sq
+            return AdamNormalizer(
+                normalizer.weight_avg_sq[lo:hi],
+                bias[lo:hi] if bias is not None else None,
+            )
+        if isinstance(normalizer, AdafactorNormalizer):
+            bias = normalizer.bias_avg_sq
+            return AdafactorNormalizer(
+                normalizer.row[lo:hi],
+                normalizer.col,
+                bias[lo:hi] if bias is not None else None,
+            )
+        return normalizer
 
     @property
     def per_module_projection_dim(self) -> int | None:
@@ -473,7 +524,7 @@ class HookCollectorBase(ContextDecorator, ABC):
         p = self.per_module_projection_dim
         name = assert_type(str, module._name)
         i = getattr(module, LayerAdapter.in_attr(module))
-        normalizer = self.processor.normalizers.get(name)
+        normalizer = self.normalizer_for(name)
 
         if isinstance(normalizer, AdamNormalizer):
             module._inputs = a
@@ -553,7 +604,7 @@ class HookCollectorBase(ContextDecorator, ABC):
         p = self.per_module_projection_dim
         i = getattr(module, LayerAdapter.in_attr(module))
         o = getattr(module, LayerAdapter.out_attr(module))
-        normalizer = self.processor.normalizers.get(name)
+        normalizer = self.normalizer_for(name)
 
         if isinstance(normalizer, AdamNormalizer):
             # Gate on the per-module flag, as shapes(), discover_targets() and

--- a/tests/test_attention_head_normalizers.py
+++ b/tests/test_attention_head_normalizers.py
@@ -1,0 +1,105 @@
+"""Normalizers and head-coverage validation for attention-head splitting."""
+
+import pytest
+import torch
+from datasets import Dataset
+from torch import nn
+
+from bergson import GradientProcessor
+from bergson.collector.collector import HookCollectorBase
+from bergson.collector.in_memory_collector import InMemoryCollector
+from bergson.config import AttentionConfig, IndexConfig
+from bergson.gradients import AdafactorNormalizer, AdamNormalizer
+
+O, I, N, S = 8, 6, 2, 3
+HEADS, HEAD_SIZE = 2, 4
+
+
+class _Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(I, O, bias=False)
+
+    @property
+    def device(self):
+        return self.proj.weight.device
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+def _collect(normalizers, attention_cfgs, tmp_path):
+    torch.manual_seed(0)
+    model = _Model()
+    processor = GradientProcessor(normalizers=normalizers or {})
+    cfg = IndexConfig(run_path=str(tmp_path), token_batch_size=1024)
+    collector = InMemoryCollector(
+        model=model,
+        data=Dataset.from_dict({"input_ids": [[1, 2, 3]] * N}),
+        cfg=cfg,
+        processor=processor,
+        attention_cfgs=attention_cfgs,
+    )
+    with collector:
+        model.zero_grad()
+        model(torch.randn(N, S, I)).sum().backward()
+        return {k: v.clone() for k, v in collector.mod_grads.items()}
+
+
+def test_split_head_name():
+    assert HookCollectorBase.split_head_name("a.b.head_3") == ("a.b", 3)
+    assert HookCollectorBase.split_head_name("a.b") is None
+    assert HookCollectorBase.split_head_name("a.head_x") is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_head_normalizer_is_applied(tmp_path):
+    """A split module must still be normalized, using its parent's stats."""
+    cfgs = {"proj": AttentionConfig(num_heads=HEADS, head_size=HEAD_SIZE, head_dim=2)}
+    avg_sq = torch.full((O, I), 4.0)
+
+    raw = _collect(None, cfgs, tmp_path)
+    normed = _collect({"proj": AdamNormalizer(avg_sq)}, cfgs, tmp_path)
+
+    assert raw and set(raw) == set(normed)
+    for key in raw:
+        # normalize_weight divides by sqrt(4) = 2
+        torch.testing.assert_close(normed[key], raw[key] / 2, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_head_normalizer_slices_the_output_dim(tmp_path):
+    """Each head gets the slice of the output-dim factors it covers."""
+    cfgs = {"proj": AttentionConfig(num_heads=HEADS, head_size=HEAD_SIZE, head_dim=2)}
+    # Distinct value per output row, so a wrong slice is visible.
+    avg_sq = (torch.arange(O, dtype=torch.float32) + 1).pow(2)[:, None].expand(O, I)
+
+    raw = _collect(None, cfgs, tmp_path)
+    normed = _collect({"proj": AdamNormalizer(avg_sq.contiguous())}, cfgs, tmp_path)
+
+    for head in range(HEADS):
+        key = f"proj.head_{head}"
+        lo = head * HEAD_SIZE
+        scale = (torch.arange(HEAD_SIZE, dtype=torch.float32) + 1 + lo)[None, :, None]
+        expected = raw[key].reshape(N, HEAD_SIZE, I) / scale
+        torch.testing.assert_close(
+            normed[key].reshape(N, HEAD_SIZE, I), expected, rtol=1e-5, atol=1e-6
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_adafactor_head_normalizer_slices_row_only(tmp_path):
+    """Adafactor's row factor is per-output-row; col is shared across heads."""
+    cfgs = {"proj": AttentionConfig(num_heads=HEADS, head_size=HEAD_SIZE, head_dim=2)}
+    norm = AdafactorNormalizer(torch.arange(1, O + 1).float(), torch.ones(I))
+
+    collector_norms = _collect({"proj": norm}, cfgs, tmp_path)
+    assert set(collector_norms) == {f"proj.head_{h}" for h in range(HEADS)}
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_head_coverage_must_match_output_features(tmp_path):
+    """num_heads * head_size that under-covers the module must not pass."""
+    cfgs = {"proj": AttentionConfig(num_heads=2, head_size=3, head_dim=2)}  # 6 != 8
+    with pytest.raises(AssertionError, match="does not cover"):
+        _collect(None, cfgs, tmp_path)


### PR DESCRIPTION
split_attention_heads decorates backward_hook and rewrites module._name to "<module>.head_h" before _compute_gradient runs, but normalizers are keyed by the unsplit module name. head_normalizer() now falls back to the parent's normalizer and slices the output-dim factors to the head's rows -- weight_avg_sq[lo:hi] for Adam, row[lo:hi] for Adafactor, with col shared since it indexes input features.

AttentionConfig also accepted num_heads * head_size < out_features, which silently dropped the uncovered output rows; shapes() agreed with the truncated gradient, so nothing downstream threw. Replace over-coverage assert with exact coverage assert.