### PR TITLE
feat: save_models on every training command; one name for token attribution

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -357,6 +357,11 @@ class TrainingConfig(AttributionConfig, Serializable):
     save_optimizer_state: Literal["none", "last", "all"] = "none"
     """Which checkpoints' optimizer second moments to persist. AdamW only."""
 
+    save_models: bool = False
+    """Save the trained model (HF format, weights + tokenizer) to
+    ``<run_path>/model``; ``validate`` saves the leave-k-out family to
+    ``<run_path>/retrained/{base,subset_<i>}`` instead."""
+
     save_mode: SaveMode = "sqrt"
     """Checkpoint saving mode.
 
@@ -448,11 +453,6 @@ class ValidationConfig(TrainingConfig, ABC):
     """When True, drop doc_ids with score == 0 from the validation
     permutation. These scores may be produced by items with fewer than
     2 tokens."""
-
-    save_models: bool = False
-    """When True, save each leave-k-out retrained model (HF format, weights +
-    tokenizer) to ``<run_path>/retrained/subset_<i>/`` so it can be reused for
-    later attribution queries without retraining. ~0.5 GB per subset for GPT-2."""
 
     subsets: str = ""
     """Path to a subsets.json to reuse; defaults to ``<run_path>/subsets.json``."""

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -196,7 +196,7 @@ def worker(
     )
 
     # Plain magic runs enter with score_path="" (scores are computed below).
-    per_token = getattr(run_cfg, "per_token", False) or (
+    per_token = (isinstance(run_cfg, MagicConfig) and run_cfg.attribute_tokens) or (
         score_path and scores_are_per_token(score_path)
     )
     if per_token:
@@ -258,25 +258,27 @@ def worker(
                 eps=run_cfg.adam_eps,
                 eps_root=run_cfg.eps_root,
             )
-            if getattr(run_cfg, "save_optimizer_state", "none") == "all"
+            if run_cfg.save_optimizer_state == "all"
             else None
         ),
         save_interval=run_cfg.save_interval,
     )
     # Called on every rank: FSDP moments are DTensors whose gather is a
     # collective; rank 0 writes inside.
-    if getattr(run_cfg, "save_optimizer_state", "none") != "none":
+    if run_cfg.save_optimizer_state != "none":
         save_second_moments_as_optimizer_pt(
             model,  # type: ignore[reportArgumentType]
             fwd_state.opt_state,
             os.path.join(run_cfg.run_path, "optimizer.pt"),
         )
 
-    if getattr(run_cfg, "save_models", False) and global_rank == 0:
-        # Persist the fully-trained (no leave-out) model alongside the per-subset
-        # models, so a later evaluate_retrained run can measure the query
-        # baseline from the bank itself instead of a separate base_model_dir.
-        base_dir = os.path.join(run_cfg.run_path, "retrained", "base")
+    if run_cfg.save_models and global_rank == 0:
+        # For the leave-k-out family the trained model is the query baseline
+        # that evaluate_retrained reads from retrained/base.
+        if isinstance(run_cfg, ValidationConfig):
+            base_dir = os.path.join(run_cfg.run_path, "retrained", "base")
+        else:
+            base_dir = os.path.join(run_cfg.run_path, "model")
         os.makedirs(base_dir, exist_ok=True)
         with fwd_state.activate(model), torch.no_grad():
             model.save_pretrained(base_dir, safe_serialization=True)
@@ -394,7 +396,7 @@ def worker(
 
     stream.requires_grad = False
 
-    if getattr(run_cfg, "skip_validation", False):
+    if isinstance(run_cfg, MagicConfig) and run_cfg.skip_validation:
         return
 
     validate_scores(

--- a/bergson/magic/config.py
+++ b/bergson/magic/config.py
@@ -13,9 +13,18 @@ class MagicConfig(ValidationConfig):
     cleanup_ckpts: bool = True
     """Whether to delete all but the last checkpoint during the backward pass."""
 
-    per_token: bool = False
-    """Whether to compute attribution scores per token (instead of per sequence)."""
+    attribute_tokens: bool = False
+    """Whether to compute attribution scores per token (instead of per sequence);
+    the same toggle as ``IndexConfig.attribute_tokens``."""
 
     skip_validation: bool = False
     """Stop after computing and saving attribution scores, before the
     leave-k-out retraining loop. Useful for score-only MAGIC runs."""
+
+    # TODO(Lucia Quirke, December 2026): remove per_token backward compatibility.
+    per_token: bool = False
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.per_token:
+            self.attribute_tokens = True

--- a/bergson/magic/metasmoothness.py
+++ b/bergson/magic/metasmoothness.py
@@ -18,6 +18,7 @@ import os
 
 import torch
 import torch.distributed as dist
+from transformers import AutoTokenizer
 
 from ..config.config import MetasmoothnessConfig
 from ..distributed import launch_distributed_run
@@ -116,6 +117,15 @@ def metasmoothness_worker(
             )
             thetas.append(theta)
             print(f"[metasmoothness] finished training {k + 1}/3 (w = 1 + {k}*h*v)")
+
+        if k == 0 and run_cfg.save_models and global_rank == 0:
+            out_dir = os.path.join(run_cfg.run_path, "model")
+            os.makedirs(out_dir, exist_ok=True)
+            with fwd_state.activate(model), torch.no_grad():
+                model.save_pretrained(out_dir, safe_serialization=True)
+            AutoTokenizer.from_pretrained(
+                run_cfg.tokenizer or run_cfg.model
+            ).save_pretrained(out_dir)
         del trainer, fwd_state, model
 
     if global_rank == 0:

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -334,7 +334,7 @@ def validate_scores(
     hf_set_verbosity_error()
 
     # Optionally persist each retrained model for later attribution queries.
-    save_models = getattr(run_cfg, "save_models", False)
+    save_models = run_cfg.save_models
     retrained_tokenizer = None
     if save_models and global_rank == 0:
         retrained_tokenizer = AutoTokenizer.from_pretrained(

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -91,7 +91,7 @@ def _train_and_query_loss(
     dataset,
     batch_size,
     *,
-    per_token: bool,
+    attribute_tokens: bool,
     zero_subset: torch.Tensor | None = None,
     shuffle_seed: int | None = None,
     seed: int = 42,
@@ -123,7 +123,7 @@ def _train_and_query_loss(
         ds, batch_size, num_docs, "Test", 0
     )
 
-    if per_token:
+    if attribute_tokens:
         T = max(len(row) for row in padded_ds["input_ids"])
         weight_shape = (len(padded_ds), T)
     else:
@@ -161,7 +161,7 @@ def _train_and_query_loss(
                 total += model(**batch).loss.item()
         loss = total / len(stream)
 
-    if per_token:
+    if attribute_tokens:
         trimmed = torch.tensor(padded_ds["doc_ids"])
         if pad_count:
             trimmed = trimmed[:-pad_count]
@@ -218,7 +218,7 @@ def test_magic_validation_loop_doc_token_dropout_equiv(model_name):
         model_name,
         ds,
         batch_size=batch_size,
-        per_token=True,
+        attribute_tokens=True,
         shuffle_seed=shuffle_seed,
         zero_subset=None,
     )
@@ -243,7 +243,7 @@ def test_magic_validation_loop_doc_token_dropout_equiv(model_name):
         model_name,
         ds,
         batch_size=batch_size,
-        per_token=False,
+        attribute_tokens=False,
         shuffle_seed=shuffle_seed,
         zero_subset=docs_to_drop,
     )
@@ -251,7 +251,7 @@ def test_magic_validation_loop_doc_token_dropout_equiv(model_name):
         model_name,
         ds,
         batch_size=batch_size,
-        per_token=True,
+        attribute_tokens=True,
         shuffle_seed=shuffle_seed,
         zero_subset=flat_drop,
     )
@@ -267,7 +267,7 @@ def _run_magic_cli(
     dataset,
     batch_size,
     *,
-    per_token: bool,
+    attribute_tokens: bool,
     shuffle_seed: int | None = None,
     seed: int = 42,
     device: str = "cpu",
@@ -292,7 +292,7 @@ def _run_magic_cli(
         ds, batch_size, num_docs, "Test", 0
     )
 
-    if per_token:
+    if attribute_tokens:
         T = max(len(row) for row in padded_ds["input_ids"])
         weight_shape = (len(padded_ds), T)
     else:
@@ -375,7 +375,7 @@ def test_magic_per_token_scores_zero_at_masked_labels(model_name):
     )
     N, T = len(ds), 5
 
-    per_tok, _ = _run_magic_cli(model_name, ds, len(ds), per_token=True)
+    per_tok, _ = _run_magic_cli(model_name, ds, len(ds), attribute_tokens=True)
     assert per_tok.shape == (N, T)
 
     labels = torch.tensor(ds["labels"])
@@ -407,8 +407,8 @@ def test_magic_per_token_sums_to_per_doc(model_name, dataset):
     N = len(dataset)
     T = len(dataset[0]["input_ids"])
 
-    per_doc, _ = _run_magic_cli(model_name, dataset, N, per_token=False)
-    per_tok, _ = _run_magic_cli(model_name, dataset, N, per_token=True)
+    per_doc, _ = _run_magic_cli(model_name, dataset, N, attribute_tokens=False)
+    per_tok, _ = _run_magic_cli(model_name, dataset, N, attribute_tokens=True)
 
     assert per_doc.shape == (N,)
     assert per_tok.shape == (N, T)
@@ -440,8 +440,8 @@ def test_magic_per_token_sums_to_per_doc_packed(model_name):
     )
     N, T, num_docs = len(ds), 6, 4
 
-    per_doc, _ = _run_magic_cli(model_name, ds, N, per_token=False)
-    per_tok, _ = _run_magic_cli(model_name, ds, N, per_token=True)
+    per_doc, _ = _run_magic_cli(model_name, ds, N, attribute_tokens=False)
+    per_tok, _ = _run_magic_cli(model_name, ds, N, attribute_tokens=True)
 
     assert per_doc.shape == (num_docs,)
     assert per_tok.shape == (N, T)
@@ -485,8 +485,8 @@ def test_magic_per_token_sums_to_per_doc_with_padding(model_name):
     T = 5
     batch_size = 2
 
-    per_doc, _ = _run_magic_cli(model_name, ds, batch_size, per_token=False)
-    per_tok, doc_ids = _run_magic_cli(model_name, ds, batch_size, per_token=True)
+    per_doc, _ = _run_magic_cli(model_name, ds, batch_size, attribute_tokens=False)
+    per_tok, doc_ids = _run_magic_cli(model_name, ds, batch_size, attribute_tokens=True)
 
     assert per_doc.shape == (num_real_docs,), f"per_doc shape {per_doc.shape}"
     assert per_tok.shape == (num_real_docs, T), f"per_tok shape {per_tok.shape}"
@@ -583,10 +583,10 @@ def test_magic_unpacked_cli_aggregation(model_name):
     shuffle_seed = 7
 
     per_tok, doc_ids = _run_magic_cli(
-        model_name, ds, batch_size, per_token=True, shuffle_seed=shuffle_seed
+        model_name, ds, batch_size, attribute_tokens=True, shuffle_seed=shuffle_seed
     )
     per_doc, _ = _run_magic_cli(
-        model_name, ds, batch_size, per_token=False, shuffle_seed=shuffle_seed
+        model_name, ds, batch_size, attribute_tokens=False, shuffle_seed=shuffle_seed
     )
 
     assert per_doc.shape == (num_docs,), f"per_doc shape {per_doc.shape}"
@@ -623,10 +623,10 @@ def test_magic_packed_cli_aggregation_with_shuffle(model_name):
     shuffle_seed = 7
 
     per_tok, doc_ids = _run_magic_cli(
-        model_name, ds, batch_size, per_token=True, shuffle_seed=shuffle_seed
+        model_name, ds, batch_size, attribute_tokens=True, shuffle_seed=shuffle_seed
     )
     per_doc, _ = _run_magic_cli(
-        model_name, ds, batch_size, per_token=False, shuffle_seed=shuffle_seed
+        model_name, ds, batch_size, attribute_tokens=False, shuffle_seed=shuffle_seed
     )
 
     assert per_doc.shape == (num_docs,)
@@ -1155,3 +1155,12 @@ def test_next_save_index_interval():
     assert next_save_index(291, 1746, "interval", save_interval=291) == 582
     with pytest.raises(ValueError, match="save_interval"):
         next_save_index(0, 100, "interval")
+
+
+def test_per_token_backward_compatibility():
+    from bergson.magic.config import MagicConfig
+
+    cfg = MagicConfig.from_dict(
+        {"run_path": "x", "per_token": True}, drop_extra_fields=False
+    )
+    assert cfg.attribute_tokens


### PR DESCRIPTION
Fable: `save_models` moves from `ValidationConfig` to `TrainingConfig`: `train`, `magic`, and `metasmoothness` save the trained (unperturbed, k=0) model to `<run_path>/model`; `validate` keeps the leave-k-out family at `retrained/{base,subset_<i>}`. The base-save block already ran on the train path — it was dead only because the field didn't exist on `TrainingConfig`.

`MagicConfig.per_token` becomes `attribute_tokens` — the name every other subsystem (build, score, TrackStar, SOURCE) already uses for the same toggle; one concept, one name.

Also replaces `getattr(run_cfg, "field", default)` probes with direct access or `isinstance` narrowing — string probes silently return their default after any rename.

E2e-verified: tiny `bergson train` writes a loadable HF model to `<run_path>/model`; 86 tests across the touched areas pass.