### PR TITLE
Restore CUDA RNG state in trainer step()/activate()

### DIFF
--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -394,7 +394,6 @@ class Trainer:
                 disables clipping.
         """
         torch.random.set_rng_state(state.cpu_rng_state)
-        # Also restore CUDA RNG so dropout replays identically in the backward.
         _maybe_set_cuda_rng_state(state.cuda_rng_state)
 
         # Trainable params live on the meta device and are swapped in from state.

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -77,13 +77,7 @@ def _maybe_get_cuda_rng_state() -> torch.Tensor:
 
 
 def _maybe_set_cuda_rng_state(rng_state: torch.Tensor) -> None:
-    """Restore a CUDA RNG state captured by :func:`_maybe_get_cuda_rng_state`.
-
-    No-op when CUDA is uninitialized: there is no device stream to restore
-    onto, and the captured value is the zeros placeholder rather than a real
-    state. On a GPU run every ``TrainerState`` is built after the model is on
-    the device, so ``cuda_rng_state`` is always a real capture here.
-    """
+    """Restore a CUDA RNG state, or no-op when CUDA is uninitialized."""
     if torch.cuda.is_initialized():
         torch.cuda.set_rng_state(rng_state)
 
@@ -400,9 +394,7 @@ class Trainer:
                 disables clipping.
         """
         torch.random.set_rng_state(state.cpu_rng_state)
-        # Restore CUDA RNG too, so CUDA-side randomness (e.g. dropout) is
-        # reproduced when this step is replayed during the metagradient
-        # backward-through-training. No-op at dropout=0 (no CUDA randomness).
+        # Also restore CUDA RNG so dropout replays identically in the backward.
         _maybe_set_cuda_rng_state(state.cuda_rng_state)
 
         # Trainable params live on the meta device and are swapped in from state.

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -67,21 +67,6 @@ class _ReplicatedAllReduceSum(torch.autograd.Function):
         return _ReplicatedAllReduceSum.apply(grad_output, ctx.group), None
 
 
-def _maybe_get_cuda_rng_state() -> torch.Tensor:
-    """ "Get the CUDA RNG state if CUDA is initialized, otherwise return zeros."""
-    if torch.cuda.is_initialized():
-        return torch.cuda.random.get_rng_state()
-
-    # This corresponds to a manual seed of 0
-    return torch.zeros(16, dtype=torch.uint8)
-
-
-def _maybe_set_cuda_rng_state(rng_state: torch.Tensor) -> None:
-    """Restore a CUDA RNG state, or no-op when CUDA is uninitialized."""
-    if torch.cuda.is_initialized():
-        torch.cuda.set_rng_state(rng_state)
-
-
 @dataclass
 class SaveFuture:
     """Wraps a DCP async_save future, destroying the gloo process group in result().
@@ -160,7 +145,7 @@ class TrainerState:
     # Non-differentiable state
     buffers: dict[str, torch.Tensor]
     batch_index: int = 0
-    cuda_rng_state: torch.Tensor = field(default_factory=_maybe_get_cuda_rng_state)
+    cuda_rng_state: torch.Tensor = field(default_factory=torch.cuda.get_rng_state)
     cpu_rng_state: torch.Tensor = field(default_factory=torch.random.get_rng_state)
 
     def copy_(self, other: "TrainerState"):
@@ -281,16 +266,16 @@ class TrainerState:
     @contextmanager
     def activate(self, model: nn.Module):
         cpu_state = torch.random.get_rng_state()
-        cuda_state = _maybe_get_cuda_rng_state()
+        cuda_state = torch.cuda.get_rng_state()
         torch.random.set_rng_state(self.cpu_rng_state)
-        _maybe_set_cuda_rng_state(self.cuda_rng_state)
+        torch.cuda.set_rng_state(self.cuda_rng_state)
 
         try:
             with swap_parameters(model, self.params, self.buffers, strict=True) as p:
                 yield p
         finally:
             torch.random.set_rng_state(cpu_state)
-            _maybe_set_cuda_rng_state(cuda_state)
+            torch.cuda.set_rng_state(cuda_state)
 
     def state_dict(self) -> dict:
         # Convert to dict manually because dataclasses.asdict does a deep copy
@@ -395,7 +380,7 @@ class Trainer:
         """
         torch.random.set_rng_state(state.cpu_rng_state)
         # Also restore CUDA RNG so dropout replays identically in the backward.
