### PR TITLE
fix: normalize SOURCE segment eigenvalues per document

### DIFF
--- a/bergson/approx_unrolling/precompute_checkpoints.py
+++ b/bergson/approx_unrolling/precompute_checkpoints.py
@@ -2,8 +2,12 @@ import shutil
 from copy import deepcopy
 from pathlib import Path
 
+import torch
 from datasets import Dataset
 
+from bergson.approx_unrolling.segment_aggregation import (
+    DOCUMENTS_PROCESSED_FILENAME,
+)
 from bergson.collector.collector import (
     CollectorComputer,
     fwd_bwd_hessian_factory,
@@ -90,6 +94,7 @@ def precompute_checkpoint_averaged_lambdas(
             ],
             ckpt_index_cfg.distributed,
         )
+        torch.save(torch.tensor(len(ds)), out_path / DOCUMENTS_PROCESSED_FILENAME)
 
 
 def _lambda_worker(

--- a/bergson/approx_unrolling/segment_aggregation.py
+++ b/bergson/approx_unrolling/segment_aggregation.py
@@ -14,18 +14,37 @@ from bergson.utils.utils import get_device
 
 _SHARD_KINDS = ("activation_sharded", "gradient_sharded")
 
+DOCUMENTS_PROCESSED_FILENAME = "documents_processed.pt"
+"""Per-checkpoint document count beside the lambda shards. The lambdas
+accumulate one squared gradient per document, so this is their normalizer --
+the analogue of ``total_processed.pt`` (tokens) for the covariances."""
+
+
+def lambda_denominator(input_dirs: list[Path]) -> float:
+    """Pooled document count over a segment's checkpoints."""
+    total = 0
+    for d in input_dirs:
+        path = d / DOCUMENTS_PROCESSED_FILENAME
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Missing {path}; re-run the per-checkpoint lambda step."
+            )
+        total += int(torch.load(path, map_location="cpu", weights_only=False))
+    return float(total)
+
 
 def sum_sharded_dirs(
     input_dirs: list[Path],
     output_dir: Path,
     distributed: DistributedConfig,
+    divisor: float = 1.0,
 ) -> None:
     """Sum per-rank shards across ``input_dirs`` into ``output_dir``."""
     output_dir.mkdir(parents=True, exist_ok=True)
     launch_distributed_run(
         "sum_sharded_dirs",
         _sum_sharded_dirs_worker,
-        [input_dirs, output_dir],
+        [input_dirs, output_dir, divisor],
         distributed,
     )
 
@@ -36,12 +55,13 @@ def _sum_sharded_dirs_worker(
     world_size: int,
     input_dirs: list[Path],
     output_dir: Path,
+    divisor: float,
 ) -> None:
     init_dist(rank, local_rank, world_size)
     device = get_device(local_rank)
     shard_name = f"shard_{rank}.safetensors"
     in_paths = [d / shard_name for d in input_dirs]
-    _sum_my_shard(in_paths, output_dir / shard_name, device=device)
+    _sum_my_shard(in_paths, output_dir / shard_name, device=device, divisor=divisor)
     if world_size > 1:
         dist.barrier()
 
@@ -50,6 +70,7 @@ def _sum_my_shard(
     in_paths: list[Path],
     out_path: Path,
     device: str,
+    divisor: float = 1.0,
 ) -> None:
     """Sum all tensor dicts in ``in_paths`` and write to ``out_path``."""
     acc: dict[str, torch.Tensor] = {}
@@ -61,6 +82,9 @@ def _sum_my_shard(
                     acc[k] = t.clone()
                 else:
                     acc[k].add_(t)
+    if divisor != 1.0:
+        for v in acc.values():
+            v.div_(divisor)
     save_file({k: v.cpu() for k, v in acc.items()}, out_path)
 
 
@@ -194,7 +218,7 @@ def aggregate_segment_lambdas(
     input_subdir: str = "averaged_ev_correct_sharded",
     output_subdir: str = "eigenvalue_correction_sharded",
 ) -> None:
-    """Sum per-checkpoint lambdas into per-segment lambda."""
+    """Average per-checkpoint lambdas into a per-document segment lambda."""
     logger = get_logger("aggregate_segment_lambdas")
     base_run = Path(run_path)
 
@@ -217,5 +241,6 @@ def aggregate_segment_lambdas(
                     f"Missing per-ckpt lambda dir {d}; did step 3 finish?"
                 )
 
-        logger.info(f"[seg {seg}] summing lambdas -> {out_dir}")
-        sum_sharded_dirs(input_dirs, out_dir, distributed)
+        divisor = lambda_denominator(input_dirs)
+        logger.info(f"[seg {seg}] summing lambdas -> {out_dir} (divisor={divisor:g})")
+        sum_sharded_dirs(input_dirs, out_dir, distributed, divisor=divisor)

--- a/tests/test_source_fisher_normalization.py
+++ b/tests/test_source_fisher_normalization.py
@@ -1,0 +1,44 @@
+"""Segment eigenvalues are normalized per document, matching kronfluence's
+``lambda_matrix.div_(num_lambda_processed)``."""
+
+import pytest
+import torch
+from safetensors.torch import load_file, save_file
+
+from bergson.approx_unrolling.segment_aggregation import (
+    DOCUMENTS_PROCESSED_FILENAME,
+    _sum_my_shard,
+    lambda_denominator,
+)
+
+DOCS = 4599
+
+
+def test_denominator_pools_over_checkpoints(tmp_path):
+    dirs = []
+    for i in range(2):
+        d = tmp_path / f"ckpt_{i}"
+        d.mkdir()
+        torch.save(torch.tensor(DOCS), d / DOCUMENTS_PROCESSED_FILENAME)
+        dirs.append(d)
+    assert lambda_denominator(dirs) == 2 * DOCS
+
+
+def test_denominator_reports_missing_counts(tmp_path):
+    d = tmp_path / "ckpt_0"
+    d.mkdir()
+    with pytest.raises(FileNotFoundError, match="lambda step"):
+        lambda_denominator([d])
+
+
+def test_sum_my_shard_divides(tmp_path):
+    ins = []
+    for i in range(2):
+        p = tmp_path / f"in_{i}.safetensors"
+        save_file({"w": torch.full((2, 3), float(i + 1))}, p)
+        ins.append(p)
+
+    out = tmp_path / "out.safetensors"
+    _sum_my_shard(ins, out, device="cpu", divisor=6.0)
+    # (1 + 2) / 6
+    assert torch.allclose(load_file(out)["w"], torch.full((2, 3), 0.5))


### PR DESCRIPTION
Segment eigenvalues were unnormalized sums over documents x checkpoints. EK-FAC is unaffected (damping is relative to mean(lambda)), but SOURCE's eigenfunctions are not scale-invariant, so we need this for Adam SOURCE merge.