### PR TITLE
feat: Adam SOURCE preconditioner and Eq-43 hybrid

### DIFF
--- a/bergson/approx_unrolling/adam_preconditioner.py
+++ b/bergson/approx_unrolling/adam_preconditioner.py
@@ -1,0 +1,187 @@
+"""Per-segment Adam/AdamW diagonal preconditioners for the preconditioned
+SOURCE (approx-unrolling) variant.
+
+:func:`build_segment_preconditioners` reads each checkpoint dir's
+``optimizer.pt``,
+bias-corrects the second moments, averages them within each segment as the
+K-FAC factors are, and writes
+
+    P = 1 / (sqrt(v_hat_bar + eps_root) + eps)
+
+to ``<run>/segment_<l>/preconditioner.safetensors``, oriented to bergson's
+``[out, in]`` gradient grids.
+"""
+
+from glob import glob
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from ..utils.load_from_optimizer import (
+    get_unfactored_second_moment,
+    load_optimizer,
+    optimizer_param_index_to_name,
+    orient_second_moment,
+)
+from ..utils.trainer_export import OPTIMIZER_STATE_FILE  # noqa: E402
+
+
+def _module_grids(hessian_dir: str | Path) -> dict[str, tuple[int, int]]:
+    """Module name -> full [out, in] grid shape, read from the factor shards.
+
+    The activation eigenvectors are ``[c_i, I]`` (columns = full in-dim) and
+    the gradient eigenvectors ``[c_o, O]``, so shard_0's column counts give
+    the full grid shape regardless of world size.
+    """
+    grids: dict[str, tuple[int, int]] = {}
+    a_dir = Path(hessian_dir) / "eigen_activation_sharded"
+    g_dir = Path(hessian_dir) / "eigen_gradient_sharded"
+    if not a_dir.is_dir() or not glob(str(g_dir / "shard_*.safetensors")):
+        raise FileNotFoundError(f"No EKFAC factor shards under {hessian_dir}")
+    with (
+        safe_open(str(a_dir / "shard_0.safetensors"), framework="pt") as fa,
+        safe_open(str(g_dir / "shard_0.safetensors"), framework="pt") as fg,
+    ):
+        for name in fa.keys():
+            in_dim = fa.get_slice(name).get_shape()[1]
+            out_dim = fg.get_slice(name).get_shape()[1]
+            grids[name] = (out_dim, in_dim)
+    return grids
+
+
+def _match_params(
+    grids: dict[str, tuple[int, int]], param_names: list[str]
+) -> dict[str, str]:
+    """Factor module name -> param name. Factor names are suffixes of the
+    model's param names (e.g. ``h.0.attn.c_attn`` ->
+    ``transformer.h.0.attn.c_attn.weight``)."""
+    matches: dict[str, str] = {}
+    for module in grids:
+        suffix = f"{module}.weight"
+        candidates = [n for n in param_names if n == suffix or n.endswith(f".{suffix}")]
+        if len(candidates) != 1:
+            raise KeyError(
+                f"Module {module!r} matched {len(candidates)} params "
+                f"({candidates}); expected exactly one *.{suffix}."
+            )
+        matches[module] = candidates[0]
+    return matches
+
+
+def _orient(p: torch.Tensor, grid: tuple[int, int], module: str, layer) -> torch.Tensor:
+    """Orient a param-shaped grid to bergson's [out, in] layout, raising on a
+    shape that fits neither orientation."""
+    oriented = orient_second_moment(p, *grid, layer=layer)
+    if oriented is None:
+        raise ValueError(
+            f"Second moments for {module!r} have shape {tuple(p.shape)}; "
+            f"expected {grid} or its transpose."
+        )
+    return oriented
+
+
+def _adam_hparams(optimizer_pt: dict) -> tuple[float, float, float]:
+    """(beta2, eps, eps_root) from a standard ``optimizer.pt``'s param_groups.
+
+    ``betas`` and ``eps`` are standard AdamW param-group keys (HF Trainer
+    checkpoints carry them); ``eps_root`` is torchopt-specific and defaults
+    to 0 (standard AdamW has no epsilon inside the sqrt)."""
+    groups = optimizer_pt.get("param_groups", [])
+    betas = groups[0].get("betas") if groups else None
+    eps = groups[0].get("eps") if groups else None
+    if betas is None or eps is None:
+        raise ValueError(
+            "optimizer.pt has no param_groups betas/eps; regenerate the "
+            "snapshot exports with TrainingConfig.save_optimizer_state "
+            "(older exports lack the hyperparameters needed to build the "
+            "preconditioner)."
+        )
+    return float(betas[1]), float(eps), float(groups[0].get("eps_root", 0.0))
+
+
+def _extract_v_hat(
+    optimizer_pt: dict, index_to_name: dict[int, str], beta2: float
+) -> dict[str, torch.Tensor]:
+    """Bias-corrected second moments keyed by param name from a standard
+    ``optimizer.pt`` dict carrying a per-entry ``step``."""
+
+    v_hat: dict[str, torch.Tensor] = {}
+    for idx, entry in optimizer_pt["state"].items():
+        idx = int(idx)
+        # Prefer the recorded param_name: positional indices written from an
+        # FSDP-wrapped model do not match a fresh model's enumeration.
+        name = entry.get("param_name") or index_to_name.get(idx)
+        if name is None:
+            continue
+        if "step" not in entry:
+            raise ValueError(
+                f"optimizer.pt state entry {idx} has no step; regenerate the "
+                "snapshot exports with TrainingConfig.save_optimizer_state."
+            )
+        step = int(
+            entry["step"].item() if torch.is_tensor(entry["step"]) else entry["step"]
+        )
+        nu = get_unfactored_second_moment(entry).to(torch.float32)
+        v_hat[name] = nu / (1.0 - beta2**step) if step > 0 else torch.zeros_like(nu)
+    return v_hat
+
+
+def build_segment_preconditioners(
+    run_path: str | Path,
+    method: str,
+    checkpoints: list[str],
+    segments: int,
+) -> list[Path]:
+    """Build ``<run>/segment_<l>/preconditioner.safetensors`` for every
+    segment from the checkpoints' ``optimizer.pt`` files; see module docs.
+    The Adam hyperparameters (betas/eps/eps_root) are read from the files.
+
+    Returns the per-segment preconditioner paths.
+    """
+    base = Path(run_path)
+    per_segment = len(checkpoints) // segments
+    # For the optimizer.pt index mapping (used when entries carry no
+    # param_name, e.g. HF Trainer checkpoints).
+    config = AutoConfig.from_pretrained(checkpoints[0])
+    reference_model = AutoModelForCausalLM.from_config(config)
+    out_paths: list[Path] = []
+    for seg in range(segments):
+        seg_ckpts = checkpoints[seg * per_segment : (seg + 1) * per_segment]
+        v_hat_sum: dict[str, torch.Tensor] = {}
+        eps = eps_root = 0.0
+        for ckpt in seg_ckpts:
+            if not (Path(ckpt) / OPTIMIZER_STATE_FILE).exists():
+                raise FileNotFoundError(
+                    f"use_adam_preconditioner requires "
+                    f"{Path(ckpt) / OPTIMIZER_STATE_FILE}; write it during "
+                    "training with TrainingConfig.save_optimizer_state."
+                )
+            optimizer_pt = load_optimizer(str(ckpt))
+            beta2, eps, eps_root = _adam_hparams(optimizer_pt)
+            index_to_name = optimizer_param_index_to_name(optimizer_pt, reference_model)
+            for name, v_hat in _extract_v_hat(
+                optimizer_pt, index_to_name, beta2
+            ).items():
+                v_hat_sum[name] = v_hat_sum.get(name, 0) + v_hat
+
+        grids = _module_grids(base / f"segment_{seg}" / method)
+        matches = _match_params(grids, list(v_hat_sum))
+        preconditioner = {}
+        for module, param_name in matches.items():
+            try:
+                layer = reference_model.get_submodule(
+                    param_name.removesuffix(".weight")
+                )
+            except AttributeError:
+                layer = None
+            v_hat_bar = v_hat_sum[param_name] / len(seg_ckpts)
+            p = 1.0 / ((v_hat_bar + eps_root).sqrt() + eps)
+            preconditioner[module] = _orient(p, grids[module], module, layer)
+
+        out_path = base / f"segment_{seg}" / "preconditioner.safetensors"
+        save_file(preconditioner, str(out_path))
+        out_paths.append(out_path)
+    return out_paths

