### PR TITLE
Add per-query MAGIC scoring (query_method="none")

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -440,16 +440,9 @@ class ValidationConfig(TrainingConfig, ABC):
     """Query/eval dataset for computing attribution target gradients.
     If not specified, defaults to the training dataset."""
 
-    query_method: Literal["mean", "sum", "none"] = "mean"
+    query_method: Literal["mean", "sum", "none"] = "none"
     """How query gradients are combined before the MAGIC backward.
-
-    ``mean``/``sum`` reduce all queries into one gradient, giving a single
-    aggregate-query score vector. ``none`` scores each query separately (one
-    backward per query), yielding a ``[num_query_docs, num_train_docs]`` score
-    matrix — the per-query attribution needed for a per-query LDS. Per-query is
-    more expensive (a backward per query, sharing one forward) but is the
-    correct unit for evaluation; aggregate-query metrics over few subsets are
-    noisy and non-comparable to per-query numbers."""
+    ``none`` will perform one backward per query."""
 
     num_subsets: int = 100
     """Number of leave-k-out subsets for Spearman correlation."""

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -440,8 +440,16 @@ class ValidationConfig(TrainingConfig, ABC):
     """Query/eval dataset for computing attribution target gradients.
     If not specified, defaults to the training dataset."""
 
-    query_method: Literal["mean", "sum"] = "mean"
-    """Method for reducing query gradients across batches."""
+    query_method: Literal["mean", "sum", "none"] = "mean"
+    """How query gradients are combined before the MAGIC backward.
+
+    ``mean``/``sum`` reduce all queries into one gradient, giving a single
+    aggregate-query score vector. ``none`` scores each query separately (one
+    backward per query), yielding a ``[num_query_docs, num_train_docs]`` score
+    matrix — the per-query attribution needed for a per-query LDS. Per-query is
+    more expensive (a backward per query, sharing one forward) but is the
+    correct unit for evaluation; aggregate-query metrics over few subsets are
+    noisy and non-comparable to per-query numbers."""
 
     num_subsets: int = 100
     """Number of leave-k-out subsets for Spearman correlation."""

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import os
 import shutil
@@ -107,6 +108,133 @@ def compute_query_gradients(
         loss_accum = loss_tensor.item()
 
     return grad_accum, float(loss_accum)
+
+
+def compute_per_query_magic_scores(
+    trainer,
+    ckpts_path: str,
+    stream: DataStream,
+    fwd_state: TrainerState,
+    model: torch.nn.Module,
+    query_dataset: Dataset,
+    num_query_docs: int,
+    run_cfg: "MagicConfig",
+    world_size: int,
+    global_rank: int,
+    pad_count: int,
+    weight_pad_count: int,
+) -> torch.Tensor:
+    """Per-query MAGIC scores: one backward per query, sharing the forward.
+
+    ``run_magic`` reduces the queries to one gradient before the backward, so it
+    yields a single aggregate-query score. This scores each query separately:
+    for each query document it takes that document's gradient at the final model
+    as the backward cotangent and runs ``Trainer.backward`` over the saved
+    trajectory, producing a ``[num_train_docs, num_query_docs]`` matrix (the
+    layout ``validate_scores`` consumes: rows are leave-out docs, columns
+    queries).
+
+    The backward is linear in the cotangent, so this is exact; the forward runs
+    once and every query reuses its checkpoints (``cleanup=False``). Per-query
+    scores are written incrementally to ``<run_path>/per_query/q{i}.pt`` so a
+    crash or preemption only loses the in-flight query (resume redoes the
+    forward but skips finished queries), and the final state is restored before
+    each query since the backward walks it back down the trajectory.
+    """
+    main = global_rank == 0
+    device = stream.weights.device
+    scores_dir = os.path.join(run_cfg.run_path, "per_query")
+    if main:
+        os.makedirs(scores_dir, exist_ok=True)
+
+    # Snapshot the final state (CPU) to restore before each query's backward, and
+    # the forward's checkpoint files so per-query temp checkpoints can be cleaned.
+    final_state = fwd_state.to("cpu").detach_()
+    orig_ckpts = set(os.listdir(ckpts_path)) if os.path.isdir(ckpts_path) else set()
+    opt_grads_zero = [
+        torch.zeros_like(buf)
+        for buf in tree_iter(fwd_state.opt_state)
+        if isinstance(buf, torch.Tensor) and buf.is_floating_point()
+    ]
+
+    per_query = []
+    for qi in range(num_query_docs):
+        qpath = os.path.join(scores_dir, f"q{qi}.pt")
+        if os.path.exists(qpath):  # resume: already scored
+            per_query.append(torch.load(qpath, map_location="cpu"))
+            continue
+
+        # Restore the final trained state (the backward walks it back down the
+        # trajectory). detach_ first: the previous iteration left params
+        # requiring grad, and copy_ is an in-place write a leaf-requiring-grad
+        # forbids. Free the GPU copy so states don't accumulate across queries.
+        fwd_state.detach_()
+        restored = final_state.to(device)
+        fwd_state.copy_(restored)
+        del restored
+
+        one = query_dataset.select([qi])
+        one, n_one, one_pad, one_wpad = pad_dataset_to_batch_size(
+            one, run_cfg.batch_size, 1, f"Query {qi}", global_rank
+        )
+        qstream = DataStream(
+            one,
+            run_cfg.batch_size,
+            device=device,
+            input_key=run_cfg.query.prompt_column,
+            weight_shape=(n_one,),
+        )
+        if one_pad:
+            qstream.weights.data[-one_wpad:] = 0.0
+        qgrads, _ = compute_query_gradients(
+            fwd_state, model, qstream, "mean", run_cfg.fsdp
+        )
+
+        fwd_state.detach_()  # clear requires_grad set by the activation above
+        stream.requires_grad = True
+        stream.weights.grad = None
+        bwd_state = BackwardState(
+            qgrads,
+            [g.clone() for g in opt_grads_zero],
+            torch.zeros_like(stream.weights),
+        )
+        bwd_state = trainer.backward(
+            ckpts_path,
+            stream,
+            bwd_state,
+            fwd_state,
+            cleanup=False,  # reuse the forward's checkpoints for every query
+            debug=run_cfg.debug,
+            inplace=True,
+            fsdp=run_cfg.fsdp,
+            save_mode=run_cfg.save_mode,
+            max_grad_norm=run_cfg.max_grad_norm,
+        )
+        if world_size > 1:
+            dist.all_reduce(bwd_state.weight_grads, op=dist.ReduceOp.SUM)
+
+        s = bwd_state.weight_grads.detach().cpu()
+        if pad_count:
+            s = s[:-weight_pad_count]
+        if main:
+            torch.save(s, qpath)
+        per_query.append(s)
+
+        # Free per-query state and any temp checkpoints the backward wrote.
+        del bwd_state, qgrads, qstream, one
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        if main and os.path.isdir(ckpts_path):
+            for name in set(os.listdir(ckpts_path)) - orig_ckpts:
+                fp = os.path.join(ckpts_path, name)
+                shutil.rmtree(fp) if os.path.isdir(fp) else os.remove(fp)
+        if main:
+            print(f"[per-query MAGIC] scored query {qi + 1}/{num_query_docs}")
+
+    # [num_train_docs, num_query_docs] — the layout validate_scores expects
+    # (rows are leave-out docs; columns are queries).
+    return torch.stack(per_query, dim=1)
 
 
 def scores_are_per_token(score_path: str) -> bool:
@@ -335,7 +463,36 @@ def worker(
     )
 
     multi_query = False
-    if not score_path:
+    if not score_path and run_cfg.query_method == "none":
+        # Per-query MAGIC: one backward per query, sharing the forward. Yields a
+        # [num_query_docs, num_train_docs] score matrix (multi_query), the unit
+        # for a per-query LDS.
+        if not isinstance(run_cfg, MagicConfig):
+            raise RuntimeError("run_cfg must be a MagicConfig to compute scores")
+        assert query_dataset is not None
+
+        scores = compute_per_query_magic_scores(
+            trainer,
+            ckpts_path,
+            stream,
+            fwd_state,
+            model,
+            query_dataset,
+            num_query_docs,
+            run_cfg,
+            world_size,
+            global_rank,
+            pad_count,
+            weight_pad_count,
+        )
+        multi_query = True
+        if global_rank == 0:
+            print(f"Baseline loss: {baseline}")
+            print(f"Score summary: {describe(scores.flatten())}")
+            score_path = os.path.join(run_cfg.run_path, "scores.pt")
+            torch.save(scores, score_path)
+            print(f"Saved per-query attribution scores to {score_path}")
+    elif not score_path:
         # Sanity check
         if not isinstance(run_cfg, MagicConfig):
             raise RuntimeError("run_cfg must be a MagicConfig to compute scores")

--- a/tests/test_distributed_magic.py
+++ b/tests/test_distributed_magic.py
@@ -46,12 +46,19 @@ def magic_cfg(
         split="train[:512]",
         chunk_length=32,
     )
+    # Single query doc: query_method="none" runs one backward per query.
+    query = DataConfig(
+        dataset="Salesforce/wikitext",
+        subset="wikitext-2-raw-v1",
+        split="train[9:10]",
+        chunk_length=32,
+    )
     return MagicConfig(
         run_path=run_path,
         model="trl-internal-testing/tiny-Phi3ForCausalLM",
         fsdp=fsdp,
         data=data,
-        query=data,
+        query=query,
         lr_schedule=LRScheduleConfig(lr=lr) if lr is not None else _LR_SCHEDULE,
         batch_size=8,
         num_epochs=1,

--- a/tests/test_per_query_magic.py
+++ b/tests/test_per_query_magic.py
@@ -1,0 +1,149 @@
+"""Per-query MAGIC scoring (`query_method="none"`).
+
+`compute_per_query_magic_scores` runs one backward per query, sharing the
+forward, to produce a ``[num_train_docs, num_query_docs]`` score matrix. Because
+the backward is linear in the query cotangent, the mean over queries of the
+per-query scores must equal the aggregate-query MAGIC score (a single backward
+whose cotangent is the mean of the per-query gradients) — exactly, when the
+queries have equal token counts so that the aggregate mean-over-tokens loss is
+the uniform mean of the per-query losses. That identity is the correctness gate.
+"""
+
+import tempfile
+
+import torch
+import torchopt
+from datasets import Dataset
+from torchopt.pytree import tree_iter
+
+from bergson.distributed import grad_tree
+from bergson.magic import BackwardState, DataStream, Trainer
+from bergson.magic.cli import compute_per_query_magic_scores
+from bergson.magic.config import MagicConfig
+from bergson.utils.math import weighted_causal_lm_ce
+
+TINY = "trl-internal-testing/tiny-Phi3ForCausalLM"
+
+
+def _model():
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    torch.manual_seed(0)
+    cfg = AutoConfig.from_pretrained(TINY)
+    m = AutoModelForCausalLM.from_config(
+        cfg, torch_dtype=torch.float32, attn_implementation="eager"
+    )
+    m.loss_function = weighted_causal_lm_ce
+    m.requires_grad_(True)
+    return m
+
+
+def _equal_length_docs(n, seqlen=5, start=1):
+    ids = [[start + i * seqlen + j for j in range(seqlen)] for i in range(n)]
+    return Dataset.from_dict(
+        {"input_ids": ids, "labels": ids, "attention_mask": [[1] * seqlen] * n}
+    )
+
+
+def _aggregate_magic_score(trainer, model, fwd_state, stream, ckpt_dir, query_ds):
+    """Single backward with cotangent = mean over the query docs' gradients."""
+    with fwd_state.activate(model) as params:
+        qstream = DataStream(query_ds, batch_size=len(query_ds), device="cpu")
+        batch = qstream[0]
+        del batch["example_weight"]
+        loss = model(
+            **batch
+        ).loss  # mean over all query tokens (equal length → uniform)
+        qgrads = {k: g.detach().clone() for k, g in grad_tree(loss, params).items()}
+        opt_grads = [
+            torch.zeros_like(b)
+            for b in tree_iter(fwd_state.opt_state)
+            if isinstance(b, torch.Tensor) and b.is_floating_point()
+        ]
+        bwd = BackwardState(qgrads, opt_grads, torch.zeros_like(stream.weights))
+    stream.requires_grad = True
+    bwd = trainer.backward(
+        ckpt_dir, stream, bwd, fwd_state, inplace=True, cleanup=False
+    )
+    return bwd.weight_grads.detach().cpu()
+
+
+def test_per_query_mean_reproduces_aggregate():
+    model = _model()
+    optimizer = torchopt.adamw(1e-4, betas=(0.95, 0.975), eps_root=1e-2)
+    trainer, fwd_state = Trainer.initialize(model, optimizer)
+
+    # Multi-step training so the backward is non-trivial.
+    train_ds = _equal_length_docs(4, start=1)
+    stream = DataStream(train_ds, batch_size=1, device="cpu")
+    assert len(stream) == 4
+
+    query_ds = _equal_length_docs(3, start=100)  # equal token counts
+
+    with tempfile.TemporaryDirectory() as run_path:
+        ckpts = f"{run_path}/checkpoints"
+        fwd_state = trainer.train(fwd_state, stream, inplace=True, save_dir=ckpts)
+
+        run_cfg = MagicConfig(run_path=run_path, query_method="none")
+        run_cfg.query.prompt_column = "input_ids"
+
+        # Snapshot final state so the aggregate reference starts where per-query does.
+        agg = _aggregate_magic_score(trainer, model, fwd_state, stream, ckpts, query_ds)
+
+        stream.requires_grad = True
+        per_query = compute_per_query_magic_scores(
+            trainer,
+            ckpts,
+            stream,
+            fwd_state,
+            model,
+            query_ds,
+            num_query_docs=len(query_ds),
+            run_cfg=run_cfg,
+            world_size=1,
+            global_rank=0,
+            pad_count=0,
+            weight_pad_count=0,
+        )
+
+    # Shape: rows = train docs, cols = queries (validate_scores layout).
+    assert per_query.shape == (len(train_ds), len(query_ds))
+    assert torch.isfinite(per_query).all()
+    # Queries are distinct (different cotangents → different score columns).
+    assert not torch.allclose(per_query[:, 0], per_query[:, 1])
+    # Correctness gate: mean over queries == aggregate-query score.
+    torch.testing.assert_close(per_query.mean(dim=1), agg, atol=1e-6, rtol=1e-4)
+
+
+def test_per_query_scores_saved_incrementally():
+    """Each query is written to per_query/q{i}.pt as it completes (crash-safe)."""
+    import os
+
+    model = _model()
+    optimizer = torchopt.adamw(1e-4, betas=(0.95, 0.975), eps_root=1e-2)
+    trainer, fwd_state = Trainer.initialize(model, optimizer)
+    stream = DataStream(_equal_length_docs(3), batch_size=1, device="cpu")
+    query_ds = _equal_length_docs(2, start=100)
+
+    with tempfile.TemporaryDirectory() as run_path:
+        ckpts = f"{run_path}/checkpoints"
+        fwd_state = trainer.train(fwd_state, stream, inplace=True, save_dir=ckpts)
+        run_cfg = MagicConfig(run_path=run_path, query_method="none")
+        run_cfg.query.prompt_column = "input_ids"
+        stream.requires_grad = True
+        compute_per_query_magic_scores(
+            trainer,
+            ckpts,
+            stream,
+            fwd_state,
+            model,
+            query_ds,
+            num_query_docs=2,
+            run_cfg=run_cfg,
+            world_size=1,
+            global_rank=0,
+            pad_count=0,
+            weight_pad_count=0,
+        )
+        assert os.path.exists(f"{run_path}/per_query/q0.pt")
+        assert os.path.exists(f"{run_path}/per_query/q1.pt")


### PR DESCRIPTION
MAGIC previously reduced the query set to one gradient before the backward (`query_method` mean/sum), so only an aggregate-query score was available. EK-FAC already supports `query_aggregation="none"`; this adds the equivalent for MAGIC.

`query_method="none"` runs one backward per query off a shared forward, producing a `[num_train_docs, num_query_docs]` score matrix consumed by the existing `multi_query` validate path. The backward is linear in the query cotangent, so per-query scores are exact. Scores are written incrementally to `per_query/q{i}.pt` (a rerun skips finished queries), the final state is restored before each query since the backward walks it back down the trajectory, and per-query GPU state copies and temp checkpoints are freed each iteration.

Tests: mean over queries of per-query scores reproduces the aggregate score to 1e-6, and per-query files are written incrementally. Full MAGIC suite (44 tests) passes on top of the fp64 changes.