-        _maybe_set_cuda_rng_state(state.cuda_rng_state)
+        torch.cuda.set_rng_state(state.cuda_rng_state)
 
         # Trainable params live on the meta device and are swapped in from state.
         # Frozen params remain on-device in the model and are left untouched.

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -76,6 +76,18 @@ def _maybe_get_cuda_rng_state() -> torch.Tensor:
     return torch.zeros(16, dtype=torch.uint8)
 
 
+def _maybe_set_cuda_rng_state(rng_state: torch.Tensor) -> None:
+    """Restore a CUDA RNG state captured by :func:`_maybe_get_cuda_rng_state`.
+
+    No-op when CUDA is uninitialized: there is no device stream to restore
+    onto, and the captured value is the zeros placeholder rather than a real
+    state. On a GPU run every ``TrainerState`` is built after the model is on
+    the device, so ``cuda_rng_state`` is always a real capture here.
+    """
+    if torch.cuda.is_initialized():
+        torch.cuda.set_rng_state(rng_state)
+
+
 @dataclass
 class SaveFuture:
     """Wraps a DCP async_save future, destroying the gloo process group in result().
@@ -275,12 +287,16 @@ class TrainerState:
     @contextmanager
     def activate(self, model: nn.Module):
         cpu_state = torch.random.get_rng_state()
+        cuda_state = _maybe_get_cuda_rng_state()
         torch.random.set_rng_state(self.cpu_rng_state)
+        _maybe_set_cuda_rng_state(self.cuda_rng_state)
 
-        with swap_parameters(model, self.params, self.buffers, strict=True) as p:
-            yield p
-
-        torch.random.set_rng_state(cpu_state)
+        try:
+            with swap_parameters(model, self.params, self.buffers, strict=True) as p:
+                yield p
+        finally:
+            torch.random.set_rng_state(cpu_state)
+            _maybe_set_cuda_rng_state(cuda_state)
 
     def state_dict(self) -> dict:
         # Convert to dict manually because dataclasses.asdict does a deep copy
@@ -384,6 +400,10 @@ class Trainer:
                 disables clipping.
         """
         torch.random.set_rng_state(state.cpu_rng_state)
+        # Restore CUDA RNG too, so CUDA-side randomness (e.g. dropout) is
+        # reproduced when this step is replayed during the metagradient
+        # backward-through-training. No-op at dropout=0 (no CUDA randomness).
+        _maybe_set_cuda_rng_state(state.cuda_rng_state)
 
         # Trainable params live on the meta device and are swapped in from state.
         # Frozen params remain on-device in the model and are left untouched.

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -67,6 +67,21 @@ class _ReplicatedAllReduceSum(torch.autograd.Function):
         return _ReplicatedAllReduceSum.apply(grad_output, ctx.group), None
 
 
+def _maybe_get_cuda_rng_state() -> torch.Tensor:
+    """Get the CUDA RNG state, or a zeros placeholder when CUDA is uninitialized."""
+    if torch.cuda.is_initialized():
+        return torch.cuda.random.get_rng_state()
+
+    # This corresponds to a manual seed of 0
+    return torch.zeros(16, dtype=torch.uint8)
+
+
+def _maybe_set_cuda_rng_state(rng_state: torch.Tensor) -> None:
+    """Restore a CUDA RNG state, or no-op when CUDA is uninitialized."""
+    if torch.cuda.is_initialized():
+        torch.cuda.set_rng_state(rng_state)
+
+
 @dataclass
 class SaveFuture:
     """Wraps a DCP async_save future, destroying the gloo process group in result().
@@ -145,7 +160,7 @@ class TrainerState:
     # Non-differentiable state
     buffers: dict[str, torch.Tensor]
     batch_index: int = 0
-    cuda_rng_state: torch.Tensor = field(default_factory=torch.cuda.get_rng_state)
+    cuda_rng_state: torch.Tensor = field(default_factory=_maybe_get_cuda_rng_state)
     cpu_rng_state: torch.Tensor = field(default_factory=torch.random.get_rng_state)
 
     def copy_(self, other: "TrainerState"):
@@ -266,16 +281,16 @@ class TrainerState:
     @contextmanager
     def activate(self, model: nn.Module):
         cpu_state = torch.random.get_rng_state()
-        cuda_state = torch.cuda.get_rng_state()
+        cuda_state = _maybe_get_cuda_rng_state()
         torch.random.set_rng_state(self.cpu_rng_state)
-        torch.cuda.set_rng_state(self.cuda_rng_state)
+        _maybe_set_cuda_rng_state(self.cuda_rng_state)
 
         try:
             with swap_parameters(model, self.params, self.buffers, strict=True) as p:
                 yield p
         finally:
             torch.random.set_rng_state(cpu_state)
-            torch.cuda.set_rng_state(cuda_state)
+            _maybe_set_cuda_rng_state(cuda_state)
 
     def state_dict(self) -> dict:
         # Convert to dict manually because dataclasses.asdict does a deep copy
@@ -380,7 +395,7 @@ class Trainer:
         """
         torch.random.set_rng_state(state.cpu_rng_state)
         # Also restore CUDA RNG so dropout replays identically in the backward.
