### PR TITLE
Add opt-in train_mode so the trainer can run with dropout

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -350,15 +350,11 @@ class TrainingConfig(AttributionConfig, Serializable):
     optimizer that can reduce memory usage and speed up training."""
 
     train_mode: bool = False
-    """Run the model in ``.train()`` mode during training so its configured
-    dropout (and any other train-mode layers) is active — the standard HF
-    training behavior. Default ``False`` keeps the model in ``.eval()``
-    (dropout disabled), which is required for the MAGIC metagradient and is
-    what bergson has always done. Set the dropout *rate* via ``model_kwargs``
-    (e.g. ``resid_pdrop=0.1``); this flag only controls the mode. Incompatible
-    with the MAGIC metagradient (the backward-through-training replay needs
-    dropout-free forwards) — use it for leave-k-out bank retrains or the base
-    model of an EK-FAC/SOURCE run, to match an external training recipe."""
+    """Train in ``.train()`` mode so the model's configured dropout is active,
+    as HF does; ``False`` keeps it in ``.eval()``. Sets the mode only — the
+    dropout *rate* comes from ``model_kwargs`` (e.g. ``resid_pdrop=0.1``).
+    MAGIC's backward replays each step from that step's saved RNG state, so
+    dropout masks are reproduced and the metagradient stays exact."""
 
     save_optimizer_state: bool = False
     """After training, export the optimizer's second moments to

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -350,11 +350,7 @@ class TrainingConfig(AttributionConfig, Serializable):
     optimizer that can reduce memory usage and speed up training."""
 
     train_mode: bool = False
-    """Train in ``.train()`` mode so the model's configured dropout is active,
-    as HF does; ``False`` keeps it in ``.eval()``. Sets the mode only — the
-    dropout *rate* comes from ``model_kwargs`` (e.g. ``resid_pdrop=0.1``).
-    MAGIC's backward replays each step from that step's saved RNG state, so
-    dropout masks are reproduced and the metagradient stays exact."""
+    """Enable ``.train()`` mode. Not certified MAGIC-safe."""
 
     save_optimizer_state: bool = False
     """After training, export the optimizer's second moments to

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -349,6 +349,17 @@ class TrainingConfig(AttributionConfig, Serializable):
     """Optimizer to use for the training steps. Muon is an efficient
     optimizer that can reduce memory usage and speed up training."""
 
