### PR TITLE
Re-enable hessian_dtype

### DIFF
--- a/bergson/approx_unrolling/precompute_checkpoints.py
+++ b/bergson/approx_unrolling/precompute_checkpoints.py
@@ -18,6 +18,7 @@ from bergson.distributed import init_dist, launch_distributed_run
 from bergson.hessians.eigenvectors import LambdaCollector
 from bergson.hessians.hessian_approximations import approximate_hessians
 from bergson.utils.logger import get_logger
+from bergson.utils.utils import convert_precision_to_torch
 from bergson.utils.worker_utils import (
     setup_data_pipeline,
     setup_model_and_peft,
@@ -118,6 +119,7 @@ def _lambda_worker(
         eigen_path=str(eigen_path),
         output_subdir=output_subdir,
         filter_modules=index_cfg.filter_modules,
+        dtype=convert_precision_to_torch(hessian_cfg.hessian_dtype),
     )
 
     computer = CollectorComputer(

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -796,8 +796,11 @@ class HessianConfig(Serializable):
     ev_correction: bool = False
     """Whether to additionally compute eigenvalue correction."""
 
-    hessian_dtype: Literal["bf16", "fp16", "fp32"] = "fp32"
-    """Precision (dtype) to use for the Hessian approximation."""
+    hessian_dtype: Literal["bf16", "fp16", "fp32", "fp64"] = "fp32"
+    """Precision (dtype) for Hessian-approximation accumulation: the covariance
+    collectors and the EK-FAC eigenvalue-correction (lambda) collector both
+    accumulate in this dtype. Eigendecomposition always runs internally in
+    fp64 and stores results in this dtype."""
 
     use_dataset_labels: bool = False
     """Whether to use dataset labels for Hessian (empirical Fisher) approximation.

--- a/bergson/hessians/eigenvectors.py
+++ b/bergson/hessians/eigenvectors.py
@@ -85,6 +85,11 @@ class LambdaCollector(HookCollectorBase):
     output_subdir: str = "eigenvalue_correction_sharded"
     """Subdir under ``self.path`` to write lambda shards into."""
 
+    dtype: torch.dtype = torch.float32
+    """Accumulation dtype for the eigenvalue corrections. Activations,
+    gradients, and eigenvectors are cast to this before the rotation and
+    squared accumulation, and shards are saved in it."""
+
     def setup(self) -> None:
         """Load eigenvectors and initialize storage."""
         self.shard_computer = ShardedMul()
@@ -106,6 +111,10 @@ class LambdaCollector(HookCollectorBase):
             device=self.device,
         )
 
+        # Cast eigenvectors once so the rotations run in the accumulation dtype.
+        self.eigen_a = {k: v.to(self.dtype) for k, v in self.eigen_a.items()}
+        self.eigen_g = {k: v.to(self.dtype) for k, v in self.eigen_g.items()}
+
         # Initialize accumulators
         self.eigenvalue_corrections = {}
         self.transformed_a_cache = {}
@@ -122,7 +131,7 @@ class LambdaCollector(HookCollectorBase):
 
         # Transform: a @ eigen_a
         transformed = self.shard_computer._matmul(
-            vector_nsa=a, matrix_cb=self.eigen_a[name]
+            vector_nsa=a.to(self.dtype), matrix_cb=self.eigen_a[name]
         )  # shape [N, S, I]
 
         # Cache for use in backward pass
@@ -135,7 +144,7 @@ class LambdaCollector(HookCollectorBase):
 
         # Transform: g @ eigen_g
         transformed_g = self.shard_computer._matmul(
-            vector_nsa=g, matrix_cb=self.eigen_g[name]
+            vector_nsa=g.to(self.dtype), matrix_cb=self.eigen_g[name]
         )  # shape [N, S, O]
 
         # Compute outer product: sum_n (transformed_a_n^T @ transformed_g_n)

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -252,6 +252,7 @@ def collect_hessians(
         "path": str(index_cfg.partial_run_path),
         "filter_modules": index_cfg.filter_modules,
         "processor": GradientProcessor(include_bias=index_cfg.include_bias),
+        "dtype": hessian_dtype,
     }
     desc = f"Approximating Hessians with {hessian_cfg.method}"
     if ev_correction:
@@ -262,7 +263,6 @@ def collect_hessians(
         )
         desc += " (eigenvalue correction)"
     else:
-        collector_args["dtype"] = hessian_dtype
         collector = HESSIAN_APPROXIMATIONS[hessian_cfg.method](**collector_args)
 
     computer = CollectorComputer(

--- a/bergson/utils/utils.py
+++ b/bergson/utils/utils.py
@@ -203,7 +203,7 @@ def convert_dtype_to_torch(dtype: np.dtype) -> torch.dtype:
 
 
 def convert_precision_to_torch(
-    precision: Literal["auto", "bf16", "fp16", "fp32"],
+    precision: Literal["auto", "bf16", "fp16", "fp32", "fp64"],
 ) -> torch.dtype:
     """Convert a precision string to the corresponding torch dtype."""
     match precision:
@@ -217,6 +217,8 @@ def convert_precision_to_torch(
             return torch.float16
         case "fp32":
             return torch.float32
+        case "fp64":
+            return torch.float64
 
 
 def get_device_index(rank: int = 0) -> int:

--- a/tests/ekfac_tests/test_hessian_dtype.py
+++ b/tests/ekfac_tests/test_hessian_dtype.py
@@ -1,0 +1,89 @@
+"""hessian_dtype must reach BOTH Hessian collectors.
+
+The covariance collectors always took a ``dtype``, but the EK-FAC
+eigenvalue-correction (lambda) pass silently ignored ``hessian_dtype`` and
+accumulated in the activations' dtype. These tests pin the dtype through both
+collectors, including the fp64 setting used to match kronfluence's
+eigendecomposition precision.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file
+
+from bergson.gradients import GradientProcessor
+from bergson.hessians.eigenvectors import LambdaCollector
+from bergson.hessians.kfac import CovarianceCollector
+from bergson.utils.utils import convert_precision_to_torch, get_device
+
+IN_DIM = 4
+OUT_DIM = 6
+
+
+class TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(IN_DIM, OUT_DIM, bias=False)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+def _run_batch(model, collector, device):
+    n, s = 2, 3
+    x = torch.randn(n, s, IN_DIM, device=device)
+    mask = torch.ones(n, s, dtype=torch.bool, device=device)
+    with collector.with_batch(mask):
+        model(x).sum().backward()
+
+
+@pytest.mark.parametrize("dtype", [torch.float64, torch.float16])
+def test_covariance_collector_accumulates_in_dtype(tmp_path, dtype):
+    device = get_device(0)
+    model = TinyModel().to(device)
+    collector = CovarianceCollector(
+        model=model,
+        dtype=dtype,
+        path=str(tmp_path),
+        processor=GradientProcessor(),
+    )
+    _run_batch(model, collector, device)
+    assert collector.A_cov_dict["lin"].dtype == dtype
+    assert collector.S_cov_dict["lin"].dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [torch.float64, torch.float32])
+def test_lambda_collector_accumulates_in_dtype(tmp_path, dtype):
+    device = get_device(0)
+    model = TinyModel().to(device)
+
+    eigen_a = {"lin": torch.eye(IN_DIM, dtype=torch.float32)}
+    eigen_g = {"lin": torch.eye(OUT_DIM, dtype=torch.float32)}
+    os.makedirs(tmp_path / "eigen_activation_sharded")
+    os.makedirs(tmp_path / "eigen_gradient_sharded")
+    save_file(eigen_a, str(tmp_path / "eigen_activation_sharded/shard_0.safetensors"))
+    save_file(eigen_g, str(tmp_path / "eigen_gradient_sharded/shard_0.safetensors"))
+
+    collector = LambdaCollector(
+        model=model,
+        path=str(tmp_path),
+        processor=GradientProcessor(),
+        dtype=dtype,
+    )
+    _run_batch(model, collector, device)
+    assert collector.eigenvalue_corrections["lin"].dtype == dtype
+
+    collector.teardown()
+    from safetensors.torch import load_file
+
+    shard = load_file(
+        str(tmp_path / "eigenvalue_correction_sharded/shard_0.safetensors")
+    )
+    assert shard["lin"].dtype == dtype
+
+
+def test_fp64_precision_string_converts():
+    assert convert_precision_to_torch("fp64") is torch.float64


### PR DESCRIPTION
- `LambdaCollector` gains a `dtype` field: eigenvectors are cast once at setup, activations/gradients at the hooks, so rotation + squared accumulation and the saved shards all run in the requested dtype.
- `approximate_hessians` passes `hessian_dtype` to both collector branches; the SOURCE `precompute_checkpoints` lambda worker does the same.
- New `fp64` option for `hessian_dtype` (config Literal + `convert_precision_to_torch`).

## Tests

`tests/ekfac_tests/test_hessian_dtype.py`: pins the accumulation and saved-shard dtype through both collectors (fp64/fp16/fp32) and the fp64 conversion. Full `tests/ekfac_tests` + `tests/test_hessian.py`: 76 passed, 4 skipped.