### PR TITLE
Remove the streaming (IterableDataset) score path

### DIFF
--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -362,32 +362,48 @@ def score_worker(
             kwargs["scorer"].writer.flush()
             del kwargs["scorer"]
     else:
-        # Convert each shard to a Dataset then map over its gradients
+        # Streaming (IterableDataset) path. Nothing in the pipeline currently
+        # produces an IterableDataset (setup_data_pipeline always returns a
+        # Dataset), so this is a safety net rather than a hot path. Mirrors the
+        # single-shard limitation of build_worker; query batching
+        # (query_batch_size) is not applied here.
         buf, shard_id = [], 0
 
         def flush(kwargs):
             nonlocal buf, shard_id
             if not buf:
                 return
+            # Each create_scorer call sizes the score index to its own shard at
+            # the same path, so a second shard would overwrite the first rather
+            # than append. Limit to a single shard, matching build_worker.
+            assert shard_id == 0, (
+                "Streaming datasets are limited to a single shard: "
+                f"{len(buf)} rows overflowed stream_shard_size="
+                f"{index_cfg.stream_shard_size}. Raise stream_shard_size above "
+                "the dataset size, or load the dataset without streaming."
+            )
             ds_shard = assert_type(Dataset, Dataset.from_list(buf))
             batches = allocate_batches(
                 ds_shard["length"][:],
                 index_cfg.token_batch_size,
                 max_batch_size=index_cfg.max_batch_size,
             )
-            kwargs["ds"] = ds_shard
+            kwargs["data"] = ds_shard
             kwargs["batches"] = batches
 
             kwargs["scorer"] = create_scorer(
-                index_cfg.partial_run_path / f"shard-{shard_id:05d}",
+                index_cfg.partial_run_path,
                 ds_shard,
                 score_cfg,
                 preprocess_cfg,
                 device=score_device,
                 dtype=score_dtype,
+                attribute_tokens=index_cfg.attribute_tokens,
             )
 
             collect_gradients(**kwargs)
+            kwargs["scorer"].writer.flush()
+            del kwargs["scorer"]
 
             buf.clear()
             shard_id += 1

--- a/tests/test_streaming_score.py
+++ b/tests/test_streaming_score.py
@@ -1,0 +1,86 @@
+"""Scoring a value set from a streaming (IterableDataset) source."""
+
+from pathlib import Path
+
+import pytest
+import torch
+from datasets import Dataset
+
+from bergson.build import build_worker
+from bergson.config import IndexConfig, PreprocessConfig, ScoreConfig
+from bergson.data import load_scores
+from bergson.score.score import score_worker
+
+N_ROWS = 6
+
+
+def _dataset() -> Dataset:
+    return Dataset.from_dict(
+        {
+            "input_ids": [[1, 2, 3, 4] for _ in range(N_ROWS)],
+            "length": [4] * N_ROWS,
+        }
+    )
+
+
+def _index_cfg(run_path: Path, shard_size: int) -> IndexConfig:
+    return IndexConfig(
+        run_path=str(run_path),
+        model="sshleifer/tiny-gpt2",
+        precision="fp32",
+        token_batch_size=64,
+        projection_dim=4,
+        stream_shard_size=shard_size,
+    )
+
+
+def _build_query(tmp_path: Path) -> Path:
+    """Build a query gradient index and return its (partial) path."""
+    q_cfg = _index_cfg(tmp_path / "query", shard_size=1000)
+    q_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+    build_worker(0, 0, 1, q_cfg, PreprocessConfig(), _dataset())
+    return q_cfg.partial_run_path
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_streaming_score_matches_in_memory(tmp_path: Path):
+    """A streamed score produces the same number of written score rows as a
+    non-streamed one over the same value data."""
+    query_path = _build_query(tmp_path)
+    ds = _dataset()
+    score_cfg = ScoreConfig(query_path=str(query_path))
+
+    mem_cfg = _index_cfg(tmp_path / "mem", shard_size=1000)
+    mem_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+    score_worker(0, 0, 1, mem_cfg, score_cfg, PreprocessConfig(), ds)
+    expected = load_scores(mem_cfg.partial_run_path)
+
+    stream_cfg = _index_cfg(tmp_path / "stream", shard_size=1000)
+    stream_cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+    score_worker(
+        0, 0, 1, stream_cfg, score_cfg, PreprocessConfig(), ds.to_iterable_dataset()
+    )
+    got = load_scores(stream_cfg.partial_run_path)
+
+    assert len(got) == len(expected) == N_ROWS
+    assert got.is_written() and expected.is_written()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_streaming_score_rejects_multiple_shards(tmp_path: Path):
+    """A second shard would overwrite the first, so it must fail loudly."""
+    query_path = _build_query(tmp_path)
+    cfg = _index_cfg(tmp_path / "value", shard_size=2)  # 6 rows -> 3 shards
+    cfg.partial_run_path.mkdir(parents=True, exist_ok=True)
+    score_cfg = ScoreConfig(query_path=str(query_path))
+
+    with pytest.raises(AssertionError, match="single shard"):
+        score_worker(
+            0,
+            0,
+            1,
+            cfg,
+            score_cfg,
+            PreprocessConfig(),
+            _dataset().to_iterable_dataset(),
+        )


### PR DESCRIPTION
HF streaming is not very good and supporting it fully would be a world of pain because it's missing most features you need, like knowing the dataset's length. For scoring datasets too big to fit on disk it probably makes more sense to write your own tool to process the arrow shards one by one with Claude at this point.