### PR TITLE
feat: matrix expansion for pipeline steps

### DIFF
--- a/bergson/config/config_io.py
+++ b/bergson/config/config_io.py
@@ -1,3 +1,4 @@
+import itertools
 import subprocess
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
@@ -154,6 +155,58 @@ def load_subconfig(
     return None
 
 
+def expand_matrix(cmd_dict: dict) -> list[dict]:
+    """Expand a step's ``matrix`` mapping into one config per grid cell.
+
+    ``{key}`` in string values substitutes the cell's value; a value that is
+    exactly ``"{key}"`` becomes the typed grid value.
+    """
+    matrix = cmd_dict.pop("matrix", None)
+    if matrix is None:
+        return [cmd_dict]
+    if not isinstance(matrix, dict) or not all(
+        isinstance(v, list) and v for v in matrix.values()
+    ):
+        raise ValueError(f"matrix must map keys to non-empty lists; got {matrix!r}.")
+
+    def substitute(value, cell: dict):
+        if isinstance(value, dict):
+            return {k: substitute(v, cell) for k, v in value.items()}
+        if isinstance(value, list):
+            return [substitute(v, cell) for v in value]
+        if isinstance(value, str):
+            for key, cell_value in cell.items():
+                if value == "{" + key + "}":
+                    return cell_value
+                value = value.replace("{" + key + "}", str(cell_value))
+        return value
+
+    keys = list(matrix)
+    cells = [dict(zip(keys, values)) for values in itertools.product(*matrix.values())]
+    expanded = [cast(dict, substitute(cmd_dict, cell)) for cell in cells]
+
+    def run_paths(value):
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if k == "run_path":
+                    yield v
+                else:
+                    yield from run_paths(v)
+
+    seen: dict = {}
+    for cfg, cell in zip(expanded, cells):
+        for rp in run_paths(cfg):
+            if rp in seen:
+                raise ValueError(
+                    f"matrix cells {seen[rp]} and {cell} both write {rp}; "
+                    "vary run_path with a {key} substitution."
+                )
+            seen[rp] = cell
+    if len(cells) > 1 and not seen:
+        raise ValueError("matrix step has no run_path; cells would collide.")
+    return expanded
+
+
 def parse_steps(
     steps: list, command_registry: dict[str, type]
 ) -> list[tuple[str, Any]]:
@@ -174,8 +227,8 @@ def parse_steps(
                 f"Valid commands: {sorted(command_registry)}."
             ) from None
 
-        # Hydrate config
-        parsed_step = cmd_cls.from_dict(cmd_dict or {}, drop_extra_fields=False)
-
-        parsed.append((cmd_name, parsed_step))
+        for cell_dict in expand_matrix(dict(cmd_dict or {})):
+            parsed.append(
+                (cmd_name, cmd_cls.from_dict(cell_dict, drop_extra_fields=False))
+            )
     return parsed

--- a/tests/test_step_matrix.py
+++ b/tests/test_step_matrix.py
@@ -1,0 +1,56 @@
+"""``matrix:`` expansion of pipeline steps."""
+
+import pytest
+
+from bergson.config.config_io import expand_matrix
+
+
+def test_no_matrix_passthrough():
+    cfg = {"run_path": "runs/x", "seed": 1}
+    assert expand_matrix(dict(cfg)) == [cfg]
+
+
+def test_cartesian_expansion_with_typed_and_string_substitution():
+    out = expand_matrix(
+        {
+            "matrix": {"seed": [1, 2], "lr": [0.1]},
+            "run_path": "runs/s{seed}_lr{lr}",
+            "seed": "{seed}",
+            "lr_schedule": {"lr": "{lr}"},
+        }
+    )
+    assert len(out) == 2
+    assert out[0] == {
+        "run_path": "runs/s1_lr0.1",
+        "seed": 1,
+        "lr_schedule": {"lr": 0.1},
+    }
+    assert out[1]["seed"] == 2 and out[1]["run_path"] == "runs/s2_lr0.1"
+
+
+def test_colliding_run_paths_raise():
+    with pytest.raises(ValueError, match="both write"):
+        expand_matrix(
+            {"matrix": {"seed": [1, 2]}, "run_path": "runs/same", "seed": "{seed}"}
+        )
+
+
+def test_matrix_without_run_path_raises():
+    with pytest.raises(ValueError, match="no run_path"):
+        expand_matrix({"matrix": {"seed": [1, 2]}, "seed": "{seed}"})
+
+
+def test_nested_run_path_collision_detected():
+    with pytest.raises(ValueError, match="both write"):
+        expand_matrix(
+            {
+                "matrix": {"d": [0.1, 0.2]},
+                "index_cfg": {"run_path": "runs/fixed"},
+                "damping": "{d}",
+            }
+        )
+
+
+def test_bad_matrix_shape_raises():
+    with pytest.raises(ValueError, match="non-empty lists"):
+        expand_matrix({"matrix": {"seed": 5}})


### PR DESCRIPTION
Fable: A `matrix:` block on a pipeline step cartesian-expands it into one step per grid cell, GitHub-Actions style but deliberately smaller: `{key}` substitution in strings, typed passthrough for exact-`"{key}"` values, sequential execution, and an error when cells collide on (or lack) a `run_path`. No expressions, no scheduler — parallel execution stays with independent processes, which compose with the expansion since each cell is an ordinary step.

Replicability is preserved because the matrix never becomes the record: expansion happens in `parse_steps`, so the pipeline `config.yaml` and every step's own `config.yaml` are written from the expanded steps — each run dir holds a literal, substitution-free config replayable with `bergson <run_dir>/config.yaml`.

**Scope is frozen at product + substitution.** If include/exclude, expressions, conditionals, or config composition are ever wanted, do not extend this — adopt Hydra (or similar) properly instead of growing a bespoke DSL.

```yaml
steps:
  - validate:
      matrix:
        seed: [1004, 1005, 1006, 1007, 1008]
      run_path: runs/wikitext_repro/retrain_seed{seed}
      seed: "{seed}"
      subsets: runs/wikitext_repro/retrain/subsets.json
```

Once this and #385 land, the 5-step retrain config collapses to the block above.