### PR TITLE
WikiText-2 / GPT-2 replication configs

### DIFF
--- a/examples/replicate_bae_approx_unrolling_source/README.md
+++ b/examples/replicate_bae_approx_unrolling_source/README.md
@@ -1,0 +1,17 @@
+# WikiText-2 / GPT-2 replication (Bae et al. 2024)
+
+Reproduces SOURCE > EK-FAC IF (Figure 6) end to end from public data.
+
+Run each config with `PYTHONPATH=$PWD python -m bergson <config>`, in order:
+
+| # | Config | Produces |
+|---|--------|----------|
+| 0 | `prep_dataset.py` | `EleutherAI/bergson-wikitext-2-4656-chunks` (already hosted; run only to rebuild) |
+| 1 | `wikitext_gpt2_train.yaml` | fine-tuned GPT-2, 6 checkpoints with optimizer state |
+| 2 | `wikitext_gpt2_source.yaml` | SOURCE scores (auto-exports the checkpoints) |
+| 3 | `wikitext_gpt2_ekfac.yaml` | EK-FAC influence scores at the final checkpoint |
+| 4 | `wikitext_gpt2_retrain.yaml` | 100 models retrained on random halves of the training data + EK-FAC LDS |
+| 5 | `wikitext_gpt2_validate.yaml` | SOURCE LDS against the retrained models |
+
+Step 2 runs before step 3 because it exports the trainer checkpoints to the
+HF format both steps load.