--- a/bergson/approx_unrolling/approx_unrolling_math.py
+++ b/bergson/approx_unrolling/approx_unrolling_math.py
@@ -14,6 +14,7 @@ from bergson.config.config import (
     ApproxUnrollingConfig,
     DistributedConfig,
     IndexConfig,
+    InversionConfig,
     PreprocessConfig,
     ScoreConfig,
 )
@@ -71,7 +72,6 @@ def compute_lr_times_steps_per_segment(
     if not 0.0 <= momentum < 1.0:
         raise ValueError(f"momentum must be in [0, 1), got {momentum}.")
     momentum_scale = 1.0 / (1.0 - momentum)
-
     if cfg.lr_list and cfg.step_size_list:
         return [
             lr * k * momentum_scale for lr, k in zip(cfg.lr_list, cfg.step_size_list)
@@ -130,6 +130,19 @@ def f_segment(lr_times_steps: float) -> Callable[[Tensor], Tensor]:
     return fn
 
 
+def f_one_minus_exp(lr_times_steps: float) -> Callable[[Tensor], Tensor]:
+    """x -> 1 - exp(-lr_times_steps*x), the numerator of :func:`f_segment`.
+
+    Used by the Eq-43 hybrid: the 1/x that completes f_segment is supplied by
+    the EK-FAC inverse applied afterwards rather than evaluated on the diagonal.
+    """
+
+    def fn(sigma: Tensor) -> Tensor:
+        return -torch.expm1(-lr_times_steps * sigma)
+
+    return fn
+
+
 def apply_eigfn_to_query(
     src_grad_path: Path,
     dst_grad_path: Path,
@@ -137,23 +150,29 @@ def apply_eigfn_to_query(
     lr_times_steps: float,
     fn_kind: str,
     distributed: DistributedConfig,
+    preconditioner_path: str = "",
+    inversion_cfg: InversionConfig | None = None,
 ) -> None:
     """Apply F_segment or F_backward of one segment to a stored query gradient.
 
-    ``fn_kind`` is "f_segment" or "f_backward". The segment eigenvalues are
-    already checkpoint-averaged (expected eigenvalues), so the eigenfunction is
-    applied to them directly.
-    """
+    ``preconditioner_path`` selects the optimizer-preconditioned variant."""
     cfg = EkfacConfig(
         hessian_method_path=str(segment_dir),
         gradient_path=str(src_grad_path),
         run_path=str(dst_grad_path),
         ev_correction=True,
+        preconditioner_path=preconditioner_path,
     )
     launch_distributed_run(
         "apply_eigfn_to_query",
         _apply_eigfn_worker,
-        [cfg, lr_times_steps, fn_kind],
+        # F_segment is the Eq-43 hybrid: diagonal exponential, EK-FAC H^-1.
+        [
+            cfg,
+            lr_times_steps,
+            fn_kind,
+            inversion_cfg if fn_kind == "f_segment" else None,
+        ],
         distributed,
     )
 
@@ -165,13 +184,21 @@ def _apply_eigfn_worker(
     cfg: EkfacConfig,
     lr_times_steps: float,
     fn_kind: str,
+    inversion_cfg: InversionConfig | None,
 ) -> None:
     init_dist(rank, local_rank, world_size)
 
     # Segment eigenvalues are already checkpoint-averaged, so the eigenfunction
     # is applied to them directly (no per-example normalization).
-    fn = {"f_segment": f_segment, "f_backward": f_backward}[fn_kind](lr_times_steps)
-    EkfacApplicator(cfg, apply_fn=fn).compute_ivhp_sharded()
+    if cfg.preconditioner_path and inversion_cfg is not None:
+        # The EK-FAC inverse applied afterwards supplies the 1/x, so
+        # multiply by the numerator only.
+        fn = f_one_minus_exp(lr_times_steps)
+    else:
+        fn = {"f_segment": f_segment, "f_backward": f_backward}[fn_kind](lr_times_steps)
+    EkfacApplicator(
+        cfg, inversion_cfg=inversion_cfg, apply_fn=fn
+    ).compute_ivhp_sharded()
 
 
 def walk_query_phase1(
@@ -179,6 +206,8 @@ def walk_query_phase1(
     method: str,
     lr_times_steps_per_segment: list[float],
     distributed: DistributedConfig,
+    preconditioner_paths: list[str] | None = None,
+    inversion_cfg: InversionConfig | None = None,
 ) -> list[Path]:
     """Phase 1: build query_grad_0, ..., query_grad_{L-1} by walking F_backward.
 
@@ -204,6 +233,7 @@ def walk_query_phase1(
             lr_times_steps=lr_times_steps_per_segment[k],
             fn_kind="f_backward",
             distributed=distributed,
+            preconditioner_path=preconditioner_paths[k] if preconditioner_paths else "",
         )
         query_grad_paths[k - 1] = dst
 
@@ -216,6 +246,8 @@ def walk_query_phase2(
     lr_times_steps_per_segment: list[float],
     query_grad_paths: list[Path],
     distributed: DistributedConfig,
+    preconditioner_paths: list[str] | None = None,
+    inversion_cfg: InversionConfig | None = None,
 ) -> list[Path]:
     """Phase 2: build query_grad_segment_0, ..., query_grad_segment_{L-1} via F_segment.
 
@@ -239,6 +271,7 @@ def walk_query_phase2(
             lr_times_steps=lr_times_steps_per_segment[l],
             fn_kind="f_segment",
             distributed=distributed,
+            preconditioner_path=preconditioner_paths[l] if preconditioner_paths else "",
         )
         query_grad_segment_paths.append(dst)
 

--- a/bergson/approx_unrolling/pipeline.py
+++ b/bergson/approx_unrolling/pipeline.py
@@ -37,7 +37,12 @@ from ..config import (
     PreprocessConfig,
 )
 from ..config.config_io import save_run_config
+from ..distributed import parent_barrier
 from ..utils.logger import get_logger
+from .adam_preconditioner import (
+    OPTIMIZER_STATE_FILE,
+    build_segment_preconditioners,
+)
 from .approx_unrolling_math import (
     compute_lr_times_steps_per_segment,
     score_per_segment_and_aggregate,
@@ -103,6 +108,15 @@ def approx_unrolling_pipeline(
 
     assert hessian_cfg.ev_correction, "Approximate unrolling pipeline currently only "
     "supports EV correction on."
+
+    if approx_unrolling_cfg.use_adam_preconditioner:
+        for ckpt in approx_unrolling_cfg.checkpoints:
+            state_path = Path(ckpt) / OPTIMIZER_STATE_FILE
+            if not state_path.exists():
+                raise FileNotFoundError(
+                    f"use_adam_preconditioner requires {state_path}; write it "
+                    "during training with TrainingConfig.save_optimizer_state."
+                )
 
     lr_times_steps_per_segment = compute_lr_times_steps_per_segment(
         approx_unrolling_cfg
@@ -197,6 +211,24 @@ def approx_unrolling_pipeline(
         )
         build(query_cfg, query_preprocess_cfg)
 
+    # Per-segment Adam preconditioners from the checkpoints' second moments
+    preconditioner_paths: list[Path] = []
+    if approx_unrolling_cfg.use_adam_preconditioner:
+        logger.info("Building per-segment Adam preconditioners...")
+        if index_cfg.distributed._node_rank == 0:
+            preconditioner_paths = build_segment_preconditioners(
+                run_path=index_cfg.run_path,
+                method=hessian_cfg.method,
+                checkpoints=[str(c) for c in approx_unrolling_cfg.checkpoints],
+                segments=n_segments,
+            )
+        else:
+            preconditioner_paths = [
+                Path(index_cfg.run_path) / f"segment_{l}" / "preconditioner.safetensors"
+                for l in range(n_segments)
+            ]
+        parent_barrier(index_cfg.distributed)
+
     # ── Step 6: Phase 1 -- walk query backwards to get segment queries
     logger.info(
         f"Step 6/{_N_TOTAL_STEPS}: "
@@ -204,11 +236,22 @@ def approx_unrolling_pipeline(
         f"query_grad_0..query_grad_(L-1)..."
     )
     logger.info(f"  lr_times_steps per segment: {lr_times_steps_per_segment}")
+    logger.info(
+        f"  optimizer variant         : "
+        f"{'preconditioned (Adam/AdamW)' if preconditioner_paths else 'sgd'}"
+        + (
+            f", momentum={approx_unrolling_cfg.momentum}"
+            if approx_unrolling_cfg.momentum
+            else ""
+        )
+    )
     query_grad_paths = walk_query_phase1(
         run_path=index_cfg.run_path,
         method=hessian_cfg.method,
         lr_times_steps_per_segment=lr_times_steps_per_segment,
         distributed=index_cfg.distributed,
+        preconditioner_paths=[str(p) for p in preconditioner_paths] or None,
+        inversion_cfg=approx_unrolling_cfg.inversion_cfg,
     )
 
     # ── Step 7: Phase 2 -- Get per-ckpt queries from segment queries
@@ -223,6 +266,8 @@ def approx_unrolling_pipeline(
         lr_times_steps_per_segment=lr_times_steps_per_segment,
         query_grad_paths=query_grad_paths,
         distributed=index_cfg.distributed,
+        preconditioner_paths=[str(p) for p in preconditioner_paths] or None,
+        inversion_cfg=approx_unrolling_cfg.inversion_cfg,
     )
 
     # ── Step 8: Phase 3 -- per-segment scoring + sum

--- a/bergson/approx_unrolling/train_cfg_io.py
+++ b/bergson/approx_unrolling/train_cfg_io.py
@@ -112,6 +112,13 @@ def resolve(cfg: ApproxUnrollingConfig) -> ApproxUnrollingConfig:
             cfg.momentum = 0.0
         return cfg
 
+    if training_cfg.optimizer == "adamw" and not cfg.use_adam_preconditioner:
+        logger.warning(
+            "%s trained with adamw but use_adam_preconditioner is not set; "
+            "scores will use the SGD variant.",
+            trainer_run,
+        )
+
     filled: list[str] = []
 
     if cfg.model_path is None:

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -817,6 +817,15 @@ class ApproxUnrollingConfig(Serializable):
     2024, App. D.2). When ``None`` it's derived from the run if present or set
     to 0.0."""
 
+    use_adam_preconditioner: bool = False
+    """Optimizer-preconditioned SOURCE (Bae et al. 2024, App. C): set when the
+    run was trained with Adam/AdamW. Needs each checkpoint dir's
+    ``optimizer.pt``."""
+
+    inversion_cfg: InversionConfig = field(default_factory=InversionConfig)
+    """Inversion for the Adam SOURCE variant's EK-FAC inverse - the SGD
+    variant has no inversion."""
+
     query: DataConfig = field(default_factory=DataConfig)
     """Query dataset spec; gradients computed at the final checkpoint."""
 

--- a/bergson/hessians/apply_hessian.py
+++ b/bergson/hessians/apply_hessian.py
@@ -14,7 +14,10 @@ from bergson.collector.collector import create_projection_matrix
 from bergson.config import InversionConfig
 from bergson.data import column_offsets, create_index, load_gradients
 from bergson.distributed import init_dist
-from bergson.hessians.preconditioner import FactoredPreconditioner
+from bergson.hessians.preconditioner import (
+    DiagonalFactoredPreconditioner,
+    FactoredPreconditioner,
+)
 from bergson.utils.logger import get_logger
 from bergson.utils.utils import get_device, numpy_to_tensor
 
@@ -34,9 +37,11 @@ class EkfacConfig:
     """When set, compress each module's IVHP output to a ``[p, p]`` Kronecker
     random projection (``P_S @ (H^-1 G) @ P_A^T``)."""
     projection_type: Literal["normal", "rademacher"] = "rademacher"
-
     projection_scale: Literal["jl", "row_norm"] = "jl"
     """Must match the index being scored. See ``IndexConfig``."""
+    preconditioner_path: str = ""
+    """Safetensors of a diagonal optimizer preconditioner (module name ->
+    [out, in] grid), for the Adam SOURCE variant."""
     debug: bool = False
 
 
@@ -49,7 +54,9 @@ class EkfacApplicator:
     gradients from the mmap into memory, applies the preconditioner, and
     writes the transformed gradients to ``run_path``. The low-level logic lives in the
     preconditioner. Pass ``inversion_cfg`` for a standard inversion, or ``apply_fn``
-    for a custom eigenvalue function (e.g. approximate unrolling) — not both.
+    for a custom eigenvalue function (e.g. approximate unrolling). Both only with
+    ``preconditioner_path``, where the EK-FAC inverse from ``inversion_cfg`` is
+    applied after ``apply_fn``'s elementwise multiplier.
     """
 
     def __init__(
@@ -58,7 +65,11 @@ class EkfacApplicator:
         inversion_cfg: InversionConfig | None = None,
         apply_fn=None,
     ):
-        if inversion_cfg is not None and apply_fn is not None:
+        if (
+            inversion_cfg is not None
+            and apply_fn is not None
+            and not cfg.preconditioner_path
+        ):
             raise ValueError("Pass either inversion_cfg or apply_fn, not both.")
 
         if cfg.projection_dim > 0 and cfg.ev_correction:
@@ -84,14 +95,46 @@ class EkfacApplicator:
         self.device = get_device(self.rank)
 
     def compute_ivhp_sharded(self):
-        preconditioner = FactoredPreconditioner.from_shards(
-            self.path,
-            rank=self.rank,
-            device=self.device,
-            inversion_cfg=None if self.apply_fn is not None else self.inversion_cfg,
-            apply_fn=self.apply_fn,
-            ev_correction=self.cfg.ev_correction,
-        )
+        chain: list = []
+        if self.cfg.preconditioner_path:
+            if self.apply_fn is None:
+                raise ValueError("preconditioner_path requires apply_fn.")
+            diagonal = DiagonalFactoredPreconditioner.from_shards(
+                self.path,
+                self.cfg.preconditioner_path,
+                rank=self.rank,
+                device=self.device,
+                apply_fn=self.apply_fn,
+                ev_correction=self.cfg.ev_correction,
+            )
+            if self.inversion_cfg is not None:
+                # Bae et al. App. D: "use the diagonal Hessian approximation for
+                # computing the matrix exponential ... Note that we still use the
+                # EK-FAC factors to compute H^-1 g in Equation 43."
+                # Eq-43 reads M_mask @ H^-1 @ g_train; applied to the QUERY
+                # gradient that is the adjoint H^-1 @ M_mask @ q, so the
+                # diagonal mask goes first and the EK-FAC inverse second.
+                chain.append(diagonal)
+                preconditioner = FactoredPreconditioner.from_shards(
+                    self.path,
+                    rank=self.rank,
+                    device=self.device,
+                    inversion_cfg=self.inversion_cfg or InversionConfig(),
+                    ev_correction=self.cfg.ev_correction,
+                )
+            else:
+                preconditioner = diagonal
+        else:
+            preconditioner = FactoredPreconditioner.from_shards(
+                self.path,
+                rank=self.rank,
+                device=self.device,
+                inversion_cfg=(
+                    None if self.apply_fn is not None else self.inversion_cfg
+                ),
+                apply_fn=self.apply_fn,
+                ev_correction=self.cfg.ev_correction,
+            )
 
         o_dims = {
             name: preconditioner.eigen_g[name].shape[1]
@@ -145,6 +188,8 @@ class EkfacApplicator:
                         device=self.device, dtype=torch.float32
                     )
 
+            for pre in chain:
+                grads = pre.apply(grads)
             transformed = preconditioner.apply(grads)
             del grads
 

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 import torch
+import torch.distributed as dist
 from safetensors.torch import load_file
 from torch import Tensor
 
@@ -225,10 +226,10 @@ class FactoredPreconditioner:
         plus the globally-reduced means, then applied across shards in-place.
         """
         lam = self.lambdas[name]
+        o, i = g.shape[1], lam.shape[1]
         if self.apply_fn is not None:
             inverse_eigvals = self.apply_fn(lam)
         else:
-            o, i = g.shape[1], lam.shape[1]
             mean = self.shard_computer.global_mean(lam, o * i)
             inversion = self.inversion_cfg.inversion
             if inversion == "factored_tikhonov":
@@ -290,6 +291,165 @@ class FactoredPreconditioner:
             g = self.shard_computer._transpose_matmul(vector_nsa=g, matrix_cb=q_a)
             self.logger.debug("%s: rotated back (H^-1 G)", name)
 
+            out[name] = g.reshape(flat.shape[0], -1).to(flat.dtype)
+        return out
+
+
+class DiagonalFactoredPreconditioner:
+    """Elementwise eigenfunctions on the preconditioned Hessian's diagonal
+    (the Adam/AdamW variant, Bae et al. 2024, App. C and D.2):
+
+    1. ``d = diag(H) = (Q_G ∘ Q_G) Λ (Q_A ∘ Q_A)^T`` from the EKFAC factors,
+    2. ``sigma = p * d``, the diagonal of ``P^1/2 H P^1/2``,
+    3. gradients are multiplied by ``apply_fn(sigma)`` in parameter space —
+       no eigenbasis rotation.
+    """
+
+    def __init__(
+        self,
+        eigen_a: dict[str, Tensor],
+        eigen_g: dict[str, Tensor],
+        lambdas: dict[str, Tensor],
+        preconditioner: dict[str, Tensor],
+        *,
+        apply_fn,
+    ):
+        self.eigen_a = eigen_a
+        self.eigen_g = eigen_g
+        self.lambdas = lambdas
+        self.preconditioner = preconditioner
+        self.apply_fn = apply_fn
+        self.shard_computer = ShardedMul()
+        self.logger = get_logger("DiagonalFactoredPreconditioner")
+        self._multipliers: dict[str, Tensor] = {}
+
+    @classmethod
+    def from_shards(
+        cls,
+        hessian_path: str | Path,
+        preconditioner_path: str | Path,
+        *,
+        rank: int,
+        device: str | torch.device,
+        apply_fn,
+        ev_correction: bool = False,
+    ) -> "DiagonalFactoredPreconditioner":
+        """Load this rank's factor shards plus its row-shard of the full
+        parameter-space preconditioner grids saved at ``preconditioner_path``."""
+        lambda_dir = (
+            "eigenvalue_correction_sharded" if ev_correction else "eigenvalue_sharded"
+        )
+        eigen_a = _load_shard(hessian_path, "eigen_activation_sharded", rank, device)
+        eigen_g = _load_shard(hessian_path, "eigen_gradient_sharded", rank, device)
+        lambdas = _load_shard(hessian_path, lambda_dir, rank, device)
+
+        full_grids = load_file(str(preconditioner_path), device=str(device))
+        sharder = ShardedMul()
+        preconditioner = {}
+        for name, q_g in eigen_g.items():
+            if name not in full_grids:
+                raise KeyError(
+                    f"Module {name!r} has EKFAC factors but no preconditioner "
+                    f"grid in {preconditioner_path}; available: "
+                    f"{sorted(full_grids.keys())}"
+                )
+            p = full_grids[name].to(torch.float32)
+            o, i = q_g.shape[1], eigen_a[name].shape[1]
+            if p.shape != (o, i):
+                raise ValueError(
+                    f"Preconditioner grid for {name!r} has shape "
+                    f"{tuple(p.shape)}, expected [out, in] = ({o}, {i})."
+                )
+            start, end = sharder.shard_bounds(o)
+            preconditioner[name] = p[start:end]
+        return cls(
+            eigen_a,
+            eigen_g,
+            lambdas,
+            preconditioner,
+            apply_fn=apply_fn,
+        )
+
+    def _diag_hessian_shard(self, name: str) -> Tensor:
+        """This rank's ``[c_o, I]`` row-shard (rows = its block of the
+        parameter out-dim) of ``diag(H) = (Q_G ∘ Q_G) Λ (Q_A ∘ Q_A)^T``.
+
+        The factors are row-sharded: ``Q_A [c_i, I']`` / ``Q_G [c_o, O']`` on
+        their parameter dims, ``Λ [c_o', I']`` on the eigen out-dim. Both
+        contractions run over a sharded dim, so each is a broadcast loop in
+        the style of :class:`ShardedMul`.
+        """
+        q_a = self.eigen_a[name]  # [c_i, I'] param rows, eigen cols
+        q_g = self.eigen_g[name]  # [c_o, O'] param rows, eigen cols
+        lam = self.lambdas[name]  # [c_o', I'] eigen rows, eigen cols
+        sc = self.shard_computer
+        n_eig_i = q_a.shape[1]
+        n_eig_o = q_g.shape[1]
+
+        if not sc.dist:
+            # Single process: shards are the full factors.
+            return (q_g**2) @ lam @ (q_a**2).T
+
+        # x_shard[o', i] = sum_i' lam[o', i'] * q_a[i, i']^2 for this rank's
+        # eigen-o' rows and ALL param-i columns (q_a's param rows are sharded).
+        x_shard = torch.empty(lam.shape[0], n_eig_i, device=lam.device, dtype=lam.dtype)
+        for rank_index in range(sc.world_size):
+            start, end = sc.shard_bounds(n_eig_i, rank_index)
+            if rank_index == sc.rank:
+                shard = q_a
+            else:
+                shard = torch.empty(
+                    (end - start, q_a.shape[1]), device=q_a.device, dtype=q_a.dtype
+                )
+            dist.broadcast(shard, src=rank_index)
+            x_shard[:, start:end] = lam @ (shard**2).T
+            if sc.rank != rank_index:
+                del shard
+
+        # d_shard[o, i] = sum_o' q_g[o, o']^2 * x[o', i]; x rows (eigen-o') are
+        # sharded across ranks, q_g's eigen-o' columns are full.
+        d_shard = torch.zeros(q_g.shape[0], n_eig_i, device=q_g.device, dtype=q_g.dtype)
+        for rank_index in range(sc.world_size):
+            start, end = sc.shard_bounds(n_eig_o, rank_index)
+            if rank_index == sc.rank:
+                shard = x_shard
+            else:
+                shard = torch.empty(
+                    (end - start, n_eig_i), device=x_shard.device, dtype=x_shard.dtype
+                )
+            dist.broadcast(shard, src=rank_index)
+            d_shard += (q_g[:, start:end] ** 2) @ shard
+            if sc.rank != rank_index:
+                del shard
+        return d_shard
+
+    def _multiplier(self, name: str) -> Tensor:
+        """This rank's ``[c_o, I]`` row-shard of the elementwise multiplier,
+        cached after the first batch (it is gradient-independent)."""
+        if name not in self._multipliers:
+            p = self.preconditioner[name]
+            sigma = p * self._diag_hessian_shard(name)
+            self._multipliers[name] = self.apply_fn(sigma)
+        return self._multipliers[name]
+
+    def apply(self, grads: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Return ``grads`` scaled elementwise in parameter space; modules
+        absent from the factors pass through unchanged."""
+        out: dict[str, Tensor] = {}
+        for name, flat in grads.items():
+            if name not in self.eigen_a:
+                out[name] = flat
+                continue
+            o = self.eigen_g[name].shape[1]
+            i = self.eigen_a[name].shape[1]
+            # copy=True because the scale below writes through: the caller's
+            # gradients may alias a read-only mmap, and a plain `.to` is a no-op
+            # when they are already float32 on this device, as on a CPU-only run.
+            g = flat.to(self.lambdas[name].device, torch.float32, copy=True).view(
+                -1, o, i
+            )
+            self.shard_computer.scale_rows_in_place(g, self._multiplier(name))
+            self.logger.debug("%s: scaled elementwise by f(p * diag(H))", name)
             out[name] = g.reshape(flat.shape[0], -1).to(flat.dtype)
         return out
 

--- a/tests/test_source_optimizer_variants.py
+++ b/tests/test_source_optimizer_variants.py
@@ -1,0 +1,379 @@
+"""Tests for the SOURCE (approx-unrolling) optimizer variants: SGD heavy-ball
+momentum lr scaling and the Adam/AdamW diagonal-preconditioner eigenfunction
+path (Bae et al., 2024, Appendix C / D.2).
+"""
+
+import numpy as np
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from bergson.approx_unrolling.approx_unrolling_math import (
+    compute_lr_times_steps_per_segment,
+    f_backward,
+    f_one_minus_exp,
+    f_segment,
+)
+from bergson.config import ApproxUnrollingConfig
+from bergson.config.config import InversionConfig
+from bergson.data import create_index, load_module_gradients
+from bergson.hessians.apply_hessian import EkfacApplicator, EkfacConfig
+from bergson.hessians.preconditioner import (
+    DiagonalFactoredPreconditioner,
+    FactoredPreconditioner,
+)
+
+MODULE = "lm_head"
+OUT_DIM, IN_DIM = 6, 4
+LR_TIMES_STEPS = 0.05
+
+
+def test_momentum_scales_lr_times_steps():
+    """SGDm terminal velocity: lr*K scaled by 1/(1-beta)."""
+    base_cfg = ApproxUnrollingConfig(
+        checkpoints=["a", "b"],
+        segments=2,
+        lr_list=[1e-3, 2e-3],
+        step_size_list=[10, 20],
+    )
+    momentum_cfg = ApproxUnrollingConfig(
+        checkpoints=["a", "b"],
+        segments=2,
+        lr_list=[1e-3, 2e-3],
+        step_size_list=[10, 20],
+        momentum=0.9,
+    )
+    base = compute_lr_times_steps_per_segment(base_cfg)
+    scaled = compute_lr_times_steps_per_segment(momentum_cfg)
+    assert scaled == pytest.approx([10 * b for b in base])
+
+
+def test_momentum_out_of_range_raises():
+    for bad in (1.0, -0.1):
+        bad_cfg = ApproxUnrollingConfig(
+            checkpoints=["a"],
+            segments=1,
+            lr_list=[1e-3],
+            step_size_list=[10],
+            momentum=bad,
+        )
+        with pytest.raises(ValueError, match="momentum"):
+            compute_lr_times_steps_per_segment(bad_cfg)
+
+
+def _random_factors():
+    """Random EKFAC-style factors: orthogonal eigenvectors, non-negative
+    eigenvalue grid."""
+    torch.manual_seed(0)
+    q_a, _ = torch.linalg.qr(torch.randn(IN_DIM, IN_DIM, dtype=torch.float64))
+    q_g, _ = torch.linalg.qr(torch.randn(OUT_DIM, OUT_DIM, dtype=torch.float64))
+    lam = torch.rand(OUT_DIM, IN_DIM, dtype=torch.float64)
+    return q_a.float().contiguous(), q_g.float().contiguous(), lam.float()
+
+
+def _write_factor_shards(tmp_path, q_a, q_g, lam, precond):
+    """Write the single-shard on-disk layout DiagonalFactoredPreconditioner
+    loads from, plus the preconditioner grid."""
+    for sub, tensor in [
+        ("eigen_activation_sharded", q_a),
+        ("eigen_gradient_sharded", q_g),
+        ("eigenvalue_correction_sharded", lam),
+    ]:
+        (tmp_path / sub).mkdir()
+        save_file({MODULE: tensor}, str(tmp_path / sub / "shard_0.safetensors"))
+    preconditioner_path = tmp_path / "precond.safetensors"
+    save_file({MODULE: precond}, str(preconditioner_path))
+    return preconditioner_path
+
+
+def _reference_diag_hessian(q_a, q_g, lam):
+    """diag(H) via the dense Kronecker Hessian — independent of the
+    implementation's factored formula.
+
+    The [OUT, IN] grid flattens row-major to vec index o*IN + i, matching
+    kron(q_g, q_a)'s row ordering, so H = kron(Q_G, Q_A) diag(vec Λ)
+    kron(Q_G, Q_A)^T.
+    """
+    q_kron = torch.kron(q_g.double(), q_a.double())
+    h = q_kron @ torch.diag(lam.double().flatten()) @ q_kron.T
+    return torch.diagonal(h).reshape(OUT_DIM, IN_DIM).float()
+
+
+@pytest.mark.parametrize("fn_kind", ["f_backward", "f_one_minus_exp"])
+def test_diagonal_preconditioner_matches_dense_reference(tmp_path, fn_kind):
+    """The diagonal path multiplies gradients elementwise by f(p * diag(H)),
+    with diag(H) recovered exactly from the EKFAC factors."""
+    q_a, q_g, lam = _random_factors()
+    precond = torch.rand(OUT_DIM, IN_DIM) + 0.5
+    preconditioner_path = _write_factor_shards(tmp_path, q_a, q_g, lam, precond)
+
+    fn = {"f_backward": f_backward, "f_one_minus_exp": f_one_minus_exp}[fn_kind](
+        LR_TIMES_STEPS
+    )
+    preconditioner = DiagonalFactoredPreconditioner.from_shards(
+        tmp_path,
+        preconditioner_path,
+        rank=0,
+        device="cpu",
+        apply_fn=fn,
+        ev_correction=True,
+    )
+
+    grads = {MODULE: torch.randn(3, OUT_DIM * IN_DIM)}
+    before = grads[MODULE].clone()
+    out = preconditioner.apply(grads)[MODULE]
+    # apply() must not write through to the caller's tensor: compute_ivhp_sharded
+    # hands it gradients aliasing a read-only mmap.
+    torch.testing.assert_close(grads[MODULE], before)
+
+    sigma = precond * _reference_diag_hessian(q_a, q_g, lam)
+    if fn_kind == "f_backward":
+        multiplier = torch.exp(-LR_TIMES_STEPS * sigma)
+    else:
+        multiplier = -torch.expm1(-LR_TIMES_STEPS * sigma)
+    expected = grads[MODULE].view(3, OUT_DIM, IN_DIM) * multiplier
+    torch.testing.assert_close(
+        out.view(3, OUT_DIM, IN_DIM), expected, rtol=1e-4, atol=1e-6
+    )
+
+
+def test_f_segment_zero_eigenvalue_limit():
+    """At sigma = 0 the segment multiplier hits its lr*K limit with no
+    NaN/inf from the 0/0."""
+    out = f_segment(LR_TIMES_STEPS)(torch.zeros(OUT_DIM, IN_DIM))
+    torch.testing.assert_close(out, torch.full((OUT_DIM, IN_DIM), LR_TIMES_STEPS))
+
+
+def test_preconditioner_shape_mismatch_raises(tmp_path):
+    q_a, q_g, lam = _random_factors()
+    bad_precond = torch.rand(OUT_DIM + 1, IN_DIM)
+    preconditioner_path = _write_factor_shards(tmp_path, q_a, q_g, lam, bad_precond)
+    with pytest.raises(ValueError, match="shape"):
+        DiagonalFactoredPreconditioner.from_shards(
+            tmp_path,
+            preconditioner_path,
+            rank=0,
+            device="cpu",
+            apply_fn=f_backward(LR_TIMES_STEPS),
+            ev_correction=True,
+        )
+
+
+def test_preconditioner_missing_module_raises(tmp_path):
+    q_a, q_g, lam = _random_factors()
+    for sub, tensor in [
+        ("eigen_activation_sharded", q_a),
+        ("eigen_gradient_sharded", q_g),
+        ("eigenvalue_correction_sharded", lam),
+    ]:
+        (tmp_path / sub).mkdir()
+        save_file({MODULE: tensor}, str(tmp_path / sub / "shard_0.safetensors"))
+    preconditioner_path = tmp_path / "precond.safetensors"
+    save_file({"other_module": torch.rand(OUT_DIM, IN_DIM)}, str(preconditioner_path))
+    with pytest.raises(KeyError, match=MODULE):
+        DiagonalFactoredPreconditioner.from_shards(
+            tmp_path,
+            preconditioner_path,
+            rank=0,
+            device="cpu",
+            apply_fn=f_backward(LR_TIMES_STEPS),
+            ev_correction=True,
+        )
+
+
+@pytest.mark.parametrize("fn_kind", ["f_backward", "f_segment"])
+def test_ekfac_applicator_uses_diagonal_path(tmp_path, fn_kind):
+    """``preconditioner_path`` routes the applicator through the diagonal
+    preconditioner; passing ``inversion_cfg`` too chains the EK-FAC inverse
+    after it (Eq-43)."""
+    q_a, q_g, lam = _random_factors()
+    precond = torch.rand(OUT_DIM, IN_DIM) + 0.5
+    preconditioner_path = _write_factor_shards(tmp_path, q_a, q_g, lam, precond)
+
+    query_path = tmp_path / "query"
+    index = create_index(
+        root=query_path,
+        num_grads=3,
+        grad_sizes={MODULE: OUT_DIM * IN_DIM},
+        dtype=np.float32,
+    )
+    index[:] = np.random.default_rng(0).standard_normal(index.shape).astype(np.float32)
+    index.flush()
+
+    hybrid = fn_kind == "f_segment"
+    cfg = EkfacConfig(
+        hessian_method_path=str(tmp_path),
+        gradient_path=str(query_path),
+        run_path=str(tmp_path / "out"),
+        ev_correction=True,
+        preconditioner_path=str(preconditioner_path),
+    )
+    fn = {"f_backward": f_backward, "f_segment": f_one_minus_exp}[fn_kind](
+        LR_TIMES_STEPS
+    )
+    inversion_cfg = InversionConfig(damping_factor=0.1) if hybrid else None
+    EkfacApplicator(
+        cfg, inversion_cfg=inversion_cfg, apply_fn=fn
+    ).compute_ivhp_sharded()
+    out = torch.from_numpy(
+        np.asarray(load_module_gradients(str(tmp_path / "out"))[MODULE][:])
+    )
+
+    grads = {MODULE: torch.from_numpy(np.asarray(index[:])).float()}
+    grads = DiagonalFactoredPreconditioner.from_shards(
+        tmp_path,
+        preconditioner_path,
+        rank=0,
+        device="cpu",
+        apply_fn=fn,
+        ev_correction=True,
+    ).apply(grads)
+    if hybrid:
+        grads = FactoredPreconditioner.from_shards(
+            tmp_path,
+            rank=0,
+            device="cpu",
+            inversion_cfg=InversionConfig(damping_factor=0.1),
+            ev_correction=True,
+        ).apply(grads)
+    torch.testing.assert_close(out, grads[MODULE].cpu())
+
+
+def test_ekfac_applicator_preconditioner_without_apply_fn_raises(tmp_path):
+    cfg = EkfacConfig(
+        hessian_method_path=str(tmp_path),
+        gradient_path=str(tmp_path),
+        run_path=str(tmp_path / "out"),
+        ev_correction=True,
+        preconditioner_path=str(tmp_path / "precond.safetensors"),
+    )
+    with pytest.raises(ValueError, match="preconditioner_path requires apply_fn"):
+        EkfacApplicator(cfg).compute_ivhp_sharded()
+
+
+def test_build_segment_preconditioners(tmp_path):
+    """Per-segment P built from the checkpoints' optimizer.pt files:
+    bias-corrected via the stored step/betas, index-mapped to param names,
+    suffix-matched to the factor modules, oriented to [out, in] (transposed
+    storage flipped), averaged within the segment, and eps-transformed."""
+    from transformers import AutoModelForCausalLM, GPT2Config
+
+    from bergson.approx_unrolling.adam_preconditioner import (
+        build_segment_preconditioners,
+    )
+
+    torch.manual_seed(0)
+    tiny_cfg = GPT2Config(n_layer=1, n_embd=4, n_head=2, n_positions=8, vocab_size=16)
+    module, out_dim, in_dim = "h.0.attn.c_attn", 12, 4
+
+    run = tmp_path / "run"
+    seg_kfac = run / "segment_0" / "kfac"
+    seg_kfac.mkdir(parents=True)
+    for sub, cols in [
+        ("eigen_activation_sharded", in_dim),
+        ("eigen_gradient_sharded", out_dim),
+        ("eigenvalue_correction_sharded", in_dim),
+    ]:
+        (seg_kfac / sub).mkdir()
+        save_file(
+            {module: torch.rand(2, cols)}, str(seg_kfac / sub / "shard_0.safetensors")
+        )
+
+    tiny_model = AutoModelForCausalLM.from_config(tiny_cfg)
+    param_names = [n for n, _ in tiny_model.named_parameters()]
+    idx = param_names.index(f"transformer.{module}.weight")
+
+    # Two checkpoints with raw (uncorrected) moments stored transposed
+    # ([in, out], like GPT-2 Conv1D params), at different steps.
+    beta2, eps_root, eps = 0.975, 1e-6, 1e-8
+    steps, nus = [5, 9], [torch.rand(in_dim, out_dim) for _ in range(2)]
+    ckpts = []
+    for step, nu in zip(steps, nus):
+        ckpt = tmp_path / f"models_step_{step}"
+        ckpt.mkdir()
+        tiny_cfg.save_pretrained(ckpt)
+        # One checkpoint keyed positionally (legacy fallback), the other under
+        # a bogus index with param_name recorded (the FSDP-scrambled case).
+        if step == steps[0]:
+            entry = {idx: {"exp_avg_sq": nu, "step": torch.tensor(step)}}
+        else:
+            entry = {
+                999: {
+                    "exp_avg_sq": nu,
+                    "step": torch.tensor(step),
+                    "param_name": f"transformer.{module}.weight",
+                }
+            }
+        torch.save(
+            {
+                "state": entry,
+                "param_groups": [
+                    {
+                        "params": list(entry),
+                        "betas": (0.9, beta2),
+                        "eps": eps,
+                        "eps_root": eps_root,
+                    }
+                ],
+            },
+            ckpt / "optimizer.pt",
+        )
+        ckpts.append(str(ckpt))
+
+    paths = build_segment_preconditioners(
+        run_path=run,
+        method="kfac",
+        checkpoints=ckpts,
+        segments=1,
+    )
+    assert paths == [run / "segment_0" / "preconditioner.safetensors"]
+    from safetensors.torch import load_file
+
+    precond = load_file(str(paths[0]))[module]
+    v_hats = [nu / (1 - beta2**step) for step, nu in zip(steps, nus)]
+    v_bar = (v_hats[0] + v_hats[1]).T / 2
+    expected = 1.0 / ((v_bar + eps_root).sqrt() + eps)
+    assert precond.shape == (out_dim, in_dim)
+    torch.testing.assert_close(precond, expected)
+
+
+def test_optimizer_pt_snapshot_fields(tmp_path):
+    """save_second_moments_as_optimizer_pt stores the standard step and betas
+    fields when given, making snapshot exports self-describing for the SOURCE
+    Adam variant's bias correction."""
+    import torch.nn as nn
+    import torchopt
+
+    from bergson.utils.load_from_optimizer import save_second_moments_as_optimizer_pt
+
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blk = nn.Linear(3, 2, bias=False)
+            self.head = nn.Linear(2, 4, bias=False)
+
+    model = TinyModel()
+    params = dict(model.named_parameters(remove_duplicate=False))
+    opt_state = torchopt.adamw(1e-3, betas=(0.9, 0.975)).init(params)
+    adam_state = next(s for s in opt_state if hasattr(s, "nu"))
+    for nu, count in zip(adam_state.nu, adam_state.count):
+        nu.copy_(torch.rand_like(nu))
+        count.fill_(7)
+
+    path = tmp_path / "step_7.optimizer.pt"
+    n = save_second_moments_as_optimizer_pt(
+        model, opt_state, path, step=7, betas=(0.9, 0.975), eps=1e-8, eps_root=1e-6
+    )
+    assert n == 2
+    optimizer_pt = torch.load(path, weights_only=False)
+    assert optimizer_pt["param_groups"][0]["betas"] == (0.9, 0.975)
+    assert optimizer_pt["param_groups"][0]["eps"] == 1e-8
+    assert optimizer_pt["param_groups"][0]["eps_root"] == 1e-6
+    names = [n for n, _ in model.named_parameters()]
+    # nu lists are in sorted(params) order; blk.weight sorts before head.weight.
+    for idx, entry in optimizer_pt["state"].items():
+        assert int(entry["step"].item()) == 7
+        # param_name recorded per entry: FSDP-scrambled indices stay readable.
+        assert entry["param_name"] == names[idx]
+        nu_idx = sorted(params).index(names[idx])
+        torch.testing.assert_close(entry["exp_avg_sq"], adam_state.nu[nu_idx])


### PR DESCRIPTION
Fable: Evaluates the unrolling eigenfunctions on a diagonal approximation of the preconditioned Hessian `P^1/2 H P^1/2`, built per segment from the checkpoints' saved second moments (Bae et al. 2024, App. C). F_segment always uses the App. D Eq-43 form — the diagonal supplies only the matrix exponential and the EK-FAC factors supply `H^-1` (quote verified against the paper, p. 36); the diagonal-only F_segment path is not implemented since the paper prescribes the Eq-43 split. Requires `optimizer.pt` in each checkpoint dir — written by the trainer's `save_optimizer_state` (#373) and carried across by `export_checkpoints`.

The replication configs follow.

Note that replicating the Kronfluence number for GPT-2 using the Bergson Trainer requires passing --train_mode to enable train mode/dropout for now (dropout does not play nicely with double backward/MAGIC)

cc: @LouisYRYJ 