### PR TITLE
feat: auto-export trainer DCP checkpoints in the SOURCE pipeline

### DIFF
--- a/bergson/approx_unrolling/approx_unrolling_math.py
+++ b/bergson/approx_unrolling/approx_unrolling_math.py
@@ -24,7 +24,8 @@ from bergson.hessians.apply_hessian import EkfacApplicator, EkfacConfig
 from bergson.score.score import score_dataset
 from bergson.score.score_writer import save_sequence_scores, save_token_scores
 
-from .trainer_run import LR_HISTORY_FILENAME, lr_history_path
+from ..magic.trainer import LR_HISTORY_FILENAME
+from .train_cfg_io import lr_history_path
 
 
 def _checkpoint_step(p: str) -> int:

--- a/bergson/approx_unrolling/pipeline.py
+++ b/bergson/approx_unrolling/pipeline.py
@@ -52,7 +52,7 @@ from .segment_aggregation import (
     aggregate_segment_covariances,
     aggregate_segment_lambdas,
 )
-from .trainer_run import resolve
+from .train_cfg_io import resolve
 
 # Total number of steps in the full approximate unrolling pipeline. Used only for the
 # user-facing "Step k/N_TOTAL_STEPS:" prefix. Bump as steps land.

--- a/bergson/approx_unrolling/train_cfg_io.py
+++ b/bergson/approx_unrolling/train_cfg_io.py
@@ -1,42 +1,17 @@
 """Fill in unset SOURCE configuration from a bergson run's ``config.yaml``
 if present."""
 
-import json
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import yaml
 
 from ..config.config import ApproxUnrollingConfig, TrainingConfig
 from ..config.config_io import CONFIG_FILENAME
+from ..magic.trainer import LR_HISTORY_FILENAME
 from ..utils.logger import get_logger
 
-EXPORT_DIRNAME = "exported"
-"""Where export_checkpoints puts ``checkpoint-<N>`` dirs by default, and so the
-first place discovery looks."""
-
-LR_HISTORY_FILENAME = "log_history.json"
-"""Per-step LRs in HF's ``log_history`` shape, written beside a run's
-checkpoints -- the path the LR math already checks first."""
-
 logger = get_logger(__name__)
-
-
-def write_lr_history(
-    save_dir: str | Path, schedule: Callable[[int], float], num_steps: int
-) -> Path:
-    """Record per-step LRs beside the checkpoints, from the ``schedule`` the
-    optimizer was built with, so it is exact rather than reconstructed."""
-    save_dir = Path(save_dir)
-    save_dir.mkdir(parents=True, exist_ok=True)
-    history = [
-        {"step": step, "learning_rate": float(schedule(step))}
-        for step in range(num_steps)
-    ]
-    path = save_dir / LR_HISTORY_FILENAME
-    with open(path, "w") as f:
-        json.dump(history, f)
-    return path
 
 
 def load_training_config(trainer_run: str | Path) -> TrainingConfig:
@@ -95,42 +70,6 @@ def derive_momentum(training_cfg: TrainingConfig) -> float:
             return 0.0
 
 
