### PR TITLE
fix: metasmoothness epochs

### DIFF
--- a/bergson/magic/metasmoothness.py
+++ b/bergson/magic/metasmoothness.py
@@ -72,8 +72,6 @@ def metasmoothness_worker(
     assert not run_cfg.fsdp, "metasmoothness does not support FSDP parameters"
     assert not getattr(run_cfg, "per_token", False)
 
-    if run_cfg.num_epochs > 1:
-        train_dataset = train_dataset.repeat(run_cfg.num_epochs)
     assert run_cfg.batch_size % world_size == 0
 
     train_dataset, num_train_docs, pad_count, weight_pad_count = (

--- a/tests/test_metasmoothness.py
+++ b/tests/test_metasmoothness.py
@@ -4,7 +4,9 @@ These tests exercise CLI parsing and the scoring function only — they never
 call `.execute()`, so they need no GPU and no model downloads.
 """
 
+import pytest
 import torch
+from datasets import Dataset
 from simple_parsing import ArgumentParser, ConflictResolution
 
 from bergson.__main__ import Main
@@ -75,3 +77,46 @@ def test_run_metasmoothness_uses_epoch_pipeline(tmp_path, monkeypatch):
     assert len(seen["ds"]) == 3 * len(ds)
     epochs = [seen["ds"]["text"][i * 4 : (i + 1) * 4] for i in range(3)]
     assert len({tuple(e) for e in epochs}) > 1
+
+
+def test_worker_does_not_reexpand_epochs(monkeypatch):
+    """``run_metasmoothness`` passes a dataset already expanded to ``num_epochs``
+    shuffled copies; ``metasmoothness_worker`` must build its training stream from
+    exactly those docs. Repeating again trains ``num_epochs**2`` epochs — the
+    regression left behind when #393 moved epoch expansion into the pipeline."""
+    from bergson.config.config import MetasmoothnessConfig
+    from bergson.magic import metasmoothness as ms
+
+    num_epochs, base = 3, 24
+    expanded = Dataset.from_dict(
+        {
+            "text": ["x"] * (num_epochs * base),
+            "doc_ids": list(range(num_epochs * base)),
+        }
+    )
+
+    monkeypatch.setattr(torch.cuda, "set_device", lambda *a, **k: None)
+    monkeypatch.setattr(
+        ms,
+        "pad_dataset_to_batch_size",
+        lambda ds, bs, n, label, gr: (ds, len(ds), 0, 0),
+    )
+
+    seen = {}
+
+    class _Stop(Exception):
+        pass
+
+    def _capture(ds, _bs, **_kw):
+        seen["docs"] = len(ds)
+        raise _Stop
+
+    monkeypatch.setattr(ms, "DataStream", _capture)
+
+    cfg = MetasmoothnessConfig(
+        run_path="unused", num_epochs=num_epochs, batch_size=8, seed=0
+    )
+    with pytest.raises(_Stop):
+        ms.metasmoothness_worker(0, 0, 1, expanded, num_epochs * base, cfg)
+
+    assert seen["docs"] == num_epochs * base


### PR DESCRIPTION
#393 moved epoch expansion into run_metasmoothness (shuffled_epochs builds num_epochs independently shuffled copies) but left the worker's train_dataset.repeat(num_epochs). Since training length is len(dataset) // batch_size, the worker then trained num_epochs**2 epochs (e.g. 250 steps instead of 125 for a 2-epoch 4k/bs64 config).

Drop the redundant repeat and add a test.