### PR TITLE
fix(magic): bound double-backward memory with double_backward_batch_size

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -399,6 +399,13 @@ class TrainingConfig(AttributionConfig, Serializable):
     Under dropout, changing this changes the shapes the masks are drawn for, so
     trajectories are not identical across values."""
 
+    double_backward_batch_size: int | None = None
+    """Max sequences per double-backward graph in the micro-batched backward
+    (requires ``grad_accum_steps > 1``). The graph retains several vocab-sized
+    tensors per sequence, so it dominates the backward's peak memory. Exact
+    under any split; ignored under dropout (``train_mode``), where the replay
+    must reuse the forward's micro-batches."""
+
     resume: bool = False
     """Resume a previously interrupted run from the last checkpoint."""
 

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -209,6 +209,8 @@ def compute_per_query_magic_scores(
             fsdp=run_cfg.fsdp,
             save_mode=run_cfg.save_mode,
             max_grad_norm=run_cfg.max_grad_norm,
+            grad_accum_steps=run_cfg.grad_accum_steps,
+            double_backward_batch_size=run_cfg.double_backward_batch_size,
         )
         if world_size > 1:
             dist.all_reduce(bwd_state.weight_grads, op=dist.ReduceOp.SUM)
@@ -525,6 +527,7 @@ def worker(
             save_mode=run_cfg.save_mode,
             max_grad_norm=run_cfg.max_grad_norm,
             grad_accum_steps=run_cfg.grad_accum_steps,
+            double_backward_batch_size=run_cfg.double_backward_batch_size,
         )
         if world_size > 1:
             dist.all_reduce(bwd_state.weight_grads, op=dist.ReduceOp.SUM)

--- a/bergson/magic/grad_accum.py
+++ b/bergson/magic/grad_accum.py
@@ -162,6 +162,7 @@ def microbatch_step_vjp(
     fsdp: bool = False,
     max_grad_norm: float | None = None,
     grad_accum_steps: int = 1,
+    double_backward_batch_size: int | None = None,
 ) -> tuple[dict[str, torch.Tensor], list[torch.Tensor], torch.Tensor]:
     """VJP through one training step, one micro-batch graph at a time.
 
@@ -262,7 +263,23 @@ def microbatch_step_vjp(
     total_denom = loss_denom(inputs)
     micro_batches = split_batch(inputs, grad_accum_steps)
     assert len(micro_batches) == len(rng_snapshots)
-    for micro_batch, snapshot in zip(micro_batches, rng_snapshots):
+    stage_b = list(zip(micro_batches, rng_snapshots))
+
+    # The double-backward graph retains several vocab-sized tensors per
+    # sequence, so re-split micro-batches down to ``double_backward_batch_size``. The
+    # gradient sum is exact under any split; only dropout runs must reuse the
+    # forward's micro-batches (the masks are drawn per forward shape).
+    if double_backward_batch_size is not None and not model.training:
+        stage_b = [
+            (sub, snapshot)
+            for micro_batch, snapshot in stage_b
+            for sub in split_batch(
+                micro_batch,
+                -(-micro_batch["input_ids"].shape[0] // double_backward_batch_size),
+            )
+        ]
+
+    for micro_batch, snapshot in stage_b:
         with swap_parameters(
             model, state_params, buffers, preserve_graph=True
         ) as params:

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -515,6 +515,7 @@ class Trainer:
         fsdp: bool = False,
         max_grad_norm: float | None = None,
         grad_accum_steps: int = 1,
+        double_backward_batch_size: int | None = None,
     ) -> "BackwardState":
         """Micro-batched VJP through one training step (metagradient replay).
 
@@ -535,6 +536,7 @@ class Trainer:
             fsdp=fsdp,
             max_grad_norm=max_grad_norm,
             grad_accum_steps=grad_accum_steps,