-def _ensure_exported(checkpoints: list[str]) -> list[str]:
-    """Convert any raw DCP ``step_<n>.ckpt`` paths to the HF ``checkpoint-<n>``
-    dirs SOURCE loads with from_pretrained, exporting on demand.
-
-    A trainer checkpoint lives at ``<run>/checkpoints/step_<n>.ckpt`` and exports
-    to ``<run>/exported/checkpoint-<n>``. Already-exported steps are reused, so
-    this is idempotent across re-runs. Non-DCP paths (HF ids, exported dirs) pass
-    through untouched.
-    """
-    # Import here: trainer_export imports this module, so a top-level import
-    # would be circular.
-    from ..utils.trainer_export import export_checkpoints
-
-    resolved = list(checkpoints)
-    # Group the DCP paths by their run so each run exports in a single pass
-    # (export_checkpoints rebuilds the model once per call).
-    todo: dict[Path, list[tuple[int, int]]] = {}
-    for i, c in enumerate(checkpoints):
-        p = Path(c)
-        if not p.name.endswith(".ckpt"):
-            continue
-        step = int(p.name.removesuffix(".ckpt").removeprefix("step_"))
-        run = p.parent.parent  # <run>/checkpoints/step_<n>.ckpt -> <run>
-        dst = run / EXPORT_DIRNAME / f"checkpoint-{step}"
-        resolved[i] = str(dst)
-        if not dst.exists():
-            todo.setdefault(run, []).append((i, step))
-
-    for run, items in todo.items():
-        steps = sorted({s for _, s in items})
-        logger.info("Auto-exporting %s from %s", steps, run)
-        export_checkpoints(run, steps=steps, overwrite=False)
-
-    return resolved
-
-
 def infer_trainer_run(checkpoints: list[str]) -> str:
     """The bergson run a checkpoint came from, or "" if it did not come from one.
 
@@ -149,9 +88,12 @@ def infer_trainer_run(checkpoints: list[str]) -> str:
 
 
 def resolve(cfg: ApproxUnrollingConfig) -> ApproxUnrollingConfig:
-    """Fill unset fields from ``cfg.trainer_run``. A no-op when it is empty;
+    """Fill unset fields from the training run the checkpoints came from;
     never overwrites a field the caller set."""
-    cfg.checkpoints = _ensure_exported(cfg.checkpoints)
+    # Local import: trainer_export imports load_training_config from here.
+    from ..utils.trainer_export import ensure_exported
+
+    cfg.checkpoints = ensure_exported(cfg.checkpoints)
 
     trainer_run = infer_trainer_run(cfg.checkpoints)
     if not trainer_run:
@@ -163,9 +105,8 @@ def resolve(cfg: ApproxUnrollingConfig) -> ApproxUnrollingConfig:
     try:
         training_cfg = load_training_config(trainer_run)
     except ValueError as e:
-        # A directory with a config.yaml is not necessarily a training run: an
-        # attribution run writes one next to the checkpoints it produced. Infer
-        # nothing from it rather than failing the pipeline.
+        # trainer_run may be a config.yaml for something other than a
+        # training run - infer nothing.
         logger.warning("Ignoring %s as a trainer run: %s", trainer_run, e)
         if cfg.momentum is None:
             cfg.momentum = 0.0

--- a/bergson/approx_unrolling/trainer_run.py
+++ b/bergson/approx_unrolling/trainer_run.py
@@ -95,16 +95,40 @@ def derive_momentum(training_cfg: TrainingConfig) -> float:
             return 0.0
 
 
-def _reject_unexported(checkpoints: list[str]) -> None:
-    """SOURCE loads checkpoints with from_pretrained, so a raw DCP directory
-    would fail deep in the pipeline; say what to do instead."""
-    native = [c for c in checkpoints if Path(c).name.endswith(".ckpt")]
-    if native:
-        raise ValueError(
-            f"{native[:3]} are the trainer's DCP checkpoints, which "
-            "from_pretrained cannot load. Export them first with "
-            "bergson.utils.trainer_export.export_checkpoints(run_path)."
-        )
+def _ensure_exported(checkpoints: list[str]) -> list[str]:
+    """Convert any raw DCP ``step_<n>.ckpt`` paths to the HF ``checkpoint-<n>``
+    dirs SOURCE loads with from_pretrained, exporting on demand.
+
+    A trainer checkpoint lives at ``<run>/checkpoints/step_<n>.ckpt`` and exports
+    to ``<run>/exported/checkpoint-<n>``. Already-exported steps are reused, so
+    this is idempotent across re-runs. Non-DCP paths (HF ids, exported dirs) pass
+    through untouched.
+    """
+    # Import here: trainer_export imports this module, so a top-level import
+    # would be circular.
+    from ..utils.trainer_export import export_checkpoints
+
+    resolved = list(checkpoints)
+    # Group the DCP paths by their run so each run exports in a single pass
+    # (export_checkpoints rebuilds the model once per call).
+    todo: dict[Path, list[tuple[int, int]]] = {}
+    for i, c in enumerate(checkpoints):
+        p = Path(c)
+        if not p.name.endswith(".ckpt"):
+            continue
+        step = int(p.name.removesuffix(".ckpt").removeprefix("step_"))
+        run = p.parent.parent  # <run>/checkpoints/step_<n>.ckpt -> <run>
+        dst = run / EXPORT_DIRNAME / f"checkpoint-{step}"
+        resolved[i] = str(dst)
+        if not dst.exists():
+            todo.setdefault(run, []).append((i, step))
+
+    for run, items in todo.items():
+        steps = sorted({s for _, s in items})
+        logger.info("Auto-exporting %s from %s", steps, run)
+        export_checkpoints(run, steps=steps, overwrite=False)
+
+    return resolved
 
 
 def infer_trainer_run(checkpoints: list[str]) -> str:
