### PR TITLE
Expose the preconditioner apply power as HessianConfig.apply_power

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -762,6 +762,10 @@ class HessianConfig(Serializable):
     method: Literal["kfac", "tkfac", "shampoo", "autocorrelation"]
     """Method for approximating the Hessian."""
 
+    apply_power: float = -1.0
+    """Inverse power applied to the fitted eigenvalue grid when preconditioning
+    the query gradient. -1.0 is the full inverse H^-1."""
+
     ev_correction: bool = False
     """Whether to additionally compute eigenvalue correction."""
 

--- a/bergson/hessians/apply_hessian.py
+++ b/bergson/hessians/apply_hessian.py
@@ -72,9 +72,8 @@ class EkfacApplicator:
 
     def compute_ivhp_sharded(self):
         if self.world_size == 1:
-            # load the full factors and run non-distributed: avoids the sharded
-            # send/recv path, which can hang on some nodes, and lets a
-            # distributed fit be applied on a single gpu
+            # load the full factors, concatenating any shards from a
+            # distributed fit; from_shards would only load this rank's shard
             preconditioner = FactoredPreconditioner.from_path(
                 self.path,
                 device=self.device,

--- a/bergson/hessians/apply_hessian.py
+++ b/bergson/hessians/apply_hessian.py
@@ -28,6 +28,9 @@ class EkfacConfig:
     `HessianConfig.ev_correction=True`."""
     apply_batch_size: int = 32
     """Number of query gradients moved on-device and preconditioned at a time."""
+    power: float = -1.0
+    """Inverse power applied to the fitted factor eigenvalues (-1.0 = full
+    inverse)."""
     debug: bool = False
 
 
@@ -68,14 +71,28 @@ class EkfacApplicator:
         self.device = get_device(self.rank)
 
     def compute_ivhp_sharded(self):
-        preconditioner = FactoredPreconditioner.from_shards(
-            self.path,
-            rank=self.rank,
-            device=self.device,
-            inversion_cfg=None if self.apply_fn is not None else self.inversion_cfg,
-            apply_fn=self.apply_fn,
-            ev_correction=self.cfg.ev_correction,
-        )
+        if self.world_size == 1:
+            # load the full factors and run non-distributed: avoids the sharded
+            # send/recv path, which can hang on some nodes, and lets a
+            # distributed fit be applied on a single gpu
+            preconditioner = FactoredPreconditioner.from_path(
+                self.path,
+                device=self.device,
+                inversion_cfg=None if self.apply_fn is not None else self.inversion_cfg,
+                apply_fn=self.apply_fn,
+                ev_correction=self.cfg.ev_correction,
+                power=self.cfg.power,
+            )
+        else:
+            preconditioner = FactoredPreconditioner.from_shards(
+                self.path,
+                rank=self.rank,
+                device=self.device,
+                inversion_cfg=None if self.apply_fn is not None else self.inversion_cfg,
+                apply_fn=self.apply_fn,
+                ev_correction=self.cfg.ev_correction,
+                power=self.cfg.power,
+            )
 
         grad_sizes = {
             name: preconditioner.eigen_g[name].shape[1]

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -60,7 +60,11 @@ def hessian_pipeline(
     method = hessian_cfg.method
     query_path = f"{run_path}/query"
     hessian_path = f"{run_path}/hessian"
-    transformed_query_path = f"{run_path}/{method}_query"
+    # tag the output dir with non-default powers so one fit can be applied
+    # at several powers
+    apply_power = hessian_cfg.apply_power
+    power_tag = "" if apply_power == -1.0 else f"_p{-apply_power:g}"
+    transformed_query_path = f"{run_path}/{method}{power_tag}_query"
     scores_path = f"{run_path}/scores"
     resume = hessian_pipeline_cfg.resume
 
@@ -110,6 +114,7 @@ def hessian_pipeline(
             gradient_path=query_path,
             run_path=transformed_query_path,
             ev_correction=hessian_cfg.ev_correction,
+            power=apply_power,
         )
         launch_distributed_run(
             "apply_hessian",


### PR DESCRIPTION
## Summary
- Adds `HessianConfig.apply_power` (default `-1.0`, the full inverse): the inverse power applied to the fitted eigenvalue grid when preconditioning the query gradient. On a factored Hessian a grid power `p` applies per-side factor powers `p`, so `-0.5` is the two-sided square-root inverse `A^-1/2 G S^-1/2` and `-0.25` the per-side quarter roots `A^-1/4 G S^-1/4` (classic Shampoo's exponent, the Muon-equivalent preconditioner).
- The fit is identical across powers, so the pipeline qualifies the transformed-query dir with the power (`shampoo_p0.25_query`) to let one fit be applied at several powers; default-power paths are unchanged.
- Threaded through `EkfacConfig.power` into `FactoredPreconditioner`. The single-process apply path now loads full factors via `from_path`, avoiding the sharded send/recv NCCL deadlock and allowing a distributed fit to be applied on one GPU.

## Test plan
- `tests/ekfac_tests/test_inversion_math.py` covers the power composition (`H^-1/2` applied twice equals `H^-1`); GPU suites `test_factored_preconditioner.py` / `test_uneven_sharding.py` / `test_inversion.py` pass on A40s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8To9uuNZ9RAxXpW5w3YQ4