-        torch.cuda.set_rng_state(state.cuda_rng_state)
+        _maybe_set_cuda_rng_state(state.cuda_rng_state)
 
         # Trainable params live on the meta device and are swapped in from state.
         # Frozen params remain on-device in the model and are left untouched.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -905,3 +905,42 @@ def test_magic_resume(dataset):
 
         for k in final_state.params:
             torch.testing.assert_close(resumed_state.params[k], final_state.params[k])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_step_reproduces_cuda_dropout_masks():
+    """``step()`` restores the CUDA RNG, so a stochastic forward (dropout)
+    replays identically. This is what makes MAGIC's backward-through-training
+    correct when the model has CUDA-side randomness. Without the CUDA restore,
+    the second replay draws fresh dropout masks and diverges.
+    """
+    device = "cuda"
+    torch.manual_seed(0)
+    config = AutoConfig.from_pretrained("EleutherAI/pythia-14m")
+    # Force dropout so the forward actually consumes CUDA randomness.
+    config.hidden_dropout = 0.5
+    model = AutoModelForCausalLM.from_config(
+        config, torch_dtype=torch.float32, attn_implementation="eager"
+    ).to(device)
+    model.requires_grad_(True)
+    model.train()  # dropout active
+
+    optimizer = torchopt.adamw(1e-4, betas=(0.95, 0.975), eps_root=1e-2)
+    trainer, state = Trainer.initialize(model, optimizer)
+
+    ids = torch.randint(0, config.vocab_size, (2, 8), device=device)
+    inputs = {
+        "input_ids": ids,
+        "labels": ids.clone(),
+        "attention_mask": torch.ones_like(ids),
+    }
+
+    # Two independent replays from the SAME state must match.
+    s1 = trainer.step(state, inputs, inplace=False)
+    loss1 = trainer._last_loss
+    s2 = trainer.step(state, inputs, inplace=False)
+    loss2 = trainer._last_loss
+
+    assert loss1 == loss2, (loss1, loss2)
+    for k in s1.params:
+        torch.testing.assert_close(s1.params[k], s2.params[k])


### PR DESCRIPTION
## Problem

`TrainerState` captures and serializes both `cpu_rng_state` and `cuda_rng_state`, but `step()` and `activate()` only ever restored the **CPU** state (`torch.random.set_rng_state`) — there was no `torch.cuda.set_rng_state` anywhere. So any CUDA-side randomness in the forward (most importantly **dropout**) is not reproduced when a step is replayed during MAGIC's backward-through-training. The metagradient would be silently wrong for any model trained with dropout on GPU.

This is latent today only because the trainer trains in eval mode (dropout off) — see the companion dropout PR. This fix is a prerequisite for supporting dropout under MAGIC.

## Fix

Add `_maybe_set_cuda_rng_state`, the symmetric partner of the existing `_maybe_get_cuda_rng_state`, and call it wherever the CPU state is restored:
- `step()`: restore CUDA RNG alongside CPU before the forward.
- `activate()`: save/restore the outer CUDA state too, and wrap the body in try/finally so the outer RNG is restored even if the body raises.

The restore is guarded on `torch.cuda.is_initialized()`. On a GPU run every `TrainerState` is constructed after the model is on the device, so `cuda_rng_state` is always a real capture (never the zeros placeholder); on CPU-only runs it's a no-op.

## Why it's safe

At dropout=0 the forward consumes **no** CUDA randomness, so restoring the CUDA RNG has no effect on the computation — existing metagradients are byte-identical. Verified: full `tests/test_magic.py` passes (26 tests).

## Test

`test_step_reproduces_cuda_dropout_masks` (CUDA-gated): with dropout active, two `step()` replays from the same state must produce identical loss and params. Confirmed it **fails** without the `step()` restore and **passes** with it.