### PR TITLE
feat: interval save mode for the trainer

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -10,6 +10,8 @@ from simple_parsing import Serializable, field
 
 from ..hessians.inversion import Inversion
 
+SaveMode = Literal["all", "sqrt", "log", "interval"]
+
 
 @dataclass
 class DataConfig(Serializable):
@@ -354,6 +356,25 @@ class TrainingConfig(AttributionConfig, Serializable):
 
     save_optimizer_state: Literal["none", "last", "all"] = "none"
     """Which checkpoints' optimizer second moments to persist. AdamW only."""
+
+    save_mode: SaveMode = "sqrt"
+    """Checkpoint saving mode.
+
+    - 'all' saves every checkpoint. This method uses O(N) space and O(N) time.
+    - 'log' saves at a log-spaced interval, more frequently near the end of a training
+      segment. Training is recursively divided into segments. This method uses O(log N)
+      space and O(N log N) time.
+    - 'sqrt' saves at a linearly-spaced interval, every sqrt(N) steps. This method uses
+      O(sqrt N) space and O(N) time.
+    - 'interval' saves every `save_interval` steps, plus the final state. Not
+      supported by MAGIC.
+
+    The original MAGIC paper used 'log', but 'sqrt' is often a better choice when disk
+    space is not a concern.
+    """
+
+    save_interval: int = 0
+    """Checkpointing interval in steps for `save_mode: interval`."""
 
     weight_decay: float = 0.01
     """Weight decay coefficient for AdamW and Muon."""

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -247,7 +247,7 @@ def worker(
         debug=run_cfg.debug,
         inplace=True,
         save_dir=ckpts_path,
-        save_mode=getattr(run_cfg, "save_mode", "sqrt"),
+        save_mode=run_cfg.save_mode,
         log_fn=log_fn,
         resume=resume,
         fsdp=run_cfg.fsdp,
@@ -262,6 +262,7 @@ def worker(
             if getattr(run_cfg, "save_optimizer_state", "none") == "all"
             else None
         ),
+        save_interval=run_cfg.save_interval,
     )
     if getattr(run_cfg, "save_optimizer_state", "none") != "none" and global_rank == 0:
         save_second_moments_as_optimizer_pt(
@@ -325,6 +326,8 @@ def worker(
         # Sanity check
         if not isinstance(run_cfg, MagicConfig):
             raise RuntimeError("run_cfg must be a MagicConfig to compute scores")
+        if run_cfg.save_mode == "interval":
+            raise ValueError("save_mode='interval' not supported for MAGIC attribution")
 
         stream.requires_grad = True
         opt_grads = [

--- a/bergson/magic/config.py
+++ b/bergson/magic/config.py
@@ -1,28 +1,11 @@
 from dataclasses import dataclass
-from typing import Literal
 
 from ..config.config import ValidationConfig
-
-MagicSaveMode = Literal["all", "sqrt", "log"]
 
 
 @dataclass
 class MagicConfig(ValidationConfig):
     """Special config for MAGIC attribution."""
-
-    save_mode: MagicSaveMode = "sqrt"
-    """Checkpoint saving mode.
-
-    - 'all' saves every checkpoint. This method uses O(N) space and O(N) time.
-    - 'log' saves at a log-spaced interval, more frequently near the end of a training
-      segment. Training is recursively divided into segments. This method uses O(log N)
-      space and O(N log N) time.
-    - 'sqrt' saves at a linearly-spaced interval, every sqrt(N) steps. This method uses
-      O(sqrt N) space and O(N) time.
-
-    The original MAGIC paper used 'log', but 'sqrt' is often a better choice when disk
-    space is not a concern.
-    """
 
     backward_save_every: int = 0
     """How often (in steps) to save backward state for resume."""

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -20,11 +20,10 @@ from torchopt.pytree import tree_flatten_with_path, tree_iter, tree_map
 from torchopt.typing import GradientTransformation, OptState
 from tqdm.auto import tqdm
 
-from ..config.config import TrainingConfig
+from ..config.config import SaveMode, TrainingConfig
 from ..data import sorted_checkpoints
 from ..utils.utils import get_device
 from ..utils.worker_utils import setup_model_and_peft
-from .config import MagicSaveMode
 from .data_stream import DataStream
 from .dtensor_patch import apply_dtensor_patch
 from .fsdp import shallow_copy, simple_fsdp
@@ -105,7 +104,9 @@ class SaveFuture:
         return result
 
 
-def next_save_index(current: int, n: int, save_mode: MagicSaveMode) -> int:
+def next_save_index(
+    current: int, n: int, save_mode: SaveMode, save_interval: int = 0
+) -> int:
     """Index of the checkpoint following the one saved at step `current`.
 
     `n` is the total number of training steps. The result is always strictly
@@ -116,6 +117,10 @@ def next_save_index(current: int, n: int, save_mode: MagicSaveMode) -> int:
         case "all":
             # Save every step
             return current + 1
+        case "interval":
+            if save_interval <= 0:
+                raise ValueError("save_mode='interval' requires save_interval > 0.")
+            return current + save_interval
         case "sqrt":
             chunk_size = math.isqrt(n)
 
@@ -546,7 +551,7 @@ class Trainer:
         debug: bool = False,
         inplace: bool = False,
         save_dir: str | None = None,
-        save_mode: MagicSaveMode = "sqrt",
+        save_mode: SaveMode = "sqrt",
         trace: bool = False,
         log_fn: Callable[[int, float], None] | None = None,
         resume: bool = False,
@@ -554,6 +559,7 @@ class Trainer:
         max_grad_norm: float | None = None,
         grad_accum_steps: int = 1,
         optimizer_cfg: dict | None = None,
+        save_interval: int = 0,
     ) -> TrainerState:
         """Train the model on the given data stream, starting from the given state.
 
@@ -582,6 +588,7 @@ class Trainer:
             optimizer_cfg: When set (to the optimizer's betas/eps/eps_root),
                 write each checkpoint's second moments to ``optimizer.pt``,
                 tagged with the step and these hyperparameters. AdamW only.
+            save_interval: Checkpointing interval in steps for ``save_mode="interval"``.
 
         Returns:
             The final trainer state after training.
@@ -639,7 +646,7 @@ class Trainer:
 
                 pending_save = state.save(p, debug_pbar=pbar if debug else None)
 
-                next_save = next_save_index(next_save, n, save_mode)
+                next_save = next_save_index(next_save, n, save_mode, save_interval)
 
             x = data[i]
             state = self.step(
@@ -657,6 +664,27 @@ class Trainer:
 
         if pending_save is not None:
             pending_save.result()
+
+        # Snapshots are written before each step; when the interval cadence
+        # lands on n, write the post-training state too.
+        if save_dir and save_mode == "interval" and next_save == n:
+            p = os.path.join(save_dir, f"step_{n}.ckpt")
+            if optimizer_cfg is not None:
+                # Local import: at module scope this cycles back into
+                # magic.trainer via the package __init__.
+                from ..utils.load_from_optimizer import (
+                    save_second_moments_as_optimizer_pt,
+                )
+
+                os.makedirs(p, exist_ok=True)
+                save_second_moments_as_optimizer_pt(
+                    self.model,
+                    state.opt_state,
+                    os.path.join(p, "optimizer.pt"),
+                    step=n,
+                    **optimizer_cfg,
+                )
+            state.save(p).result()
 
         return state
 
@@ -720,7 +748,7 @@ class Trainer:
         fsdp: bool = False,
         resume: bool = False,
         save_every: int = 0,
-        save_mode: MagicSaveMode = "sqrt",
+        save_mode: SaveMode = "sqrt",
         max_grad_norm: float | None = None,
         grad_accum_steps: int = 1,
     ) -> BackwardState:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1146,3 +1146,12 @@ def test_accumulate_grads_matches_full_batch(valid_lens):
     # The loss casts logits to fp32 internally, so fp32-level associativity
     # noise is the floor even for a float64 model.
     assert num / den < 1e-6, f"accumulated gradient off by {num / den:.3e}"
+
+
+def test_next_save_index_interval():
+    from bergson.magic.trainer import next_save_index
+
+    assert next_save_index(0, 1746, "interval", save_interval=291) == 291
+    assert next_save_index(291, 1746, "interval", save_interval=291) == 582
+    with pytest.raises(ValueError, match="save_interval"):
+        next_save_index(0, 100, "interval")


### PR DESCRIPTION
`save_mode="interval"` writes a checkpoint every `save_interval` steps, plus the final state when the cadence lands on it — the checkpoint schedule SOURCE needs from a training run.

`save_mode`/`save_interval` move from `MagicConfig` to `TrainingConfig`, so trainer-only runs use `bergson train` directly (no MAGIC involvement). The earlier `skip_metagradient` flag is dropped: `bergson train` already returns after training when no query is set, so a flag that ran MAGIC as a trainer was redundant. The MAGIC backward now rejects `interval` mode, whose spacing its replay indexing does not support.