### PR TITLE
Add rank-truncated pseudoinverse inversion modes (Meta distributed_shampoo semantics)

### DIFF
--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -16,7 +16,6 @@ from ..config.config import (
     HessianConfig,
     HessianPipelineConfig,
     IndexConfig,
-    TrackstarIndexConfig,
     MetasmoothnessConfig,
     MixConfig,
     PreprocessConfig,
@@ -24,6 +23,7 @@ from ..config.config import (
     RecallConfig,
     ScoreConfig,
     TrackstarConfig,
+    TrackstarIndexConfig,
     TrainingConfig,
     ValidationConfig,
 )

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -76,9 +76,9 @@ class InversionConfig(Serializable):
       damping.
     - "factored_tikhonov": damped inverse with the damping split across the
       activation (A) and gradient (G) Kronecker factors via the Martens &
-      Grosse trace ratio ``π = sqrt(mean(λ_A) / mean(λ_G))``. Factored EKFAC
-      only; falls back to ``damped_inverse`` for the dense autocorrelation
-      Hessian, which has no Kronecker structure.
+      Grosse trace ratio ``π = sqrt(mean(λ_A) / mean(λ_G))``. Factored
+      Hessians only; falls back to ``damped_inverse`` for the dense
+      autocorrelation Hessian, which has no Kronecker structure.
     - "pseudoinverse": ``1/λ`` where ``λ > c·mean(λ)``, else ``0`` (truncated
       Moore-Penrose pseudoinverse).
     - "pseudoinverse_rank": ``1/λ`` where ``λ > clamp(rank_rtol·max(λ),
@@ -89,7 +89,7 @@ class InversionConfig(Serializable):
       Kronecker factor; a grid cell ``λ_G·λ_A`` survives only if both factor
       eigenvalues pass their own factor's threshold — matching
       distributed_shampoo's per-side truncated roots ``L^{†p} G R^{†p}``.
-      Factored EKFAC only (falls back to "pseudoinverse_rank" for the dense
+      Factored Hessians only (falls back to "pseudoinverse_rank" for the dense
       autocorrelation Hessian); incompatible with ``ev_correction``.
     - "tikhonov_filtered": ``λ / (λ² + α²)`` with ``α = c·mean(λ)`` — the
       Tikhonov filter factor / ridge solution ``(H² + α²I)⁻¹H``."""

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -96,22 +96,16 @@ class InversionConfig(Serializable):
 
     damping_factor: float = 0.1
     """Damping / truncation strength, relative to the mean eigenvalue. Ignored
-    by the "pseudoinverse_rank" / "pseudoinverse_factored" modes, which use
-    ``rank_rtol`` / ``rank_atol`` instead."""
+    by the "pseudoinverse_rank" / "pseudoinverse_factored" modes."""
 
     rank_rtol: float | None = None
-    """Relative truncation tolerance for the "pseudoinverse_rank" /
-    "pseudoinverse_factored" modes: eigenvalues at or below
-    ``rank_rtol·max(λ)`` are zeroed. ``None`` uses the
-    ``torch.linalg.matrix_rank`` / Meta distributed_shampoo default,
-    ``numel(λ)·machine_eps``. Being relative, it is invariant to the trace
-    normalization and sample-count scaling of the stored factors."""
+    """Relative truncation tolerance for the rank-based pseudoinverse modes:
+    eigenvalues at or below ``rank_rtol·max(λ)`` are zeroed. ``None`` uses
+    ``numel(λ)·machine_eps``. See :ref:`preconditioners`."""
 
     rank_atol: float = 0.0
     """Absolute floor for the truncation threshold of the rank-based
-    pseudoinverse modes. Compared in units of the stored eigenvalues, which
-    for factored Hessians are trace-normalized and scaled by
-    ``sqrt(total_processed)`` per factor."""
+    pseudoinverse modes. See :ref:`preconditioners`."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -81,11 +81,37 @@ class InversionConfig(Serializable):
       Hessian, which has no Kronecker structure.
     - "pseudoinverse": ``1/λ`` where ``λ > c·mean(λ)``, else ``0`` (truncated
       Moore-Penrose pseudoinverse).
+    - "pseudoinverse_rank": ``1/λ`` where ``λ > clamp(rank_rtol·max(λ),
+      min=rank_atol)``, else ``0`` — the ``torch.linalg.matrix_rank`` cutoff
+      used by Meta distributed_shampoo's ``PseudoInverseConfig``, applied to
+      the joint spectrum. Ignores ``damping_factor``.
+    - "pseudoinverse_factored": the same cutoff computed separately per
+      Kronecker factor; a grid cell ``λ_G·λ_A`` survives only if both factor
+      eigenvalues pass their own factor's threshold — matching
+      distributed_shampoo's per-side truncated roots ``L^{†p} G R^{†p}``.
+      Factored EKFAC only (falls back to "pseudoinverse_rank" for the dense
+      autocorrelation Hessian); incompatible with ``ev_correction``.
     - "tikhonov_filtered": ``λ / (λ² + α²)`` with ``α = c·mean(λ)`` — the
       Tikhonov filter factor / ridge solution ``(H² + α²I)⁻¹H``."""
 
     damping_factor: float = 0.1
-    """Damping / truncation strength, relative to the mean eigenvalue."""
+    """Damping / truncation strength, relative to the mean eigenvalue. Ignored
+    by the "pseudoinverse_rank" / "pseudoinverse_factored" modes, which use
+    ``rank_rtol`` / ``rank_atol`` instead."""
+
+    rank_rtol: float | None = None
+    """Relative truncation tolerance for the "pseudoinverse_rank" /
+    "pseudoinverse_factored" modes: eigenvalues at or below
+    ``rank_rtol·max(λ)`` are zeroed. ``None`` uses the
+    ``torch.linalg.matrix_rank`` / Meta distributed_shampoo default,
+    ``numel(λ)·machine_eps``. Being relative, it is invariant to the trace
+    normalization and sample-count scaling of the stored factors."""
+
+    rank_atol: float = 0.0
+    """Absolute floor for the truncation threshold of the rank-based
+    pseudoinverse modes. Compared in units of the stored eigenvalues, which
+    for factored Hessians are trace-normalized and scaled by
+    ``sqrt(total_processed)`` per factor."""
 
 
 @dataclass

--- a/bergson/hessians/inversion.py
+++ b/bergson/hessians/inversion.py
@@ -16,6 +16,15 @@ mean over the whole spectrum:
 - ``tikhonov_filtered``: ``λ / (λ² + α²)`` with ``α = c·mean(λ)`` (the Tikhonov
   filter factor; formerly named ``cauchy`` for its Lorentzian shape).
 - ``pseudoinverse``: ``1/λ`` where ``λ > c·mean(λ)``, else ``0``.
+- ``pseudoinverse_rank``: ``1/λ`` where ``λ > clamp(rtol·max(λ), min=atol)``,
+  else ``0`` — the ``torch.linalg.matrix_rank`` cutoff used by Meta's
+  distributed_shampoo ``PseudoInverseConfig``, applied to the joint spectrum.
+  Ignores ``damping_factor``; ``rtol = None`` defaults to ``numel(λ)·eps``.
+- ``pseudoinverse_factored``: the Meta cutoff computed per Kronecker factor —
+  a grid cell survives only if *both* its ``λ_A`` and ``λ_G`` pass their own
+  factor's threshold, matching distributed_shampoo's per-factor
+  ``L^{†p} G R^{†p}``. Factored EKFAC only; falls back to
+  ``pseudoinverse_rank`` for the dense autocorrelation Hessian.
 - ``factored_tikhonov``: damping split across the Kronecker activation (A) and
   gradient (G) factors (see :func:`factored_tikhonov_damped`). This has no dense
   analogue (there is no A/G split for a dense Gram), so on the dense path it
@@ -28,7 +37,12 @@ import torch
 from torch import Tensor
 
 Inversion = Literal[
-    "damped_inverse", "factored_tikhonov", "pseudoinverse", "tikhonov_filtered"
+    "damped_inverse",
+    "factored_tikhonov",
+    "pseudoinverse",
+    "pseudoinverse_rank",
+    "pseudoinverse_factored",
+    "tikhonov_filtered",
 ]
 """Eigenvalue function used to invert a Hessian / preconditioner matrix."""
 
@@ -36,6 +50,8 @@ INVERSIONS: tuple[Inversion, ...] = (
     "damped_inverse",
     "factored_tikhonov",
     "pseudoinverse",
+    "pseudoinverse_rank",
+    "pseudoinverse_factored",
     "tikhonov_filtered",
 )
 
@@ -85,6 +101,77 @@ def pseudoinverse_eigfn(
     tol = damping_factor * mean
     return torch.where(
         eigenvals > tol, eigenvals.reciprocal(), torch.zeros_like(eigenvals)
+    )
+
+
+def rank_eigenvalue_threshold(
+    spectrum_max: Tensor,
+    spectrum_numel: int,
+    rank_rtol: float | None,
+    rank_atol: float,
+) -> Tensor:
+    """The ``torch.linalg.matrix_rank``-style truncation cutoff
+    ``clamp(rtol·max(λ)⁺, min=atol)`` used by Meta's distributed_shampoo
+    pseudo-inverse (``rtol = None`` → ``numel(λ)·eps`` of the dtype).
+
+    ``spectrum_max`` must be the max over the full spectrum (globally reduced
+    when sharded) and ``spectrum_numel`` the full element count, so every rank
+    computes the same cutoff.
+    """
+    rtol = (
+        spectrum_numel * torch.finfo(spectrum_max.dtype).eps
+        if rank_rtol is None
+        else rank_rtol
+    )
+    return torch.clamp(rtol * spectrum_max.relu(), min=rank_atol)
+
+
+def rank_pseudoinverse_multiplier(
+    eigvals: Tensor,
+    spectrum_max: Tensor,
+    spectrum_numel: int,
+    rank_rtol: float | None,
+    rank_atol: float,
+) -> Tensor:
+    """Truncated pseudoinverse with the Meta / ``matrix_rank`` cutoff:
+    ``1/λ`` where ``λ > clamp(rtol·max(λ), min=atol)``, else ``0``."""
+    tol = rank_eigenvalue_threshold(spectrum_max, spectrum_numel, rank_rtol, rank_atol)
+    tiny = torch.finfo(eigvals.dtype).tiny
+    return torch.where(
+        eigvals > tol,
+        eigvals.clamp_min(tiny).reciprocal(),
+        torch.zeros_like(eigvals),
+    )
+
+
+def factored_rank_pseudoinverse_multiplier(
+    eigvals: Tensor,
+    factor_a: Tensor,
+    factor_g: Tensor,
+    max_a: Tensor,
+    max_g: Tensor,
+    numel_a: int,
+    numel_g: int,
+    rank_rtol: float | None,
+    rank_atol: float,
+) -> Tensor:
+    """Per-factor truncated pseudoinverse on the EKFAC eigenvalue grid.
+
+    Each factor's spectrum gets its own Meta-style cutoff; a grid cell
+    ``λ = λ_G[o]·λ_A[i]`` survives only if both ``λ_G[o]`` and ``λ_A[i]`` pass
+    theirs. Raised to a fractional power downstream this reproduces
+    distributed_shampoo's per-side truncated roots ``L^{†p} G R^{†p}`` exactly,
+    since ``(L^† ⊗ R^†)^p`` masks and powers factor-wise.
+
+    ``factor_a`` is the full ``λ_A [I]``; ``factor_g`` may be this rank's
+    row-shard of ``λ_G [O]``, with ``max_g`` / ``numel_g`` globally reduced.
+    """
+    tol_a = rank_eigenvalue_threshold(max_a, numel_a, rank_rtol, rank_atol)
+    tol_g = rank_eigenvalue_threshold(max_g, numel_g, rank_rtol, rank_atol)
+    mask = (factor_g > tol_g).unsqueeze(1) & (factor_a > tol_a).unsqueeze(0)
+    tiny = torch.finfo(eigvals.dtype).tiny
+    return torch.where(
+        mask, eigvals.clamp_min(tiny).reciprocal(), torch.zeros_like(eigvals)
     )
 
 
@@ -143,6 +230,14 @@ def eigenvalue_multiplier(
     factor_g: Tensor | None = None,
     mean_a: Tensor | None = None,
     mean_g: Tensor | None = None,
+    spectrum_max: Tensor | None = None,
+    spectrum_numel: int | None = None,
+    max_a: Tensor | None = None,
+    max_g: Tensor | None = None,
+    numel_a: int | None = None,
+    numel_g: int | None = None,
+    rank_rtol: float | None = None,
+    rank_atol: float = 0.0,
     power: float = -1.0,
 ) -> Tensor:
     """The elementwise inverse multiplier ``m(λ)``.
@@ -154,8 +249,11 @@ def eigenvalue_multiplier(
     ``-0.5`` for the matrix square-root inverse (the multiplier is raised to
     ``-power`` so that applying it twice recovers the full inverse).
 
-    ``factored_tikhonov`` requires the per-factor eigenvalues and their means; the
-    other modes are pure functions of ``(λ, mean, c)``.
+    ``factored_tikhonov`` requires the per-factor eigenvalues and their means;
+    ``pseudoinverse_rank`` requires the (globally reduced) ``spectrum_max`` /
+    ``spectrum_numel``; ``pseudoinverse_factored`` requires the per-factor
+    eigenvalues and their (globally reduced) maxes; the remaining modes are pure
+    functions of ``(λ, mean, c)``.
     """
     if inversion == "factored_tikhonov":
         assert (
@@ -167,6 +265,33 @@ def eigenvalue_multiplier(
         multiplier = factored_tikhonov_damped(
             eigvals, factor_a, factor_g, mean, mean_a, mean_g, damping_factor
         ).reciprocal()
+    elif inversion == "pseudoinverse_rank":
+        assert (
+            spectrum_max is not None and spectrum_numel is not None
+        ), "pseudoinverse_rank needs the global spectrum max and numel"
+        multiplier = rank_pseudoinverse_multiplier(
+            eigvals, spectrum_max, spectrum_numel, rank_rtol, rank_atol
+        )
+    elif inversion == "pseudoinverse_factored":
+        assert (
+            factor_a is not None
+            and factor_g is not None
+            and max_a is not None
+            and max_g is not None
+            and numel_a is not None
+            and numel_g is not None
+        ), "pseudoinverse_factored needs the per-factor eigenvalues, maxes, numels"
+        multiplier = factored_rank_pseudoinverse_multiplier(
+            eigvals,
+            factor_a,
+            factor_g,
+            max_a,
+            max_g,
+            numel_a=numel_a,
+            numel_g=numel_g,
+            rank_rtol=rank_rtol,
+            rank_atol=rank_atol,
+        )
     else:
         multiplier = EIGENFNS[inversion](eigvals, mean, damping_factor)
 
@@ -182,6 +307,8 @@ def invert_psd_matrix(
     damping_factor: float = 0.1,
     power: float = -1.0,
     dtype: torch.dtype = torch.float64,
+    rank_rtol: float | None = None,
+    rank_atol: float = 0.0,
 ) -> Tensor:
     """Dense regularized inverse power of a p.s.d. matrix H via eigendecomposition.
 
@@ -196,8 +323,9 @@ def invert_psd_matrix(
     factored path); for ``power = -0.5`` it is raised to ``0.5`` so that applying
     the result twice recovers the full inverse.
 
-    ``factored_tikhonov`` has no dense analogue (there is no Kronecker A/G split
-    for a dense Gram) and falls back to ``damped_inverse`` here.
+    ``factored_tikhonov`` and ``pseudoinverse_factored`` have no dense analogue
+    (there is no Kronecker A/G split for a dense Gram) and fall back to
+    ``damped_inverse`` / ``pseudoinverse_rank`` respectively here.
     """
     original_dtype = H.dtype
     H = H.to(dtype=dtype)
@@ -208,11 +336,21 @@ def invert_psd_matrix(
     # below is real-valued).
     eigvals = eigvals.clamp_min(0)
 
-    dense_inversion = (
-        "damped_inverse" if inversion == "factored_tikhonov" else inversion
-    )
+    dense_fallbacks: dict[Inversion, Inversion] = {
+        "factored_tikhonov": "damped_inverse",
+        "pseudoinverse_factored": "pseudoinverse_rank",
+    }
+    dense_inversion = dense_fallbacks.get(inversion, inversion)
     scaled = eigenvalue_multiplier(
-        dense_inversion, eigvals, eigvals.mean(), damping_factor, power=power
+        dense_inversion,
+        eigvals,
+        eigvals.mean(),
+        damping_factor,
+        spectrum_max=eigvals.max(),
+        spectrum_numel=eigvals.numel(),
+        rank_rtol=rank_rtol,
+        rank_atol=rank_atol,
+        power=power,
     )
 
     return (eigvecs * scaled @ eigvecs.mH).to(original_dtype)

--- a/bergson/hessians/inversion.py
+++ b/bergson/hessians/inversion.py
@@ -2,7 +2,7 @@
 
 Two representations of the Hessian coexist in the library:
 
-- the factored EKFAC family (kfac / tkfac / shampoo), where the Hessian is a
+- the factored Hessian family (kfac / tkfac / shampoo), where the Hessian is a
   Kronecker product applied via the eigenbasis rotation in
   :class:`~bergson.hessians.preconditioner.FactoredPreconditioner`, and
 - the dense autocorrelation Gram, where :func:`invert_psd_matrix`
@@ -23,7 +23,7 @@ mean over the whole spectrum:
 - ``pseudoinverse_factored``: the Meta cutoff computed per Kronecker factor —
   a grid cell survives only if *both* its ``λ_A`` and ``λ_G`` pass their own
   factor's threshold, matching distributed_shampoo's per-factor
-  ``L^{†p} G R^{†p}``. Factored EKFAC only; falls back to
+  ``L^{†p} G R^{†p}``. Factored Hessians only; falls back to
   ``pseudoinverse_rank`` for the dense autocorrelation Hessian.
 - ``factored_tikhonov``: damping split across the Kronecker activation (A) and
   gradient (G) factors (see :func:`factored_tikhonov_damped`). This has no dense
@@ -155,7 +155,7 @@ def factored_rank_pseudoinverse_multiplier(
     rank_rtol: float | None,
     rank_atol: float,
 ) -> Tensor:
-    """Per-factor truncated pseudoinverse on the EKFAC eigenvalue grid.
+    """Per-factor truncated pseudoinverse on the factored eigenvalue grid.
 
     Each factor's spectrum gets its own Meta-style cutoff; a grid cell
     ``λ = λ_G[o]·λ_A[i]`` survives only if both ``λ_G[o]`` and ``λ_A[i]`` pass
@@ -177,7 +177,7 @@ def factored_rank_pseudoinverse_multiplier(
 
 # Inversion modes expressible as a pure function of ``(λ, mean(λ), c)``. These
 # operate elementwise, so they apply unchanged to the dense 1-D spectrum and to
-# the EKFAC eigenvalue grid. ``factored_tikhonov`` is intentionally absent: it
+# the factored eigenvalue grid. ``factored_tikhonov`` is intentionally absent: it
 # needs the per-factor A/G eigenvalues and only exists for the factored path.
 EIGENFNS: dict[str, Callable[[Tensor, Tensor, float], Tensor]] = {
     "damped_inverse": damped_inverse_eigfn,
@@ -203,7 +203,7 @@ def factored_tikhonov_damped(
 
         λ + π·√(c·mean(λ))·λ_G + (√(c·mean(λ))/π)·λ_A + c·mean(λ)
 
-    ``eigvals`` is the EKFAC eigenvalue grid ``λ`` (= ``λ_G ⊗ λ_A``); ``factor_a``
+    ``eigvals`` is the factored eigenvalue grid ``λ`` (= ``λ_G ⊗ λ_A``); ``factor_a``
     / ``factor_g`` are the per-factor eigenvalues ``λ_A`` ``[I]`` / ``λ_G`` ``[O]``.
     All means are passed in so the distributed path can supply globally-reduced
     values rather than per-shard ones. Reciprocate the result for the inverse.

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -68,6 +68,8 @@ class DensePreconditioner:
                 inversion=inversion_cfg.inversion,
                 damping_factor=inversion_cfg.damping_factor,
                 power=power,
+                rank_rtol=inversion_cfg.rank_rtol,
+                rank_atol=inversion_cfg.rank_atol,
             )
             for name, H in processor.hessians.items()
         }
@@ -186,21 +188,23 @@ class FactoredPreconditioner:
     def _from_loaded(
         cls, load, load_replicated, inversion_cfg, apply_fn, power, ev_correction
     ):
-        factored_tikhonov = (
-            inversion_cfg is not None and inversion_cfg.inversion == "factored_tikhonov"
+        needs_factor_eigs = inversion_cfg is not None and inversion_cfg.inversion in (
+            "factored_tikhonov",
+            "pseudoinverse_factored",
         )
-        if factored_tikhonov and ev_correction:
+        if needs_factor_eigs and ev_correction:
             raise ValueError(
-                "factored_tikhonov inversion is incompatible with ev_correction: "
-                "the corrected eigenvalues do not factorize as λ_G ⊗ λ_A. Use a "
-                "different inversion (e.g. damped_inverse) or set ev_correction=False."
+                f"{inversion_cfg.inversion} inversion is incompatible with "  # type: ignore[union-attr]
+                "ev_correction: the corrected eigenvalues do not factorize as "
+                "λ_G ⊗ λ_A. Use a different inversion (e.g. damped_inverse) or "
+                "set ev_correction=False."
             )
 
         lambda_dir = (
             "eigenvalue_correction_sharded" if ev_correction else "eigenvalue_sharded"
         )
         factor_eig_a = factor_eig_g = None
-        if factored_tikhonov:
+        if needs_factor_eigs:
             # factor_eig_a indexes the unsharded column dim I -> replicated, full
             # [I]; factor_eig_g indexes the sharded row dim O -> row-sharded.
             factor_eig_a = load_replicated("factor_eig_a")  # replicated, full [I]
@@ -243,6 +247,36 @@ class FactoredPreconditioner:
                     factor_g=factor_g,
                     mean_a=factor_a.clamp_min(0).mean(),
                     mean_g=self.shard_computer.global_mean(factor_g.clamp_min(0), o),
+                    power=self.power,
+                )
+            elif inversion == "pseudoinverse_factored":
+                factor_a = self.factor_eig_a[name]
+                factor_g = self.factor_eig_g[name]
+                inverse_eigvals = eigenvalue_multiplier(
+                    inversion,
+                    lam,
+                    mean,
+                    self.inversion_cfg.damping_factor,
+                    factor_a=factor_a,
+                    factor_g=factor_g,
+                    max_a=factor_a.max(),
+                    max_g=self.shard_computer.global_max(factor_g),
+                    numel_a=i,
+                    numel_g=o,
+                    rank_rtol=self.inversion_cfg.rank_rtol,
+                    rank_atol=self.inversion_cfg.rank_atol,
+                    power=self.power,
+                )
+            elif inversion == "pseudoinverse_rank":
+                inverse_eigvals = eigenvalue_multiplier(
+                    inversion,
+                    lam,
+                    mean,
+                    self.inversion_cfg.damping_factor,
+                    spectrum_max=self.shard_computer.global_max(lam),
+                    spectrum_numel=o * i,
+                    rank_rtol=self.inversion_cfg.rank_rtol,
+                    rank_atol=self.inversion_cfg.rank_atol,
                     power=self.power,
                 )
             else:

--- a/bergson/hessians/sharded_computation.py
+++ b/bergson/hessians/sharded_computation.py
@@ -121,6 +121,17 @@ class ShardedMul:
             dist.all_reduce(total, op=dist.ReduceOp.SUM)
         return total / full_numel
 
+    def global_max(self, x_shard: Tensor) -> Tensor:
+        """Max of a row-sharded tensor over its full extent.
+
+        ``x_shard`` is this rank's row-shard. Maxes locally, all-reduces when
+        distributed, so every rank gets the global max.
+        """
+        local_max = x_shard.max()
+        if self.dist:
+            dist.all_reduce(local_max, op=dist.ReduceOp.MAX)
+        return local_max
+
     def scale_rows_in_place(
         self,
         matrix_noi: Float[Tensor, "n o i"],

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -246,6 +246,76 @@ With ``--method kfac`` / ``tkfac`` / ``shampoo``:
        --truncation \
        --method kfac
 
+.. _preconditioners:
+
+Preconditioners: Inverting and Applying Hessians
+------------------------------------------------
+
+A fitted Hessian is applied to gradients as a *preconditioner* ``H^p``. Two
+knobs control this: ``apply_power`` (how much inverse) and the
+``InversionConfig`` (how eigenvalues are regularized before the power is
+taken). The fit itself is identical for every setting of both — only the
+apply changes.
+
+**Apply power**
+
+``HessianConfig.apply_power`` is the inverse power ``p`` applied to the fitted
+eigenvalue grid. For a factored (Kronecker) Hessian ``H = A ⊗ S``, a grid
+power ``p`` is equivalent to per-side factor powers ``p``, since
+``(A ⊗ S)^p = A^p ⊗ S^p``:
+
+- ``-1.0`` — the full inverse ``A^-1 G S^-1``, the influence-function
+  preconditioner.
+- ``-0.5`` — the two-sided square-root inverse ``A^-1/2 G S^-1/2``. Applied to
+  *both* sides of a score inner product this recovers the full inverse
+  (``⟨H^-1/2 q, H^-1/2 g⟩ = q^T H^-1 g``, the ``unit_normalize`` convention);
+  applied one-sided it is a genuinely gentler preconditioner.
+- ``-0.25`` — the per-side quarter roots ``A^-1/4 G S^-1/4``: classic
+  Shampoo's exponent (Meta distributed_shampoo's default root ``1/(2·order)``
+  for a matrix) and the Muon-orthogonalization-equivalent preconditioner.
+
+Because one fit serves every power, the hessian pipeline tags its output
+directory with non-default powers (e.g. ``shampoo_p0.25_query``).
+
+**Inversion modes and their knobs**
+
+Each ``InversionConfig.inversion`` mode maps eigenvalues ``λ`` to a multiplier
+``m(λ)``, which is then raised to ``-apply_power``; regularization therefore
+composes *inside* the power for the damped modes (``(λ + δ)^p``) and as
+truncate-then-power for the pseudoinverse modes (``λ^p·𝟙[λ > tol]``).
+
+The mean-relative modes (``damped_inverse``, ``tikhonov_filtered``,
+``pseudoinverse``, ``factored_tikhonov``) are controlled by
+``damping_factor``: their damping or truncation threshold is
+``damping_factor · mean(λ)``.
+
+The rank-based modes (``pseudoinverse_rank``, ``pseudoinverse_factored``)
+ignore ``damping_factor`` and instead use the ``torch.linalg.matrix_rank``
+convention, matching Meta distributed_shampoo's ``PseudoInverseConfig``:
+
+- threshold = ``clamp(rank_rtol · max(λ), min=rank_atol)``;
+- ``rank_rtol=None`` (the default) means ``numel(λ) · machine_eps``, the
+  ``torch.linalg.matrix_rank`` / distributed_shampoo default;
+- distributed_shampoo requires ``epsilon=0`` with pseudo-inverse, and
+  correspondingly no damping term is added in these modes.
+
+``pseudoinverse_rank`` thresholds the joint eigenvalue spectrum;
+``pseudoinverse_factored`` computes a separate threshold per Kronecker factor,
+so a grid cell ``λ_G·λ_A`` survives only if both factor eigenvalues pass their
+own factor's cutoff — a cell whose *product* is large is still zeroed when one
+factor is rank-deficient, reproducing distributed_shampoo's per-side truncated
+roots ``L^{†p} G R^{†p}``.
+
+**Tolerance units**
+
+The stored factor eigenvalues are trace-normalized and scaled by
+``sqrt(total_processed)`` per factor. ``rank_rtol`` is relative to
+``max(λ)``, so it is invariant to both rescalings and transfers across fits —
+prefer it. ``rank_atol`` is compared in the stored units, *not* in units of a
+raw gradient-covariance accumulator, so an absolute floor tuned for one fit
+(or borrowed from an optimizer setting such as ``eps=1e-15``) does not
+transfer directly.
+
 Choosing the Right Command
 --------------------------
 

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -316,6 +316,34 @@ raw gradient-covariance accumulator, so an absolute floor tuned for one fit
 (or borrowed from an optimizer setting such as ``eps=1e-15``) does not
 transfer directly.
 
+**Background: influence-function vs optimizer-style inversion**
+
+The two regularization families come from different lineages, and they answer
+the rank-deficiency question differently.
+
+The influence-function literature (Koh & Liang 2017; EK-FAC influence, Grosse
+et al. 2023) inverts with Tikhonov damping — ``(H + δI)^-1`` with ``δ``
+proportional to the mean eigenvalue. Near-null directions receive a large but
+*bounded* gain of about ``1/δ``: rare directions get extra credit, but noise
+in the unexplored subspace cannot dominate a score. This is bergson's default
+(``damped_inverse``).
+
+The optimizer lineage instead takes fractional inverse roots of the gradient
+second moment (Shampoo's per-side quarter roots), and in practice handles
+rank deficiency by *truncation*: Meta's distributed_shampoo with
+pseudo-inverse enabled zeroes the deficient part of each factor's spectrum
+rather than damping it, as highlighted in Rohan Anil's NanoGPT-speedrun
+retuning (https://x.com/_arohan_/status/2064631528806908134). Null directions
+are ignored entirely — the preconditioner acts only on the subspace the data
+actually explored.
+
+That optimizer configuration transplants into attribution as
+``apply_power: -0.25`` with ``inversion: pseudoinverse_factored`` and default
+tolerances; ``examples/pipelines/rohan_shampoo_gpt2_lds.yaml`` runs exactly
+this against the influence-function baseline. Whether zeroing or damping the
+null space attributes better is an empirical question — the LDS comparisons
+these knobs exist for.
+
 Choosing the Right Command
 --------------------------
 

--- a/examples/pipelines/rohan_shampoo_gpt2_lds.yaml
+++ b/examples/pipelines/rohan_shampoo_gpt2_lds.yaml
@@ -1,0 +1,50 @@
+# https://x.com/_arohan_/status/2064631528806908134
+#
+# Run with:
+#   bergson examples/pipelines/rohan_shampoo_gpt2_lds.yaml
+run_path: /mnt/ssd-2/lucia-adam-shampoo/shampoo_rohan_adam/pipeline
+steps:
+- ekfac:
+    index_cfg:
+      run_path: /mnt/ssd-2/lucia-adam-shampoo/shampoo_rohan_adam/scores
+      model: /mnt/ssd-2/lucia-adam-shampoo/run_adam/N4k/retrained/base
+      overwrite: false
+      projection_dim: 0
+      token_batch_size: 1024
+      max_batch_size: 64
+      filter_modules: lm_head
+      distributed:
+        nproc_per_node: 8
+        nnode: 1
+      data: &train_data
+        dataset: /mnt/ssd-1/lucia/bergson-damping/runs/ekfac_vs_n/datasets/train_4k.hf
+        split: train
+        chunk_length: 0
+    hessian_cfg:
+      method: shampoo
+      apply_power: -0.25
+      ev_correction: false
+    score_cfg:
+      batch_size: 1024
+    preprocess_cfg:
+      unit_normalize: false
+    hessian_pipeline_cfg:
+      query: &query_data
+        dataset: /mnt/ssd-1/lucia/bergson-damping/runs/ekfac_vs_n/datasets/query_50.hf
+        split: train
+        chunk_length: 0
+      query_aggregation: none
+      inversion_cfg:
+        inversion: pseudoinverse_factored
+        rank_rtol: null
+        rank_atol: 0.0
+      resume: true
+- validate:
+    run_path: /mnt/ssd-2/lucia-adam-shampoo/shampoo_rohan_adam/validate
+    model: gpt2
+    overwrite: true
+    scores: /mnt/ssd-2/lucia-adam-shampoo/shampoo_rohan_adam/scores/scores
+    retrained_dir: /mnt/ssd-2/lucia-adam-shampoo/run_adam/N4k
+    data: *train_data
+    query: *query_data
+    batch_size: 50

--- a/tests/ekfac_tests/test_factored_preconditioner.py
+++ b/tests/ekfac_tests/test_factored_preconditioner.py
@@ -75,9 +75,10 @@ def test_factored_matches_ekfac_applicator(
     query_path = str(tmp_path / "query")
     _make_query_gradients(query_path, grad_sizes, num_grads)
 
-    # factored_tikhonov assumes the eigenvalue grid factorizes as λ = λ_G ⊗ λ_A,
-    # which the EV-corrected eigenvalues do not; apply it to the uncorrected grid.
-    ev_correction = inversion != "factored_tikhonov"
+    # factored_tikhonov and pseudoinverse_factored assume the eigenvalue grid
+    # factorizes as λ = λ_G ⊗ λ_A, which the EV-corrected eigenvalues do not;
+    # apply them to the uncorrected grid.
+    ev_correction = inversion not in ("factored_tikhonov", "pseudoinverse_factored")
 
     # Reference: the pipeline's file-based applicator (full inverse).
     ref = _apply(

--- a/tests/ekfac_tests/test_inversion.py
+++ b/tests/ekfac_tests/test_inversion.py
@@ -70,10 +70,13 @@ def test_inversion_methods_apply(ekfac_results_path: str, tmp_path):
     sample = sorted(grad_sizes.keys())[0]
     outputs = {}
     for inversion in INVERSIONS:
-        # factored_tikhonov splits the damping across the Kronecker factors,
-        # which assumes λ = λ_G ⊗ λ_A; the EV-corrected eigenvalues do not
-        # factorize, so it is applied to the uncorrected grid instead.
-        ev_correction = inversion != "factored_tikhonov"
+        # factored_tikhonov and pseudoinverse_factored operate on the Kronecker
+        # factors, which assumes λ = λ_G ⊗ λ_A; the EV-corrected eigenvalues do
+        # not factorize, so they are applied to the uncorrected grid instead.
+        ev_correction = inversion not in (
+            "factored_tikhonov",
+            "pseudoinverse_factored",
+        )
         out = _apply(
             hessian_path,
             query_path,

--- a/tests/ekfac_tests/test_inversion_math.py
+++ b/tests/ekfac_tests/test_inversion_math.py
@@ -12,6 +12,7 @@ from bergson.hessians.inversion import (
     eigenvalue_multiplier,
     factored_tikhonov_damped,
     invert_psd_matrix,
+    rank_eigenvalue_threshold,
 )
 
 
@@ -156,6 +157,97 @@ def test_factored_tikhonov_regularizes():
     )
     assert torch.isfinite(inv).all() and (inv > 0).all()
     assert (inv < grid.reciprocal()).all()  # regularized inverse < raw 1/λ
+
+
+# ── rank-based pseudoinverse (Meta distributed_shampoo semantics) ──────────
+
+
+def test_rank_threshold_default_matches_matrix_rank_convention():
+    """rank_rtol=None uses the torch.linalg.matrix_rank / Meta default,
+    numel(λ)·machine_eps, scaled by the spectrum max."""
+    lam = torch.tensor([4.0, 1.0, 1e-20], dtype=torch.float64)
+    tol = rank_eigenvalue_threshold(lam.max(), lam.numel(), None, 0.0)
+    expected = lam.numel() * torch.finfo(lam.dtype).eps * lam.max()
+    assert torch.allclose(tol, expected)
+    # atol acts as an absolute floor over the relative cutoff
+    tol_floored = rank_eigenvalue_threshold(lam.max(), lam.numel(), None, 0.5)
+    assert tol_floored == 0.5
+
+
+def test_pseudoinverse_rank_absolute_floor_truncates_then_powers():
+    """rank_rtol=0 + rank_atol=eps is the eps-style absolute cutoff: eigenvalues
+    at or below eps are zeroed, survivors get λ^p (truncate, then power)."""
+    lam = torch.tensor([0.0, 1e-16, 1e-3, 1.0, 4.0], dtype=torch.float64)
+    m = eigenvalue_multiplier(
+        "pseudoinverse_rank",
+        lam,
+        lam.mean(),
+        0.1,  # damping_factor must be ignored by this mode
+        spectrum_max=lam.max(),
+        spectrum_numel=lam.numel(),
+        rank_rtol=0.0,
+        rank_atol=1e-15,
+        power=-0.25,
+    )
+    expected = torch.where(lam > 1e-15, lam.pow(-0.25), torch.zeros_like(lam))
+    assert torch.allclose(m, expected)
+
+
+def test_invert_psd_matrix_pseudoinverse_rank_matches_torch_pinv():
+    """With default tolerances, the dense rank-truncated pseudoinverse at
+    power=-1 equals torch.linalg.pinv on a rank-deficient PSD matrix."""
+    g = torch.Generator().manual_seed(5)
+    q, _ = torch.linalg.qr(torch.randn(6, 6, generator=g, dtype=torch.float64))
+    eig = torch.tensor([3.0, 2.0, 1.0, 0.5, 0.0, 0.0], dtype=torch.float64)
+    h = q @ torch.diag(eig) @ q.T
+
+    pinv = invert_psd_matrix(h, "pseudoinverse_rank")
+    assert torch.allclose(pinv, torch.linalg.pinv(h, hermitian=True), atol=1e-7)
+
+
+def test_pseudoinverse_factored_equals_per_side_truncated_roots():
+    """The factored multiplier must equal the outer product of the two factors'
+    independently truncated inverse roots — distributed_shampoo's
+    L^{†p} G R^{†p} — including cells whose *product* is large but where one
+    factor eigenvalue falls below its own cutoff."""
+    lam_a = torch.tensor([2.0, 1.0, 1e-18], dtype=torch.float64)  # λ_A [I]
+    lam_g = torch.tensor([4.0, 1e-18, 0.5], dtype=torch.float64)  # λ_G [O]
+    grid = torch.outer(lam_g, lam_a)
+    power = -0.25
+    rtol, atol = 0.0, 1e-15
+
+    m = eigenvalue_multiplier(
+        "pseudoinverse_factored",
+        grid,
+        grid.mean(),
+        0.1,  # damping_factor must be ignored by this mode
+        factor_a=lam_a,
+        factor_g=lam_g,
+        max_a=lam_a.max(),
+        max_g=lam_g.max(),
+        numel_a=lam_a.numel(),
+        numel_g=lam_g.numel(),
+        rank_rtol=rtol,
+        rank_atol=atol,
+        power=power,
+    )
+
+    def side(lam):
+        return torch.where(lam > atol, lam.pow(power), torch.zeros_like(lam))
+
+    assert torch.allclose(m, torch.outer(side(lam_g), side(lam_a)))
+    # The joint-grid mode would keep e.g. cell (0, 2): 4.0·1e-18 > 0 product
+    # semantics differ — per-side must zero the whole row/column instead.
+    assert (m[1, :] == 0).all() and (m[:, 2] == 0).all()
+
+
+def test_pseudoinverse_factored_dense_fallback_is_rank_mode():
+    """The dense Gram has no Kronecker split, so pseudoinverse_factored falls
+    back to pseudoinverse_rank."""
+    h = _psd(6)
+    factored = invert_psd_matrix(h, "pseudoinverse_factored", rank_atol=1e-12)
+    rank = invert_psd_matrix(h, "pseudoinverse_rank", rank_atol=1e-12)
+    assert torch.allclose(factored, rank)
 
 
 def test_factored_tikhonov_zero_damping_is_raw_inverse():


### PR DESCRIPTION
## Summary
Stacked on #383; adds truncate-then-power regularization matching Meta distributed_shampoo's `PseudoInverseConfig` (cutoff `clamp(rank_rtol * max(eigval), min=rank_atol)`, `rank_rtol=None` → `numel * machine_eps`, the `torch.linalg.matrix_rank` convention):

- `inversion: pseudoinverse_rank` — cutoff on the joint eigenvalue spectrum.
- `inversion: pseudoinverse_factored` — cutoff per Kronecker factor, reproducing distributed_shampoo's per-side truncated roots `L^{†p} G R^{†p}`; factored path only, incompatible with `ev_correction`, falls back to `pseudoinverse_rank` on the dense path.
- `rank_rtol` / `rank_atol` knobs on `InversionConfig`; `ShardedMul.global_max` all-reduce so distributed ranks agree on the cutoff.
- `examples/pipelines/rohan_shampoo_gpt2_lds.yaml`: the exact Rohan configuration (`method: shampoo`, `apply_power: -0.25`, `pseudoinverse_factored` with Meta-default tolerances) on the GPT-2 Adam fine-tune, scored and LDS-validated against the retraining bank. Run with `bergson examples/pipelines/rohan_shampoo_gpt2_lds.yaml`.

## Test plan
- New unit tests: default-rtol formula, absolute-floor truncate-then-power, dense equivalence to `torch.linalg.pinv` on a rank-deficient PSD matrix, per-side vs joint-grid truncation distinction, dense fallback (17/17).
- GPU applicator-equivalence and inversion suites are parametrized over `INVERSIONS`, so both new modes ran end-to-end through the file-based `EkfacApplicator` (15/15, plus `test_inversion.py`).
- The yaml dry-parses through bergson's config loader to the intended step configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8To9uuNZ9RAxXpW5w3YQ4