@@ -127,7 +151,7 @@ def infer_trainer_run(checkpoints: list[str]) -> str:
 def resolve(cfg: ApproxUnrollingConfig) -> ApproxUnrollingConfig:
     """Fill unset fields from ``cfg.trainer_run``. A no-op when it is empty;
     never overwrites a field the caller set."""
-    _reject_unexported(cfg.checkpoints)
+    cfg.checkpoints = _ensure_exported(cfg.checkpoints)
 
     trainer_run = infer_trainer_run(cfg.checkpoints)
     if not trainer_run:
@@ -136,7 +160,17 @@ def resolve(cfg: ApproxUnrollingConfig) -> ApproxUnrollingConfig:
             cfg.momentum = 0.0
         return cfg
 
-    training_cfg = load_training_config(trainer_run)
+    try:
+        training_cfg = load_training_config(trainer_run)
+    except ValueError as e:
+        # A directory with a config.yaml is not necessarily a training run: an
+        # attribution run writes one next to the checkpoints it produced. Infer
+        # nothing from it rather than failing the pipeline.
+        logger.warning("Ignoring %s as a trainer run: %s", trainer_run, e)
+        if cfg.momentum is None:
+            cfg.momentum = 0.0
+        return cfg
+
     filled: list[str] = []
 
     if cfg.model_path is None:

