### PR TITLE
docs: five-seed replication LDS results

### DIFF
--- a/examples/replicate_bae_approx_unrolling_source/README.md
+++ b/examples/replicate_bae_approx_unrolling_source/README.md
@@ -18,5 +18,8 @@ HF format both steps load.
 
 | Method | LDS (mean Spearman over 481 queries, 95% CI) |
 |--------|----------------------------------------------|
-| EK-FAC IF | 0.418 ± 0.016 |
-| SOURCE | 0.429 ± 0.015 |
+| EK-FAC IF | 0.468 ± 0.015 |
+| SOURCE | 0.476 ± 0.015 |
+
+Query losses averaged over the five retrain seeds; kronfluence reports 0.44
+for EK-FAC IF on its own five-seed ground truth.


### PR DESCRIPTION
Fable: Final numbers from the shipped chain with query losses averaged over the five retrain seeds (Eq. 8's expectation): EK-FAC IF 0.4677 ± 0.0154, SOURCE 0.4764 ± 0.0153 over 481 queries; paired delta +0.0087, SOURCE wins 308/481, Wilcoxon p = 2.3e-11. Single-seed ground truth gave 0.418/0.429 — the averaging recovered the attenuation exactly as predicted. Per-seed EK-FAC spread across the five rulers: 0.4142–0.4183.