### PR TITLE
feat(validate): retrain a slice of the subsets

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -457,6 +457,14 @@ class ValidationConfig(TrainingConfig, ABC):
     subsets: str = ""
     """Path to a subsets.json to reuse; defaults to ``<run_path>/subsets.json``."""
 
+    subset_start: int = 0
+    """First subset index to retrain. With ``subset_stop``, splits the
+    retraining across independent processes; the subsets are drawn from
+    ``seed``, so every process agrees on the full list."""
+
+    subset_stop: int | None = None
+    """One past the last subset index to retrain; ``None`` means ``num_subsets``."""
+
     subset_fraction: float = 0.0
     """When > 0, each of the ``num_subsets`` leave-k-out subsets is an
     independent draw (without replacement within a subset, overlapping across

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -272,7 +272,11 @@ def worker(
             os.path.join(run_cfg.run_path, "optimizer.pt"),
         )
 
-    if getattr(run_cfg, "save_models", False) and global_rank == 0:
+    if (
+        getattr(run_cfg, "save_models", False)
+        and global_rank == 0
+        and getattr(run_cfg, "subset_start", 0) == 0
+    ):
         # Persist the fully-trained (no leave-out) model alongside the per-subset
         # models, so a later evaluate_retrained run can measure the query
         # baseline from the bank itself instead of a separate base_model_dir.

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -188,12 +188,13 @@ def report_multi_query_validation(
     score_sums: list[list[float]],
     baselines: torch.Tensor,
     num_subsets: int,
+    summary_name: str = "summary.csv",
 ):
     """Print per-query correlations and write one summary.csv row per query."""
     num_queries = len(diffs[0])
 
     summary_csv_writer = CSVWriter(
-        os.path.join(run_path, "summary.csv"),
+        os.path.join(run_path, summary_name),
         columns=[
             "query",
             "spearman_corr",
@@ -318,7 +319,12 @@ def validate_scores(
     else:
         raise ValueError(f"Unknown subset strategy: {run_cfg.subset_strategy}")
 
-    csv_path = os.path.join(run_cfg.run_path, "validation.csv")
+    start = run_cfg.subset_start
+    stop = len(subsets) if run_cfg.subset_stop is None else run_cfg.subset_stop
+    sliced = (start, stop) != (0, len(subsets))
+
+    csv_name = f"validation_{start}_{stop}.csv" if sliced else "validation.csv"
+    csv_path = os.path.join(run_cfg.run_path, csv_name)
     val_csv_writer = CSVWriter(
         csv_path,
         columns=(
@@ -341,12 +347,14 @@ def validate_scores(
             run_cfg.tokenizer or run_cfg.model
         )
         # Row i lists the doc ids left out of retrained/subset_i;
-        # evaluate_retrained needs this to reuse the bank.
-        with open(os.path.join(run_cfg.run_path, "subsets.json"), "w") as f:
-            json.dump([s.tolist() for s in subsets], f)
+        # evaluate_retrained needs this to reuse the models. The first
+        # process owns the shared files.
+        if start == 0:
+            with open(os.path.join(run_cfg.run_path, "subsets.json"), "w") as f:
+                json.dump([s.tolist() for s in subsets], f)
 
-    pbar = tqdm(subsets, desc="Validating", disable=global_rank != 0)
-    for i, subset in enumerate(pbar):
+    pbar = tqdm(subsets[start:stop], desc="Validating", disable=global_rank != 0)
+    for i, subset in enumerate(pbar, start=start):
         trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
         fwd_state.detach_()
 
@@ -432,7 +440,12 @@ def validate_scores(
     if global_rank == 0:
         if multi_query:
             report_multi_query_validation(
-                run_cfg.run_path, diffs, score_sums, baseline_per_doc, len(subsets)
+                run_cfg.run_path,
+                diffs,
+                score_sums,
+                baseline_per_doc,
+                stop - start,
+                summary_name=f"summary_{start}_{stop}.csv" if sliced else "summary.csv",
             )
             print(f"Saved validation data to {csv_path}")
             return
@@ -628,7 +641,12 @@ def evaluate_retrained(
     else:
         print(f"Baseline query loss (no leave-out): {baseline}")
 
-    csv_path = os.path.join(run_cfg.run_path, "validation.csv")
+    start = run_cfg.subset_start
+    stop = len(subsets) if run_cfg.subset_stop is None else run_cfg.subset_stop
+    sliced = (start, stop) != (0, len(subsets))
+
+    csv_name = f"validation_{start}_{stop}.csv" if sliced else "validation.csv"
+    csv_path = os.path.join(run_cfg.run_path, csv_name)
     val_csv_writer = CSVWriter(
         csv_path,
         columns=(


### PR DESCRIPTION
`subset_start`/`subset_stop` select which of the deterministically drawn subsets a process retrains, so independent single-GPU processes can split the retraining. Motivation: at batch size 8, data-parallel retraining is all-reduce-bound — 8 GPUs run at 2.8 it/s vs 4 it/s on one — while subset-level parallelism is embarrassingly parallel (~8x). Sliced runs write range-suffixed `validation`/`summary` CSVs and absolute `subset_<i>` dirs; `subsets.json` and `retrained/base` belong to the process starting at 0.

Known caveat found at full scale: resuming the base training replays the final step and rewrites/deletes the trailing checkpoint, so *simultaneously started* sliced processes race on those files — start them staggered (each after the previous passes base resume), or run the 0-process first. A follow-up could suppress checkpoint writes when `subset_start > 0`, making concurrent resume read-only.

Being exercised at full scale on the WikiText replication now.