+            double_backward_batch_size=double_backward_batch_size,
         )
         return BackwardState(
             param_grads, opt_grads, weight_cot + bwd_state.weight_grads
@@ -774,6 +776,7 @@ class Trainer:
         save_mode: SaveMode = "sqrt",
         max_grad_norm: float | None = None,
         grad_accum_steps: int = 1,
+        double_backward_batch_size: int | None = None,
     ) -> BackwardState:
         """Run a backward pass through the training trajectory saved at `ckpt_dir`.
 
@@ -809,6 +812,8 @@ class Trainer:
             grad_accum_steps: Micro-batch count used during the forward pass;
                 must match for the replay to be faithful. When > 1 the traced
                 step uses the two-stage micro-VJP (`Trainer.metagrad_step`).
+            double_backward_batch_size: Max sequences per double-backward graph in the
+                micro-VJP; see `TrainingConfig.double_backward_batch_size`.
 
         Returns:
             The final backward state after processing the entire trajectory.
@@ -946,6 +951,7 @@ class Trainer:
                     fsdp=fsdp,
                     max_grad_norm=max_grad_norm,
                     grad_accum_steps=grad_accum_steps,
+                    double_backward_batch_size=double_backward_batch_size,
                 )
                 main_pbar.update()
             else:

--- a/examples/magic/gpt2_wikitext_tiny.yaml
+++ b/examples/magic/gpt2_wikitext_tiny.yaml
@@ -9,21 +9,21 @@ steps:
       overwrite: true
 
       data:
-        dataset: Salesforce/wikitext
-        subset: wikitext-2-raw-v1
-        split: "train[:512]"
-        chunk_length: 128
+        dataset: EleutherAI/bergson-wikitext-512-chunks
+        split: "train"
+        chunk_length: 0
 
       query:
-        dataset: Salesforce/wikitext
-        subset: wikitext-2-raw-v1
-        split: "train[:512]"
-        chunk_length: 128
+        dataset: EleutherAI/bergson-wikitext-512-chunks
+        split: "test[0:1]"
+        chunk_length: 0
 
       distributed:
         nproc_per_node: 1
 
-      batch_size: 16
+      batch_size: 64
+      grad_accum_steps: 4
+      double_backward_batch_size: 4
       num_epochs: 1
       lr_schedule:
         lr_scheduler_type: polynomial

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1038,8 +1038,15 @@ def test_metagrad_step_matches_single_shot_under_dropout(dataset, device):
     ref_weights = ref[-1]
     assert ref_weights is not None and ref_weights.abs().sum() > 0
 
+    # double_backward_batch_size must be ignored under dropout: re-splitting
+    # would change the shapes the masks are drawn for and break the replay.
     out = trainer.metagrad_step(
-        fwd_state, batch_mb, bwd_state, stream.weights, grad_accum_steps=2
+        fwd_state,
+        batch_mb,
+        bwd_state,
+        stream.weights,
+        grad_accum_steps=2,
+        double_backward_batch_size=1,
     )
 
     for k, expected in ref_params.items():
@@ -1177,7 +1184,7 @@ def test_magic_grad_accum_weight_grads_match(model_name, dataset, dtype):
     an algorithmic difference would show here.
     """
 
-    def scores(ga: int) -> torch.Tensor:
+    def scores(ga: int, double_backward_batch_size: int | None = None) -> torch.Tensor:
         torch.manual_seed(42)
         config = AutoConfig.from_pretrained(model_name)
         model = AutoModelForCausalLM.from_config(
@@ -1221,13 +1228,16 @@ def test_magic_grad_accum_weight_grads_match(model_name, dataset, dtype):
                 inplace=True,
                 cleanup=True,
                 grad_accum_steps=ga,
+                double_backward_batch_size=double_backward_batch_size,
             )
         return bwd_state.weight_grads.detach().float().cpu()
 
     s1 = scores(1)
     s2 = scores(2)
+    s3 = scores(2, double_backward_batch_size=1)
     assert s1.abs().sum() > 0, "metagradient is all zero; test is degenerate"
     torch.testing.assert_close(s2, s1, atol=1e-6, rtol=1e-4)
+    torch.testing.assert_close(s3, s1, atol=1e-6, rtol=1e-4)
 
 
 def test_weighted_ce_preserves_fp64():


### PR DESCRIPTION
Reduce VRAM by splitting double backward micro-batches down. 

Ignored under dropout (`train_mode`), where the replay must reuse the forward's micro-batches to draw the same masks.

Also threads `grad_accum_steps` into the per-query backward.


Measured on `gpt2_wikitext_tiny.yaml` (bs 64, `grad_accum_steps` 4, `double_backward_batch_size` 4): peak GPU memory 48.5 → 26.4 GiB, backward ~5% slower (10.6 → 11.1 s/step). Setting it to 1 reaches the Stage 0 floor (~17 GiB) at ~17% slower.