### PR TITLE
perf: re-use re-train bank losses in `bergson validate`

### DIFF
--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -7,6 +7,7 @@ loss increase is correlated against the summed attribution scores of the
 left-out documents.
 """
 
+import hashlib
 import json
 import os
 import random
@@ -17,6 +18,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from peft import PeftModel
 from scipy.stats import pearsonr, spearmanr
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -78,6 +80,38 @@ def load_attribution_scores(score_path: str) -> tuple[torch.Tensor, bool]:
     return scores, False
 
 
+def bank_loss_cache_key(
+    run_cfg: ValidationConfig, multi_query: bool, num_subsets: int
+) -> str:
+    """Cache filename for a bank's per-subset query losses.
+
+    The losses depend on the banked models, the query set, how the models are
+    loaded, and (for the single-query token-mean) the batch grouping.
+    ``num_subsets`` and ``multi_query`` determine the shape.
+    """
+    q = run_cfg.query
+    identity = {
+        "model": run_cfg.model,
+        "model_kwargs": run_cfg.model_kwargs,
+        "query_dataset": q.dataset,
+        "query_split": q.split,
+        "query_subset": q.subset,
+        "query_prompt_column": q.prompt_column,
+        "query_completion_column": q.completion_column,
+        "query_truncation": q.truncation,
+        "query_format_template": q.format_template,
+        "query_data_kwargs": q.data_kwargs,
+        "query_chunk_length": q.chunk_length,
+        "batch_size": run_cfg.batch_size,
+        "multi_query": multi_query,
+        "num_subsets": num_subsets,
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, default=str).encode()
+    ).hexdigest()[:16]
+    return f"losses_{digest}.pt"
+
+
 def _load_banked_model(
     run_cfg: ValidationConfig, out_dir: str, device: torch.device | str
 ) -> torch.nn.Module:
@@ -85,8 +119,6 @@ def _load_banked_model(
     load_kwargs = {"dtype": torch.float32, "attn_implementation": "eager"}
     load_kwargs.update(simple_parse_kwargs_string(run_cfg.model_kwargs))
     if os.path.isfile(os.path.join(out_dir, "adapter_config.json")):
-        from peft import PeftModel
-
         base = AutoModelForCausalLM.from_pretrained(run_cfg.model, **load_kwargs)
         model = PeftModel.from_pretrained(base, out_dir)
     else:
@@ -514,23 +546,67 @@ def evaluate_retrained(
             :num_real_query_docs
         ].cpu()
 
-    # The bank's no-leave-out model (retrained/base) gives the query baseline;
-    # absent it, baseline stays 0 (correlation-safe).
-    base_dir = models_root / "base"
-    baseline = 0.0
-    baseline_per_doc = torch.zeros(num_real_query_docs)
-    if base_dir.exists():
-        base = _load_banked_model(run_cfg, str(base_dir), device)
+    def compute_bank_losses() -> tuple[float, torch.Tensor, torch.Tensor]:
+        """Evaluate every banked model, returning baseline + per-subset losses.
+
+        ``per_subset`` is ``[num_subsets, num_real_query_docs]`` for multi-query
+        or ``[num_subsets]`` for single-query. The bank's no-leave-out model
+        (``retrained/base``) gives the baseline; absent it the baseline stays 0
+        (correlation-safe).
+        """
+        base_dir = models_root / "base"
+        base_scalar = 0.0
+        base_per_doc = torch.zeros(num_real_query_docs)
+        if base_dir.exists():
+            base = _load_banked_model(run_cfg, str(base_dir), device)
+            if multi_query:
+                base_per_doc = query_losses_per_doc(base)
+            else:
+                base_scalar = query_loss(base)
+            del base
+
         if multi_query:
-            baseline_per_doc = query_losses_per_doc(base)
-            print(
-                f"Baseline per-query losses (no leave-out) from {base_dir}: "
-                f"{baseline_per_doc.tolist()}"
-            )
+            per_subset = torch.zeros(len(subsets), num_real_query_docs)
         else:
-            baseline = query_loss(base)
-            print(f"Baseline query loss (no leave-out) from {base_dir}: {baseline}")
-        del base
+            per_subset = torch.zeros(len(subsets))
+        for i in tqdm(range(len(subsets)), desc="Evaluating bank"):
+            model = _load_banked_model(run_cfg, str(models_root / f"subset_{i}"), device)
+            if multi_query:
+                per_subset[i] = query_losses_per_doc(model)
+            else:
+                per_subset[i] = query_loss(model)
+            del model
+        return base_scalar, base_per_doc, per_subset
+
+    # Cache per-subset query losses for re-use with different attribution methods.
+    cache_path = src / "query_loss_cache" / bank_loss_cache_key(
+        run_cfg, multi_query, len(subsets)
+    )
+    if cache_path.exists():
+        print(f"Reusing cached bank losses from {cache_path}")
+        blob = torch.load(cache_path, map_location="cpu")
+        baseline = float(blob["baseline"])
+        baseline_per_doc = blob["baseline_per_doc"]
+        per_subset_losses = blob["per_subset"]
+    else:
+        baseline, baseline_per_doc, per_subset_losses = compute_bank_losses()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "baseline": baseline,
+                "baseline_per_doc": baseline_per_doc,
+                "per_subset": per_subset_losses,
+            },
+            cache_path,
+        )
+        print(f"Saved bank losses to {cache_path}")
+
+    if multi_query:
+        print(
+            f"Baseline per-query losses (no leave-out): {baseline_per_doc.tolist()}"
+        )
+    else:
+        print(f"Baseline query loss (no leave-out): {baseline}")
 
     csv_path = os.path.join(run_cfg.run_path, "validation.csv")
     val_csv_writer = CSVWriter(
@@ -542,48 +618,25 @@ def evaluate_retrained(
         ),
     )
 
+    # Combine cached losses with attribution subset scores.
     diffs = []
     score_sums = []
-    pbar = tqdm(range(len(subsets)), desc="Evaluating")
-    for i in pbar:
-        model_dir = models_root / f"subset_{i}"
-        model = _load_banked_model(run_cfg, str(model_dir), device)
+    for i in range(len(subsets)):
         if multi_query:
-            diff_vec = baseline_per_doc - query_losses_per_doc(model)
-            del model
-
+            diff_vec = baseline_per_doc - per_subset_losses[i]
             score_sum_vec = scores[subsets[i]].sum(dim=0)
             for q in range(num_real_query_docs):
                 val_csv_writer.writerow(
                     i, q, diff_vec[q].item(), score_sum_vec[q].item()
                 )
-
             diffs.append(diff_vec.tolist())
             score_sums.append(score_sum_vec.tolist())
-            if len(diffs) >= 2:
-                rhos = [
-                    spearmanr(
-                        [row[q] for row in diffs],
-                        [row[q] for row in score_sums],
-                    ).statistic
-                    for q in range(num_real_query_docs)
-                ]
-                pbar.set_postfix({"mean_rho": float(np.mean(rhos))})
-            continue
-
-        loss = query_loss(model)
-        del model
-
-        diff = baseline - loss
-        score_sum = scores[subsets[i]].sum().item()
-        val_csv_writer.writerow(i, diff, score_sum)
-
-        diffs.append(diff)
-        score_sums.append(score_sum)
-        if len(diffs) >= 2:
-            sp = spearmanr(diffs, score_sums)
-            pe = pearsonr(diffs, score_sums)
-            pbar.set_postfix({"rho": sp.statistic, "r": pe.statistic})
+        else:
+            diff = baseline - float(per_subset_losses[i])
+            score_sum = scores[subsets[i]].sum().item()
+            val_csv_writer.writerow(i, diff, score_sum)
+            diffs.append(diff)
+            score_sums.append(score_sum)
 
     val_csv_writer.close()
     print(f"Saved validation data to {csv_path}")

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -570,7 +570,9 @@ def evaluate_retrained(
         else:
             per_subset = torch.zeros(len(subsets))
         for i in tqdm(range(len(subsets)), desc="Evaluating bank"):
-            model = _load_banked_model(run_cfg, str(models_root / f"subset_{i}"), device)
+            model = _load_banked_model(
+                run_cfg, str(models_root / f"subset_{i}"), device
+            )
             if multi_query:
                 per_subset[i] = query_losses_per_doc(model)
             else:
@@ -579,8 +581,10 @@ def evaluate_retrained(
         return base_scalar, base_per_doc, per_subset
 
     # Cache per-subset query losses for re-use with different attribution methods.
-    cache_path = src / "query_loss_cache" / bank_loss_cache_key(
-        run_cfg, multi_query, len(subsets)
+    cache_path = (
+        src
+        / "query_loss_cache"
+        / bank_loss_cache_key(run_cfg, multi_query, len(subsets))
     )
     if cache_path.exists():
         print(f"Reusing cached bank losses from {cache_path}")
@@ -602,9 +606,7 @@ def evaluate_retrained(
         print(f"Saved bank losses to {cache_path}")
 
     if multi_query:
-        print(
-            f"Baseline per-query losses (no leave-out): {baseline_per_doc.tolist()}"
-        )
+        print(f"Baseline per-query losses (no leave-out): {baseline_per_doc.tolist()}")
     else:
         print(f"Baseline query loss (no leave-out): {baseline}")
 

--- a/tests/test_bank_loss_cache.py
+++ b/tests/test_bank_loss_cache.py
@@ -1,0 +1,164 @@
+"""Reuse of method-independent per-subset query losses in ``evaluate_retrained``.
+
+Evaluating a pre-saved leave-k-out bank re-runs every banked model on the query
+set to get each subset's query-loss diff. Those losses depend only on the bank
+and query set, not the attribution scores, so they are cached under the bank
+and reused across every method scored on the same bank/query -- the second run
+must not touch a single banked model, yet must produce identical correlations.
+"""
+
+import copy
+import json
+
+import numpy as np
+import pytest
+import torch
+from datasets import Dataset
+
+import bergson.validate as validate
+from bergson.config.config import DataConfig
+from bergson.magic.config import MagicConfig
+from bergson.validate import bank_loss_cache_key, evaluate_retrained
+
+MODEL = "trl-internal-testing/tiny-Phi3ForCausalLM"
+
+# Bank drops these train doc ids per subset; scores must cover the max id.
+SUBSETS = [[0, 1], [2, 3], [4]]
+NUM_DOCS = 5
+
+
+def _build_bank(tmp_path, model):
+    """A tiny bank: a base model plus one distinctly-perturbed model per subset."""
+    root = tmp_path / "bank"
+    models_root = root / "retrained"
+    for i, name in enumerate(["base", *[f"subset_{j}" for j in range(len(SUBSETS))]]):
+        m = copy.deepcopy(model)
+        with torch.no_grad():
+            # Distinct perturbation per model so subset losses differ.
+            next(m.parameters()).add_(0.05 * (i + 1))
+        m.save_pretrained(models_root / name)
+    with open(root / "subsets.json", "w") as f:
+        json.dump(SUBSETS, f)
+    return root
+
+
+def _query_dataset(tmp_path):
+    """Four short query docs saved to disk for ``load_data_string``."""
+    ds = Dataset.from_dict(
+        {"text": ["the cat sat", "a dog ran fast", "birds fly high", "fish swim deep"]}
+    )
+    path = tmp_path / "query"
+    ds.save_to_disk(path)
+    return path, len(ds)
+
+
+def _run_cfg(tmp_path, run_name, query_path, batch_size=2):
+    return MagicConfig(
+        run_path=str(tmp_path / run_name),
+        model=MODEL,
+        batch_size=batch_size,
+        precision="fp32",
+        query=DataConfig(
+            dataset=str(query_path), split="train", prompt_column="text", chunk_length=0
+        ),
+    )
+
+
+def _read_validation(run_path):
+    rows = []
+    with open(run_path / "validation.csv") as f:
+        header = f.readline().strip().split(",")
+        for line in f:
+            rows.append(dict(zip(header, line.strip().split(","))))
+    return rows
+
+
+def test_bank_loss_cache_key_pins_query_and_load_settings():
+    base = MagicConfig(run_path="x", model=MODEL, batch_size=2)
+    name0 = bank_loss_cache_key(base, multi_query=True, num_subsets=3)
+
+    # Same identity -> same file (run_path is irrelevant to the losses).
+    name_same = bank_loss_cache_key(
+        MagicConfig(run_path="y", model=MODEL, batch_size=2),
+        multi_query=True,
+        num_subsets=3,
+    )
+    assert name0 == name_same
+
+    # Any identity change -> different file, so a different query/model/batch
+    # never reuses these losses.
+    changed = [
+        dict(run_path="x", model=MODEL, batch_size=4),
+        dict(run_path="x", model="other-model", batch_size=2),
+    ]
+    for kw in changed:
+        name = bank_loss_cache_key(MagicConfig(**kw), multi_query=True, num_subsets=3)
+        assert name != name0, kw
+
+    # Mode and subset count pin the tensor shape, so they key too.
+    name_single = bank_loss_cache_key(base, multi_query=False, num_subsets=3)
+    name_n = bank_loss_cache_key(base, multi_query=True, num_subsets=4)
+    assert len({name0, name_single, name_n}) == 3
+
+
+@pytest.mark.parametrize("multi_query", [True, False])
+def test_evaluate_retrained_reuses_cached_bank_losses(
+    tmp_path, model, monkeypatch, multi_query
+):
+    root = _build_bank(tmp_path, model)
+    query_path, n_query = _query_dataset(tmp_path)
+
+    cols = n_query if multi_query else 1
+    rng = np.random.default_rng(0)
+    scores = rng.standard_normal((NUM_DOCS, cols)).astype(np.float32)
+    score_path = tmp_path / "scores.npy"
+    np.save(score_path, scores)
+
+    # First run: cold cache, evaluates the bank and writes the cache.
+    cfg1 = _run_cfg(tmp_path, "run1", query_path)
+    evaluate_retrained(cfg1, str(root), score_path=str(score_path))
+
+    cache_dir = root / "query_loss_cache"
+    cache_files = list(cache_dir.glob("losses_*.pt"))
+    assert len(cache_files) == 1, "first run must persist exactly one cache file"
+
+    expected_name = bank_loss_cache_key(cfg1, multi_query, len(SUBSETS))
+    assert cache_files[0].name == expected_name
+
+    rows1 = _read_validation(tmp_path / "run1")
+
+    # Second run: any attempt to load a banked model means the cache was missed.
+    def _fail_load(*args, **kwargs):
+        raise AssertionError("banked model loaded despite a valid loss cache")
+
+    monkeypatch.setattr(validate, "_load_banked_model", _fail_load)
+
+    cfg2 = _run_cfg(tmp_path, "run2", query_path)
+    evaluate_retrained(cfg2, str(root), score_path=str(score_path))
+
+    rows2 = _read_validation(tmp_path / "run2")
+
+    # Identical diffs and score sums => identical correlations, cache-independent.
+    assert len(rows1) == len(rows2)
+    for a, b in zip(rows1, rows2):
+        assert a["diff"] == b["diff"]
+        assert a["score_sum"] == b["score_sum"]
+
+
+def test_different_query_does_not_reuse_losses(tmp_path, model):
+    """A different query set keys a different cache file, never the first's."""
+    root = _build_bank(tmp_path, model)
+    query_path, n_query = _query_dataset(tmp_path)
+    scores = np.random.default_rng(2).standard_normal((NUM_DOCS, n_query)).astype("f4")
+    score_path = tmp_path / "scores.npy"
+    np.save(score_path, scores)
+
+    cfg_a = _run_cfg(tmp_path, "run_a", query_path)
+    evaluate_retrained(cfg_a, str(root), score_path=str(score_path))
+
+    # Same bank, different query split -> a distinct cache file is written.
+    cfg_b = _run_cfg(tmp_path, "run_b", query_path)
+    cfg_b.query.split = "train[:3]"
+    name_a = bank_loss_cache_key(cfg_a, True, len(SUBSETS))
+    name_b = bank_loss_cache_key(cfg_b, True, len(SUBSETS))
+    assert name_a != name_b


### PR DESCRIPTION
Cache per-subset losses and baseline in the re-train bank, with a cache key based on the query and model load settings. This makes future calls to validate much faster.