+    train_mode: bool = False
+    """Run the model in ``.train()`` mode during training so its configured
+    dropout (and any other train-mode layers) is active — the standard HF
+    training behavior. Default ``False`` keeps the model in ``.eval()``
+    (dropout disabled), which is required for the MAGIC metagradient and is
+    what bergson has always done. Set the dropout *rate* via ``model_kwargs``
+    (e.g. ``resid_pdrop=0.1``); this flag only controls the mode. Incompatible
+    with the MAGIC metagradient (the backward-through-training replay needs
+    dropout-free forwards) — use it for leave-k-out bank retrains or the base
+    model of an EK-FAC/SOURCE run, to match an external training recipe."""
+
     save_optimizer_state: bool = False
     """After training, export the optimizer's second moments to
     ``<run_path>/optimizer.pt`` for use as an attribution normalizer.

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -234,23 +234,6 @@ def worker(
     torch.cuda.manual_seed_all(run_cfg.seed)
     trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
 
-    # A metagradient runs when there is a query and no precomputed scores
-    # (bank retrains pass no query and return before the backward below).
-    do_metagradient = query_dataset is not None and not score_path
-    if do_metagradient and getattr(run_cfg, "train_mode", False):
-        raise ValueError(
-            "train_mode=True is incompatible with the MAGIC metagradient: the "
-            "backward-through-training replay needs dropout-free forwards. Unset "
-            "train_mode, or run without a query (bank retrain) / with EK-FAC or "
-            "SOURCE if you want to train the base with dropout."
-        )
-    if do_metagradient and global_rank == 0:
-        print(
-            "MAGIC metagradient run: training the base in eval() mode (dropout "
-            "disabled), required for a correct backward-through-training. Set "
-            "train_mode=True to train with dropout on non-metagradient runs."
-        )
-
     ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")
     resume = run_cfg.resume
 

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -234,6 +234,23 @@ def worker(
     torch.cuda.manual_seed_all(run_cfg.seed)
     trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
 
+    # A metagradient runs when there is a query and no precomputed scores
+    # (bank retrains pass no query and return before the backward below).
+    do_metagradient = query_dataset is not None and not score_path
+    if do_metagradient and getattr(run_cfg, "train_mode", False):
+        raise ValueError(
+            "train_mode=True is incompatible with the MAGIC metagradient: the "
+            "backward-through-training replay needs dropout-free forwards. Unset "
+            "train_mode, or run without a query (bank retrain) / with EK-FAC or "
+            "SOURCE if you want to train the base with dropout."
+        )
+    if do_metagradient and global_rank == 0:
+        print(
+            "MAGIC metagradient run: training the base in eval() mode (dropout "
+            "disabled), required for a correct backward-through-training. Set "
+            "train_mode=True to train with dropout on non-metagradient runs."
+        )
+
     ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")
     resume = run_cfg.resume
 

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -67,16 +67,6 @@ class _ReplicatedAllReduceSum(torch.autograd.Function):
         return _ReplicatedAllReduceSum.apply(grad_output, ctx.group), None
 
 
-def _has_active_dropout(model: nn.Module) -> bool:
-    """Whether any ``nn.Dropout`` in ``model`` is currently stochastic (train
-    mode with a nonzero rate). Covers the standard HF blocks (GPT-2, NeoX,
-    Phi, …), which use ``nn.Dropout`` submodules; functional dropout is not
-    detected."""
-    return any(
-        isinstance(m, nn.Dropout) and m.training and m.p > 0 for m in model.modules()
-    )
-
-
 def _maybe_get_cuda_rng_state() -> torch.Tensor:
     """Get the CUDA RNG state, or a zeros placeholder when CUDA is uninitialized."""
     if torch.cuda.is_initialized():
@@ -700,20 +690,6 @@ class Trainer:
         Returns:
             The final backward state after processing the entire trajectory.
         """
-        # The metagradient replays each step's forward to rebuild its graph.
-        # Active dropout draws fresh masks that (currently) can't be matched to
-        # the original forward, so the metagradient would be silently wrong. A
-        # model in train() mode with all dropout rates at 0 is deterministic and
-        # allowed. See TrainingConfig.train_mode.
-        if _has_active_dropout(self.model):
-            raise ValueError(
-                "The MAGIC metagradient requires dropout-free forwards, but the "
-                "model has active dropout (train() mode with a nonzero dropout "
-                "rate). Unset TrainingConfig.train_mode (or zero the dropout "
-                "rate in model_kwargs) for MAGIC runs; use train_mode only for "
-                "leave-k-out retrains or an EK-FAC/SOURCE base model."
-            )
-
         ckpts = sorted_checkpoints(ckpt_dir)
         ckpt_paths = [path for _, path in ckpts]
         preserve_paths = {ckpt_paths[-1]} if cleanup else set(ckpt_paths)
@@ -912,11 +888,8 @@ def prepare_trainer(cfg: TrainingConfig, rank: int, schedule: Callable):
     )
     model.to(get_device(rank))  # type: ignore[reportArgumentType]
 
-    # ``setup_model_and_peft`` returns the model in eval mode (the HF
-    # ``from_pretrained`` default). Only enter train mode — activating dropout
-    # per the model config — when explicitly requested; MAGIC's metagradient
-    # requires eval-mode forwards and guards against train mode in backward().
-    if getattr(cfg, "train_mode", False):
+    # setup_model_and_peft leaves the model in from_pretrained's eval mode.
+    if cfg.train_mode:
         model.train()
     else:
         model.eval()

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -67,6 +67,16 @@ class _ReplicatedAllReduceSum(torch.autograd.Function):
         return _ReplicatedAllReduceSum.apply(grad_output, ctx.group), None
 
 
+def _has_active_dropout(model: nn.Module) -> bool:
+    """Whether any ``nn.Dropout`` in ``model`` is currently stochastic (train
+    mode with a nonzero rate). Covers the standard HF blocks (GPT-2, NeoX,
+    Phi, …), which use ``nn.Dropout`` submodules; functional dropout is not
+    detected."""
+    return any(
+        isinstance(m, nn.Dropout) and m.training and m.p > 0 for m in model.modules()
+    )
+
+
 def _maybe_get_cuda_rng_state() -> torch.Tensor:
     """Get the CUDA RNG state, or a zeros placeholder when CUDA is uninitialized."""
     if torch.cuda.is_initialized():