--- a/bergson/approx_unrolling/trainer_run.py
+++ b/bergson/approx_unrolling/trainer_run.py
@@ -40,8 +40,10 @@ def write_lr_history(
 
 
 def load_training_config(trainer_run: str | Path) -> TrainingConfig:
-    """Load the ``TrainingConfig`` a run was launched with. ``save_run_config``
-    writes ``{command_name: {...}}``, so the single value is the config."""
+    """Load the ``TrainingConfig`` a run was launched with.
+
+    ``save_run_config`` writes ``{steps: [{command_name: {...}}], metadata: ...}``,
+    so the training config is the first step's single value."""
     path = Path(trainer_run) / CONFIG_FILENAME
     if not path.is_file():
         raise FileNotFoundError(
@@ -50,9 +52,11 @@ def load_training_config(trainer_run: str | Path) -> TrainingConfig:
         )
 
     with open(path) as f:
-        loaded = yaml.safe_load(f)
+        loaded: Any = yaml.safe_load(f)
 
-    # One-step configs are a list of {command: payload}; take the first payload.
+    if isinstance(loaded, dict) and "steps" in loaded:
+        loaded = loaded["steps"]
+    # Steps are a list of {command: payload}; take the first payload.
     if isinstance(loaded, list):
         if not loaded:
             raise ValueError(f"{path} is empty")
@@ -64,7 +68,12 @@ def load_training_config(trainer_run: str | Path) -> TrainingConfig:
     if not isinstance(payload, dict):
         raise ValueError(f"{path} is not a bergson run config")
 
-    return TrainingConfig.from_dict(payload, drop_extra_fields=True)
+    try:
+        return TrainingConfig.from_dict(payload, drop_extra_fields=True)
+    except Exception as e:
+        # An attribution run's config.yaml has the same shape, so reaching here
+        # is expected; callers that guess at a run dir catch ValueError.
+        raise ValueError(f"{path} is not a bergson training config: {e}") from e
 
 
 def derive_momentum(training_cfg: TrainingConfig) -> float:

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -26,7 +26,6 @@ from transformers.utils.logging import (
     set_verbosity_error as hf_set_verbosity_error,
 )
 
-from ..approx_unrolling.trainer_run import write_lr_history
 from ..config.config import TrainingConfig, ValidationConfig
 from ..config.config_io import save_run_config
 from ..distributed import grad_tree, launch_distributed_run
@@ -39,7 +38,7 @@ from ..utils.worker_utils import setup_data_pipeline
 from ..validate import load_attribution_scores, validate_scores
 from .config import MagicConfig
 from .data_stream import DataStream, pad_dataset_to_batch_size
-from .trainer import BackwardState, TrainerState, prepare_trainer
+from .trainer import BackwardState, TrainerState, prepare_trainer, write_lr_history
 
 
 def compute_query_gradients(

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -1,3 +1,4 @@
+import json
 import math
 import os
 import time
@@ -5,6 +6,7 @@ from collections.abc import Callable
 from concurrent.futures import Future
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from pathlib import Path
 from shutil import rmtree
 from typing import Any, cast
 
@@ -38,6 +40,27 @@ from .grad_accum import (
 from .optim import muon
 from .rtl_tqdm import RtlTqdm
 from .swap import swap_parameters
+
+LR_HISTORY_FILENAME = "log_history.json"
+"""Per-step LRs in HF's ``log_history`` shape, written beside a run's
+checkpoints."""
+
+
+def write_lr_history(
+    save_dir: str | Path, schedule: Callable[[int], float], num_steps: int
+) -> Path:
+    """Record per-step LRs beside the checkpoints, from the ``schedule`` the
+    optimizer was built with."""
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+    history = [
+        {"step": step, "learning_rate": float(schedule(step))}
+        for step in range(num_steps)
+    ]
+    path = save_dir / LR_HISTORY_FILENAME
+    with open(path, "w") as f:
+        json.dump(history, f)
+    return path
 
 
 @contextmanager

--- a/bergson/utils/trainer_export.py
+++ b/bergson/utils/trainer_export.py
@@ -7,10 +7,13 @@ from pathlib import Path
 import torch
 from transformers import AutoTokenizer
 
-from ..approx_unrolling.trainer_run import EXPORT_DIRNAME, load_training_config
+from ..approx_unrolling.train_cfg_io import load_training_config
 from ..config.config import TrainingConfig
 from ..magic.trainer import prepare_trainer
 from .logger import get_logger
+
+EXPORT_DIRNAME = "exported"
+"""Where export_checkpoints puts ``checkpoint-<N>`` dirs by default."""
 
 OPTIMIZER_STATE_FILE = "optimizer.pt"
 """Second moments, written inside the checkpoint dir they belong to -- both by
@@ -108,3 +111,33 @@ def export_checkpoints(
 
     del trainer, state, model
     return exported
+
+
+def ensure_exported(checkpoints: list[str]) -> list[str]:
+    """Convert any raw DCP ``step_<n>.ckpt`` paths to the HF ``checkpoint-<n>``
+    dirs SOURCE loads with from_pretrained, exporting on demand.
+
+    A trainer checkpoint lives at ``<run>/checkpoints/step_<n>.ckpt`` and exports
+    to ``<run>/exported/checkpoint-<n>``. Already-exported steps are reused.
+    """
+    resolved = list(checkpoints)
+    # Group the DCP paths by their run so each run exports in a single pass
+    # (export_checkpoints rebuilds the model once per call).
+    todo: dict[Path, list[tuple[int, int]]] = {}
+    for i, c in enumerate(checkpoints):
+        p = Path(c)
+        if not p.name.endswith(".ckpt"):
+            continue
+        step = int(p.name.removesuffix(".ckpt").removeprefix("step_"))
+        run = p.parent.parent  # <run>/checkpoints/step_<n>.ckpt -> <run>
+        dst = run / EXPORT_DIRNAME / f"checkpoint-{step}"
+        resolved[i] = str(dst)
+        if not dst.exists():
+            todo.setdefault(run, []).append((i, step))
+
+    for run, items in todo.items():
+        steps = sorted({s for _, s in items})
+        logger.info("Auto-exporting %s from %s", steps, run)
+        export_checkpoints(run, steps=steps, overwrite=False)
+
+    return resolved

--- a/tests/test_source_trainer_integration.py
+++ b/tests/test_source_trainer_integration.py
@@ -458,13 +458,30 @@ def test_save_optimizer_state_accepts_old_booleans(value, expected):
     assert cfg.save_optimizer_state == expected
 
 
-def test_dcp_checkpoints_are_rejected_with_the_export_hint(tmp_path):
-    """Passing raw step_<i>.ckpt dirs should fail early, not inside the pipeline."""
-    ckpt = tmp_path / "checkpoints" / "step_0.ckpt"
-    ckpt.mkdir(parents=True)
+def test_dcp_checkpoints_resolve_to_exported_dirs(tmp_path, monkeypatch):
+    """Raw step_<i>.ckpt paths map to exported/checkpoint-<i>, reusing an
+    existing export and exporting the rest in one call per run."""
+    import bergson.utils.trainer_export as te
 
-    with pytest.raises(ValueError, match="export_checkpoints"):
-        resolve(ApproxUnrollingConfig(checkpoints=[str(ckpt)]))
+    for step in (10, 20):
+        (tmp_path / "checkpoints" / f"step_{step}.ckpt").mkdir(parents=True)
+    (tmp_path / "exported" / "checkpoint-10").mkdir(parents=True)
+
+    calls = []
+    monkeypatch.setattr(
+        te, "export_checkpoints", lambda run, steps=None, **kw: calls.append(steps)
+    )
+    cfg = resolve(
+        ApproxUnrollingConfig(
+            checkpoints=[
+                str(tmp_path / "checkpoints" / f"step_{s}.ckpt") for s in (10, 20)
+            ]
+        )
+    )
+    assert cfg.checkpoints == [
+        str(tmp_path / "exported" / f"checkpoint-{s}") for s in (10, 20)
+    ]
+    assert calls == [[20]]
 
 
 def test_export_checkpoints_end_to_end(tmp_path):
@@ -523,3 +540,20 @@ def test_export_checkpoints_end_to_end(tmp_path):
     out = resolve(ApproxUnrollingConfig(checkpoints=[str(p) for p in exported]))
     assert out.model_path == model_name
     assert out.momentum == 0.0  # adamw
+
+
+def test_resolve_ignores_a_non_training_config(tmp_path):
+    """A checkpoint dir's sibling config.yaml may belong to an attribution run.
+
+    ``infer_trainer_run`` only checks that a config.yaml exists, so ``resolve``
+    has to tolerate one it cannot read as a TrainingConfig.
+    """
+    run = tmp_path / "attribution_run"
+    (run / "models" / "step_1").mkdir(parents=True)
+    (run / "config.yaml").write_text("steps:\n- approxunrolling:\n    index_cfg: {}\n")
+
+    cfg = ApproxUnrollingConfig(checkpoints=[str(run / "models" / "step_1")])
+    resolved = resolve(cfg)
+
+    assert resolved.momentum == 0.0
+    assert resolved.model_path is None

--- a/tests/test_source_trainer_integration.py
+++ b/tests/test_source_trainer_integration.py
@@ -14,15 +14,14 @@ from bergson.approx_unrolling.approx_unrolling_math import (
     _checkpoint_step,
     compute_lr_times_steps_per_segment,
 )
-from bergson.approx_unrolling.trainer_run import (
-    LR_HISTORY_FILENAME,
+from bergson.approx_unrolling.train_cfg_io import (
     derive_momentum,
     load_training_config,
     resolve,
-    write_lr_history,
 )
 from bergson.config.config import ApproxUnrollingConfig, TrainingConfig
 from bergson.config.config_io import save_run_config
+from bergson.magic.trainer import LR_HISTORY_FILENAME, write_lr_history
 
 
 def _run_dir(tmp_path, **overrides):
@@ -417,7 +416,7 @@ def test_trainer_writes_optimizer_state_inside_each_checkpoint(tmp_path):
 
 def test_trainer_run_inferred_from_exported_checkpoints(tmp_path):
     """Setting checkpoints is enough; the run is found from their path."""
-    from bergson.approx_unrolling.trainer_run import EXPORT_DIRNAME
+    from bergson.utils.trainer_export import EXPORT_DIRNAME
 
     run = _run_dir(tmp_path, optimizer="sgd", adam_beta1=0.9, model="gpt2")
     ckpt = run / EXPORT_DIRNAME / "checkpoint-3"
@@ -492,11 +491,11 @@ def test_export_checkpoints_end_to_end(tmp_path):
     from datasets import Dataset
     from transformers import AutoConfig, AutoModelForCausalLM
 
-    from bergson.approx_unrolling.trainer_run import EXPORT_DIRNAME
     from bergson.magic.data_stream import DataStream
     from bergson.magic.trainer import Trainer
     from bergson.utils.load_from_optimizer import load_optimizer
     from bergson.utils.trainer_export import (
+        EXPORT_DIRNAME,
         OPTIMIZER_STATE_FILE,
         export_checkpoints,
     )

--- a/tests/test_source_trainer_integration.py
+++ b/tests/test_source_trainer_integration.py
@@ -22,13 +22,15 @@ from bergson.approx_unrolling.trainer_run import (
     write_lr_history,
 )
 from bergson.config.config import ApproxUnrollingConfig, TrainingConfig
+from bergson.config.config_io import save_run_config
 
 
 def _run_dir(tmp_path, **overrides):
-    """A bergson run directory with a config.yaml, as save_run_config writes it."""
-    cfg = TrainingConfig(run_path=str(tmp_path), **overrides)
-    payload = {"magic": cfg.to_dict()}
-    (tmp_path / "config.yaml").write_text(yaml.safe_dump([payload]))
+    """A bergson run directory with a config.yaml.
+
+    Written by ``save_run_config`` itself so the loader is pinned against the
+    real on-disk shape rather than a hand-rolled approximation of it."""
+    save_run_config(TrainingConfig(run_path=str(tmp_path), **overrides), tmp_path)
     return tmp_path
 
 
@@ -135,6 +137,23 @@ def test_explicit_model_path_wins(tmp_path):
 def test_missing_config_yaml_is_explained(tmp_path):
     with pytest.raises(FileNotFoundError, match="bergson run directory"):
         load_training_config(tmp_path)
+
+
+def test_load_reads_the_saved_steps_document(tmp_path):
+    """save_run_config wraps the step list in {steps, metadata}."""
+    _run_dir(tmp_path, optimizer="adamw", adam_beta2=0.98)
+
+    doc = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert set(doc) == {"steps", "metadata"}
+    assert load_training_config(tmp_path).adam_beta2 == pytest.approx(0.98)
+
+
+def test_load_still_reads_a_bare_step_list(tmp_path):
+    """Runs saved before the {steps, metadata} wrapper stay readable."""
+    cfg = TrainingConfig(run_path=str(tmp_path), optimizer="sgd", adam_beta1=0.8)
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump([{"magic": cfg.to_dict()}]))
+
+    assert load_training_config(tmp_path).adam_beta1 == pytest.approx(0.8)
 
 
 # ── LR history ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
`resolve()` automatically converts raw `checkpoints/step_<n>.ckpt` paths to the HF `exported/checkpoint-<n>` dirs `from_pretrained` needs. 

Includes two dependent/parent config-reading fixes: 
- `load_training_config` reads the `{steps, metadata}` document the pipeline writes.
- `resolve()` doesn't crash when it finds a `config.yaml` that doesn't contain the config class it's seeking to optionally fill in unset config values