### PR TITLE
fix(magic): grad accumulation in query

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -28,7 +28,7 @@ from transformers.utils.logging import (
 
 from ..config.config import TrainingConfig, ValidationConfig
 from ..config.config_io import save_run_config
-from ..distributed import grad_tree, launch_distributed_run
+from ..distributed import launch_distributed_run
 from ..utils.load_from_optimizer import (
     save_second_moments_as_optimizer_pt,
 )
@@ -38,6 +38,7 @@ from ..utils.worker_utils import setup_data_pipeline
 from ..validate import load_attribution_scores, validate_scores
 from .config import MagicConfig
 from .data_stream import DataStream, pad_dataset_to_batch_size
+from .grad_accum import accumulate_grads
 from .trainer import BackwardState, TrainerState, prepare_trainer, write_lr_history
 
 
@@ -47,6 +48,7 @@ def compute_query_gradients(
     query_stream: DataStream,
     method: str = "mean",
     fsdp: bool = False,
+    grad_accum_steps: int = 1,
 ) -> tuple[dict[str, torch.Tensor], float]:
     """Compute reduced query gradients over the query dataset.
 
@@ -66,8 +68,9 @@ def compute_query_gradients(
     with fwd_state.activate(model) as params:
         for batch in tqdm(query_stream, desc="Query", disable=not main):
             del batch["example_weight"]
-            loss = model(**batch).loss
-            grads = grad_tree(loss, params)
+            grads, loss = accumulate_grads(
+                model, params, batch, grad_accum_steps, create_graph=False
+            )
 
             if grad_accum is None:
                 grad_accum = {k: g.detach().clone() for k, g in grads.items()}
@@ -75,7 +78,7 @@ def compute_query_gradients(
                 for k, g in grads.items():
                     grad_accum[k] += g.detach()
 
-            loss_accum += loss.detach()
+            loss_accum += loss
 
     assert grad_accum is not None, "Query stream was empty"
 
@@ -99,7 +102,9 @@ def compute_query_gradients(
             }
 
         # Loss is never a DTensor
-        dist.all_reduce(loss_accum)
+        loss_tensor = torch.tensor(loss_accum, device=torch.cuda.current_device())
+        dist.all_reduce(loss_tensor)
+        loss_accum = loss_tensor.item()
 
     return grad_accum, float(loss_accum)
 
@@ -321,7 +326,12 @@ def worker(
         query_stream.weights.data[-query_weight_pad_count:] = 0.0
 
     query_grads, baseline = compute_query_gradients(
-        fwd_state, model, query_stream, run_cfg.query_method, run_cfg.fsdp
+        fwd_state,
+        model,
+        query_stream,
+        run_cfg.query_method,
+        run_cfg.fsdp,
+        run_cfg.grad_accum_steps,
     )
 
     multi_query = False

--- a/bergson/magic/grad_accum.py
+++ b/bergson/magic/grad_accum.py
@@ -245,6 +245,11 @@ def microbatch_step_vjp(
         for i in range(num_params, num_inputs)
     ]
 
+    # Free Stage A's update graph and gradient copies before Stage B's
+    # double backward; keeping them alive raises the peak by several GiB.
+    del grads_detached, grad_variables, updated_state, stage_a_results
+    del direct_cotangents
+
     # ``example_weight`` is one indexing of ``data_weights`` shared by all
     # micro-batch slices, so accumulate cotangents on it and map them back
     # to ``data_weights`` once after the loop.
@@ -283,7 +288,7 @@ def microbatch_step_vjp(
                 )
         if example_weight_cotangent is not None and contributions[-1] is not None:
             example_weight_cotangent = example_weight_cotangent + contributions[-1]
-        del micro_grads, contributions
+        del micro_grads, contributions, outputs, micro_loss
 
     weight_cotangent = torch.zeros_like(data_weights)
     if (


### PR DESCRIPTION
Running \`examples/magic/gpt2_wikitext_tiny.yaml\` at its committed settings (\`batch_size: 64\`, \`grad_accum_steps: 4\`) OOMed on a 48GiB GPU in two places, both outside the training loop (which micro-batches correctly and peaks at ~22GiB):

1. **Query gradients** (\`compute_query_gradients\`): always ran a full \`batch_size\` forward/backward, ignoring \`grad_accum_steps\`. With eager fp32 attention a 64x512 batch hits ~43GiB of activations before the 6GiB logits allocation fails. Now micro-batched via \`accumulate_grads\`, which reproduces the full-batch mean-loss gradient exactly (per-micro-batch token-count scaling).

2. **Backward Stage B** (\`microbatch_step_vjp\`): the per-micro-batch double backward held Stage A's traced optimizer-update graph, two full gradient copies, and the previous iteration's logits alive, raising the peak several GiB above the equivalent single-shot traced step. Freed before/inside the Stage B loop.

Verified: the tiny config previously OOMed at the query pass; with the fix, training/query/backward run at bs64+accum4 within ~45.6GiB peak. \`pytest tests/test_magic.py -k accum\` passes (includes the accum-vs-full-batch weight-gradient equivalence test).