@@ -690,6 +700,20 @@ class Trainer:
         Returns:
             The final backward state after processing the entire trajectory.
         """
+        # The metagradient replays each step's forward to rebuild its graph.
+        # Active dropout draws fresh masks that (currently) can't be matched to
+        # the original forward, so the metagradient would be silently wrong. A
+        # model in train() mode with all dropout rates at 0 is deterministic and
+        # allowed. See TrainingConfig.train_mode.
+        if _has_active_dropout(self.model):
+            raise ValueError(
+                "The MAGIC metagradient requires dropout-free forwards, but the "
+                "model has active dropout (train() mode with a nonzero dropout "
+                "rate). Unset TrainingConfig.train_mode (or zero the dropout "
+                "rate in model_kwargs) for MAGIC runs; use train_mode only for "
+                "leave-k-out retrains or an EK-FAC/SOURCE base model."
+            )
+
         ckpts = sorted_checkpoints(ckpt_dir)
         ckpt_paths = [path for _, path in ckpts]
         preserve_paths = {ckpt_paths[-1]} if cleanup else set(ckpt_paths)
@@ -887,6 +911,15 @@ def prepare_trainer(cfg: TrainingConfig, rank: int, schedule: Callable):
         apply_fsdp=False,
     )
     model.to(get_device(rank))  # type: ignore[reportArgumentType]
+
+    # ``setup_model_and_peft`` returns the model in eval mode (the HF
+    # ``from_pretrained`` default). Only enter train mode — activating dropout
+    # per the model config — when explicitly requested; MAGIC's metagradient
+    # requires eval-mode forwards and guards against train mode in backward().
+    if getattr(cfg, "train_mode", False):
+        model.train()
+    else:
+        model.eval()
 
     if target_modules:
         # Only train the PEFT adapter parameters

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -944,3 +944,50 @@ def test_step_reproduces_cuda_dropout_masks():
     assert loss1 == loss2, (loss1, loss2)
     for k in s1.params:
         torch.testing.assert_close(s1.params[k], s2.params[k])
+
+
+def test_prepare_trainer_respects_train_mode(tmp_path):
+    """train_mode drives the model's train/eval mode; default is eval (the
+    long-standing dropout-off behavior)."""
+    from bergson.magic.config import MagicConfig
+    from bergson.magic.trainer import prepare_trainer
+
+    def build(train_mode):
+        cfg = MagicConfig(
+            run_path=str(tmp_path),
+            model="EleutherAI/pythia-14m",
+            train_mode=train_mode,
+        )
+        _, _, model = prepare_trainer(cfg, rank=0, schedule=lambda step: 1e-4)
+        return model.training
+
+    assert build(False) is False
+    assert build(True) is True
+
+
+def test_backward_rejects_active_dropout(tmp_path):
+    """The metagradient backward refuses active dropout: masks in the replayed
+    forward can't be matched to the original, so it would be silently wrong.
+    Dropout-free train mode (all rates 0) is allowed."""
+    torch.manual_seed(0)
+    config = AutoConfig.from_pretrained("EleutherAI/pythia-14m")
+    config.hidden_dropout = 0.5  # make the forward stochastic
+    model = AutoModelForCausalLM.from_config(
+        config, torch_dtype=torch.float32, attn_implementation="eager"
+    )
+    model.requires_grad_(True)
+    trainer, state = Trainer.initialize(model, torchopt.adamw(1e-4))
+
+    trainer.model.train()  # dropout now active
+    with pytest.raises(ValueError, match="dropout"):
+        # The guard runs before any checkpoint/data access.
+        trainer.backward(str(tmp_path), None, None, state)
+
+    # Dropout-free train mode is fine: the guard does not fire (it fails later
+    # on the empty checkpoint dir instead, not with the dropout message).
+    for m in trainer.model.modules():
+        if isinstance(m, torch.nn.Dropout):
+            m.p = 0.0
+    with pytest.raises(Exception) as exc:
+        trainer.backward(str(tmp_path), None, None, state)
+    assert "dropout" not in str(exc.value)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -656,13 +656,16 @@ def _multi_step_stream(n_steps: int, device: str = "cpu") -> DataStream:
     return DataStream(ds, batch_size=1, device=device)
 
 
-def _fresh_trainer(seed: int = 42):
+def _fresh_trainer(seed: int = 42, dropout: float = 0.0):
     """Build a fresh model/trainer/state, as a new process would."""
     torch.manual_seed(seed)
     config = AutoConfig.from_pretrained(TINY_MODEL)
+    if dropout:
+        config.resid_pdrop = dropout
     model = AutoModelForCausalLM.from_config(
         config, torch_dtype=torch.float32, attn_implementation="eager"
     )
+    model.train() if dropout else model.eval()
     model.loss_function = weighted_causal_lm_ce
     model.requires_grad_(True)
 
@@ -947,8 +950,7 @@ def test_step_reproduces_cuda_dropout_masks():
 
 
 def test_prepare_trainer_respects_train_mode(tmp_path):
-    """train_mode drives the model's train/eval mode; default is eval (the
-    long-standing dropout-off behavior)."""
+    """train_mode drives the model's train/eval mode; default is eval."""
     from bergson.magic.config import MagicConfig
     from bergson.magic.trainer import prepare_trainer
 
