### PR TITLE
refactor: rename save_retrained_models to save_models

### DIFF
--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -276,7 +276,7 @@ class Validate(ValidationConfig):
     retrained_dir: str = ""
     """Optional: evaluate on an existing run directory of
     leave-k-out re-trained models written with
-    ``save_retrained_models=true``."""
+    ``save_models=true``."""
 
     def execute(self):
         """Run the validation."""

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -428,7 +428,7 @@ class ValidationConfig(TrainingConfig, ABC):
     permutation. These scores may be produced by items with fewer than
     2 tokens."""
 
-    save_retrained_models: bool = False
+    save_models: bool = False
     """When True, save each leave-k-out retrained model (HF format, weights +
     tokenizer) to ``<run_path>/retrained/subset_<i>/`` so it can be reused for
     later attribution queries without retraining. ~0.5 GB per subset for GPT-2."""

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -270,7 +270,7 @@ def worker(
             os.path.join(run_cfg.run_path, "optimizer.pt"),
         )
 
-    if getattr(run_cfg, "save_retrained_models", False) and global_rank == 0:
+    if getattr(run_cfg, "save_models", False) and global_rank == 0:
         # Persist the fully-trained (no leave-out) model alongside the per-subset
         # models, so a later evaluate_retrained run can measure the query
         # baseline from the bank itself instead of a separate base_model_dir.

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -115,7 +115,7 @@ def bank_loss_cache_key(
 def _load_banked_model(
     run_cfg: ValidationConfig, out_dir: str, device: torch.device | str
 ) -> torch.nn.Module:
-    """Load a banked ``save_retrained_models`` checkpoint into a ready model."""
+    """Load a banked ``save_models`` checkpoint into a ready model."""
     load_kwargs = {"dtype": torch.float32, "attn_implementation": "eager"}
     load_kwargs.update(simple_parse_kwargs_string(run_cfg.model_kwargs))
     if os.path.isfile(os.path.join(out_dir, "adapter_config.json")):
@@ -330,7 +330,7 @@ def validate_scores(
     hf_set_verbosity_error()
 
     # Optionally persist each retrained model for later attribution queries.
-    save_models = getattr(run_cfg, "save_retrained_models", False)
+    save_models = getattr(run_cfg, "save_models", False)
     retrained_tokenizer = None
     if save_models and global_rank == 0:
         retrained_tokenizer = AutoTokenizer.from_pretrained(
@@ -464,7 +464,7 @@ def evaluate_retrained(
     """Evaluate a bank of pre-saved leave-k-out models on a query, no retraining.
 
     Reads models written by an earlier run with
-    ``save_retrained_models=true`` and evaluates attribution scores. No training
+    ``save_models=true`` and evaluates attribution scores. No training
     happens so evaluation is cheap.
     """
     assert score_path, "evaluate_retrained requires precomputed --scores"
@@ -474,7 +474,7 @@ def evaluate_retrained(
     if not subsets_path.exists():
         raise FileNotFoundError(
             f"{subsets_path} not found; retrained_dir must point at a run "
-            f"directory written with save_retrained_models=true"
+            f"directory written with save_models=true"
         )
 
     run_path = Path(run_cfg.run_path)

--- a/examples/magic/gpt2_wikitext.yaml
+++ b/examples/magic/gpt2_wikitext.yaml
@@ -49,4 +49,4 @@ steps:
 
       wandb_project: magic
       save_optimizer_state: True
-      save_retrained_models: True
+      save_models: True

--- a/tests/test_banked_model_loading.py
+++ b/tests/test_banked_model_loading.py
@@ -1,6 +1,6 @@
-"""Loading banked ``save_retrained_models`` checkpoints in ``evaluate_retrained``.
+"""Loading banked ``save_models`` checkpoints in ``evaluate_retrained``.
 
-``save_retrained_models`` banks whatever ``model.save_pretrained`` produces:
+``save_models`` banks whatever ``model.save_pretrained`` produces:
 a full HF checkpoint for plain fine-tunes, or an adapter-only directory when
 ``peft_init_kwargs`` is set. ``AutoModelForCausalLM.from_pretrained`` pointed
 straight at an adapter-only directory silently returns a randomly-initialised


### PR DESCRIPTION
Rename the leave-k-out bank flag across config, MAGIC CLI, validate, and example configs. 