### PR TITLE
fix: call save_second_moments_as_optimizer_pt from every rank

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -264,7 +264,9 @@ def worker(
         ),
         save_interval=run_cfg.save_interval,
     )
-    if getattr(run_cfg, "save_optimizer_state", "none") != "none" and global_rank == 0:
+    # Called on every rank: FSDP moments are DTensors whose gather is a
+    # collective; rank 0 writes inside.
+    if getattr(run_cfg, "save_optimizer_state", "none") != "none":
         save_second_moments_as_optimizer_pt(
             model,  # type: ignore[reportArgumentType]
             fwd_state.opt_state,


### PR DESCRIPTION
Gathering FSDP's sharded (DTensor) moments is a collective, so gating the call on `global_rank == 0` hangs non-zero ranks. The function already restricts the file write to rank 0 internally.