--- a/examples/replicate_bae_approx_unrolling_source/prep_dataset.py
+++ b/examples/replicate_bae_approx_unrolling_source/prep_dataset.py
@@ -1,0 +1,78 @@
+"""Reproduce the WikiText-2 / GPT-2 512-token-chunk dataset for the replication.
+
+Production rule is the standard HF ``run_clm`` recipe (also what kronfluence's
+``examples/wikitext`` uses): tokenize raw wikitext-2-raw-v1 with the GPT-2
+tokenizer, then ``group_texts`` -- within each 1000-row map batch, concatenate
+tokens, drop the remainder, and slice into fixed 512-token blocks (one block ==
+one document). This is a public preprocessing recipe, not a borrowed ground
+truth, and it reproduces the exact 4656 train / 481 validation chunking used by
+the replication configs.
+
+The pushed copy is ``EleutherAI/bergson-wikitext-2-4656-chunks`` (columns
+``input_ids`` and ``length``), which the replication YAMLs load with
+``chunk_length: 0``.
+
+    # Dry run (prints split sizes); add --push <repo> to push to the hub.
+    python examples/replicate_bae_approx_unrolling_source/prep_dataset.py
+"""
+
+import argparse
+
+from datasets import DatasetDict, load_dataset
+from transformers import AutoTokenizer
+
+BLOCK = 512
+DEFAULT_REPO = "EleutherAI/bergson-wikitext-2-4656-chunks"
+
+
+def group_texts(examples: dict) -> dict:
+    concat = sum(examples["input_ids"], [])
+    total = (len(concat) // BLOCK) * BLOCK
+    return {"input_ids": [concat[i : i + BLOCK] for i in range(0, total, BLOCK)]}
+
+
+def build() -> DatasetDict:
+    tok = AutoTokenizer.from_pretrained("gpt2")
+    raw = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1")
+
+    out = {}
+    for split in ("train", "validation"):
+        toks = raw[split].map(
+            lambda b: tok(b["text"]),
+            batched=True,
+            remove_columns=raw[split].column_names,
+            desc=f"tokenize {split}",
+        )
+        blocks = toks.map(
+            group_texts,
+            batched=True,
+            remove_columns=[c for c in toks.column_names if c != "input_ids"],
+            desc=f"chunk {split}",
+        )
+        out[split] = blocks.map(lambda x: {"length": len(x["input_ids"])})
+    return DatasetDict(out)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--push",
+        nargs="?",
+        const=DEFAULT_REPO,
+        default="",
+        help=f"push to this hub repo id (default {DEFAULT_REPO} when bare)",
+    )
+    args = ap.parse_args()
+
+    ds = build()
+    for split, d in ds.items():
+        print(f"{split}: {len(d)} chunks, cols={d.column_names}")
+
+    if args.push:
+        print(f"pushing to {args.push} ...")
+        ds.push_to_hub(args.push)
+        print("pushed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_ekfac.yaml
+++ b/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_ekfac.yaml
@@ -1,0 +1,44 @@
+# EK-FAC influence functions at the final checkpoint. Run after the SOURCE
+# step, which exports it.
+#
+#   PYTHONPATH=$PWD python -m bergson examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_ekfac.yaml
+
+steps:
+  - ekfac:
+      index_cfg:
+        run_path: runs/wikitext_repro/if_scores
+        model: runs/wikitext_repro/train/exported/checkpoint-1746
+        overwrite: true
+        precision: fp32
+        token_batch_size: 1024
+        max_batch_size: 64
+        filter_modules: "lm_head"
+        distributed:
+          nproc_per_node: 8
+          nnode: 1
+        data:
+          dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+          split: train
+          chunk_length: 0
+
+      hessian_cfg:
+        method: kfac
+        hessian_dtype: fp32
+        ev_correction: true
+
+      score_cfg:
+        batch_size: 1024
+        query_batch_size: 64
+
+      preprocess_cfg:
+        unit_normalize: false
+
+      hessian_pipeline_cfg:
+        query:
+          dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+          split: validation
+          chunk_length: 0
+        query_aggregation: none
+        # Effectively undamped, matching the reference implementation.
+        inversion_cfg:
+          damping_factor: 1.0e-8

--- a/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_retrain.yaml
+++ b/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_retrain.yaml
@@ -1,0 +1,45 @@
+# Ground truth: retrain GPT-2 100 times with the training recipe, each on a
+# random half of the training data, saving every model, and report EK-FAC LDS
+# in the same pass.
+#
+#   PYTHONPATH=$PWD python -m bergson examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_retrain.yaml
+
+steps:
+  - validate:
+      run_path: runs/wikitext_repro/retrain
+      model: gpt2
+      overwrite: true
+      precision: fp32
+      seed: 1004
+      scores: runs/wikitext_repro/if_scores/scores
+
+      data:
+        dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+        split: train
+        chunk_length: 0
+      query:
+        dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+        split: validation
+        chunk_length: 0
+
+      distributed:
+        nproc_per_node: 8
+        nnode: 1
+
+      optimizer: adamw
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1.0e-8
+      eps_root: 0.0
+      weight_decay: 0.01
+      batch_size: 8
+      num_epochs: 3
+      lr_schedule:
+        lr_scheduler_type: constant
+        lr: 3.0e-5
+      train_mode: true
+
+      subset_strategy: random
+      num_subsets: 100
+      subset_fraction: 0.5
+      save_models: true

--- a/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_source.yaml
+++ b/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_source.yaml
@@ -1,0 +1,52 @@
+# SOURCE on the training run, optimizer-preconditioned (it trained with
+# AdamW). The raw trainer checkpoints are exported to HF format automatically.
+#
+#   PYTHONPATH=$PWD python -m bergson examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_source.yaml
+
+steps:
+  - approxunrolling:
+      index_cfg:
+        run_path: runs/wikitext_repro/source_scores
+        model: runs/wikitext_repro/train/exported/checkpoint-1746
+        overwrite: true
+        precision: fp32
+        token_batch_size: 1024
+        max_batch_size: 64
+        # GPT-2 ties lm_head to wte; tracking both double-counts the embedding.
+        filter_modules: "lm_head"
+        distributed:
+          nproc_per_node: 8
+          nnode: 1
+        data:
+          dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+          split: train
+          chunk_length: 0
+
+      hessian_cfg:
+        method: kfac
+        hessian_dtype: fp32
+        ev_correction: true
+
+      approx_unrolling_cfg:
+        checkpoints:
+          - runs/wikitext_repro/train/checkpoints/step_291.ckpt
+          - runs/wikitext_repro/train/checkpoints/step_582.ckpt
+          - runs/wikitext_repro/train/checkpoints/step_873.ckpt
+          - runs/wikitext_repro/train/checkpoints/step_1164.ckpt
+          - runs/wikitext_repro/train/checkpoints/step_1455.ckpt
+          - runs/wikitext_repro/train/checkpoints/step_1746.ckpt
+        segments: 3
+        lr_list: [3.0e-5, 3.0e-5, 3.0e-5]
+        step_size_list: [582, 582, 582]
+        query:
+          dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+          split: validation
+          chunk_length: 0
+        # One score column per validation query, for per-query LDS.
+        query_aggregation: none
+        query_batch_size: 64
+
+        use_adam_preconditioner: true
+        # Effectively undamped, matching the reference implementation.
+        inversion_cfg:
+          damping_factor: 1.0e-8

--- a/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_train.yaml
+++ b/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_train.yaml
@@ -1,0 +1,37 @@
+# Fine-tune GPT-2 on WikiText-2 with the Bae et al. 2024 recipe (App. B.1).
+#
+#   PYTHONPATH=$PWD python -m bergson examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_train.yaml
+
+steps:
+  - train:
+      run_path: runs/wikitext_repro/train
+      model: gpt2
+      overwrite: true
+      precision: fp32
+      seed: 1004
+
+      data:
+        dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+        split: train
+        chunk_length: 0
+
+      distributed:
+        nproc_per_node: 1
+        nnode: 1
+
+      optimizer: adamw
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1.0e-8
+      eps_root: 0.0
+      weight_decay: 0.01
+      batch_size: 8
+      num_epochs: 3
+      lr_schedule:
+        lr_scheduler_type: constant
+        lr: 3.0e-5
+      train_mode: true
+
+      save_mode: interval
+      save_interval: 291
+      save_optimizer_state: all

--- a/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_validate.yaml
+++ b/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_validate.yaml
@@ -1,0 +1,20 @@
+# SOURCE LDS against the saved retrained models. No retraining happens here.
+#
+#   PYTHONPATH=$PWD python -m bergson examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_validate.yaml
+
+steps:
+  - validate:
+      run_path: runs/wikitext_repro/validate_source
+      model: gpt2
+      overwrite: true
+      scores: runs/wikitext_repro/source_scores/scores
+      retrained_dir: runs/wikitext_repro/retrain
+      batch_size: 64
+      data:
+        dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+        split: train
+        chunk_length: 0
+      query:
+        dataset: EleutherAI/bergson-wikitext-2-4656-chunks
+        split: validation
+        chunk_length: 0


### PR DESCRIPTION
The full replication chain against merged main: train (interval checkpoints + optimizer state) → SOURCE (auto-exported checkpoints, Adam preconditioner, `inversion_cfg.damping_factor: 1e-8`) → EK-FAC → 100 models retrained on random halves of the training data → SOURCE LDS. Dataset is the hosted `EleutherAI/bergson-wikitext-2-4656-chunks` with the script that reproduces it bit-for-bit from public WikiText-2. All configs parse against current `main`; replaces #370.

The retrain + validate steps are running now on this machine; LDS numbers will be posted here when they land.