@@ -965,29 +967,37 @@ def test_prepare_trainer_respects_train_mode(tmp_path):
     assert build(True) is True
 
 
-def test_backward_rejects_active_dropout(tmp_path):
-    """The metagradient backward refuses active dropout: masks in the replayed
-    forward can't be matched to the original, so it would be silently wrong.
-    Dropout-free train mode (all rates 0) is allowed."""
-    torch.manual_seed(0)
-    config = AutoConfig.from_pretrained("EleutherAI/pythia-14m")
-    config.hidden_dropout = 0.5  # make the forward stochastic
-    model = AutoModelForCausalLM.from_config(
-        config, torch_dtype=torch.float32, attn_implementation="eager"
+def test_magic_backward_matches_across_save_modes_with_dropout(monkeypatch):
+    """Sparse checkpointing must not change MAGIC scores when dropout is active.
+
+    Each save mode rematerializes a different number of steps before the traced
+    re-do, so if the replay drew fresh dropout masks instead of restoring each
+    step's saved RNG, the schedules would disagree.
+    """
+    import types
+
+    from bergson.magic import trainer as trainer_mod
+
+    monkeypatch.setattr(
+        trainer_mod.psutil,
+        "virtual_memory",
+        lambda: types.SimpleNamespace(available=1 << 60),
     )
-    model.requires_grad_(True)
-    trainer, state = Trainer.initialize(model, torchopt.adamw(1e-4))
 
-    trainer.model.train()  # dropout now active
-    with pytest.raises(ValueError, match="dropout"):
-        # The guard runs before any checkpoint/data access.
-        trainer.backward(str(tmp_path), None, None, state)
+    scores = {}
+    for mode in ("all", "log"):
+        trainer, fwd_state, model = _fresh_trainer(dropout=0.5)
+        assert any(
+            isinstance(m, torch.nn.Dropout) and m.training and m.p > 0
+            for m in model.modules()
+        ), "dropout is not active; test is degenerate"
+        stream = _multi_step_stream(9)
 
-    # Dropout-free train mode is fine: the guard does not fire (it fails later
-    # on the empty checkpoint dir instead, not with the dropout message).
-    for m in trainer.model.modules():
-        if isinstance(m, torch.nn.Dropout):
-            m.p = 0.0
-    with pytest.raises(Exception) as exc:
-        trainer.backward(str(tmp_path), None, None, state)
-    assert "dropout" not in str(exc.value)
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            fwd_state = trainer.train(
+                fwd_state, stream, inplace=True, save_dir=ckpt_dir, save_mode=mode
+            )
+            scores[mode] = _magic_scores(trainer, model, fwd_state, stream, ckpt_dir)
+
+    assert scores["all"].abs().sum() > 0, "scores are all zero; test is degenerate"
+    torch.testing.assert_close(scores["log"], scores["all"], atol=1e-12, rtol=1e-6)


### PR DESCRIPTION
The trainer always ran the model in `eval()` mode. We want the option to use dropout etc. via .train(). We add an opt-in `TrainingConfig.train_mode`. 