### PR TITLE
fix(magic): pass grad_accum_steps to per-query query gradients

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -431,6 +431,7 @@ def worker(
         )
 
     # Pad query dataset to be divisible by batch_size (weight=0 for padding)
+    num_real_query_docs = num_query_docs
     query_dataset, num_query_docs, query_pad_count, query_weight_pad_count = (
         pad_dataset_to_batch_size(
             query_dataset, run_cfg.batch_size, num_query_docs, "Query", global_rank
@@ -480,7 +481,7 @@ def worker(
             fwd_state,
             model,
             query_dataset,
-            num_query_docs,
+            num_real_query_docs,
             run_cfg,
             world_size,
             global_rank,

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -187,7 +187,7 @@ def compute_per_query_magic_scores(
         if one_pad:
             qstream.weights.data[-one_wpad:] = 0.0
         qgrads, _ = compute_query_gradients(
-            fwd_state, model, qstream, "mean", run_cfg.fsdp
+            fwd_state, model, qstream, "mean", run_cfg.fsdp, run_cfg.grad_accum_steps
         )
 
         fwd_state.detach_()  # clear requires_grad set by the activation above

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -4,7 +4,7 @@ import os
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from shutil import rmtree
@@ -640,52 +640,61 @@ class Trainer:
         main = not dist.is_initialized() or dist.get_rank() == 0
         pbar = tqdm(range(start, n), desc="Training", disable=not main)
 
-        for i in pbar:
-            # Save checkpoint BEFORE each step. Step 0 is the initial state prior to
-            # any updates, step 1 is the state after the first update, etc.
-            if save_dir and i == next_save:
-                # Wait for the previous save before starting a new one to avoid
-                # multiple concurrent DCP saves with separate Gloo groups, which can
-                # deadlock when background threads call distributed operations.
-                if pending_save is not None:
+        try:
+            for i in pbar:
+                # Save checkpoint BEFORE each step. Step 0 is the initial state prior
+                # to any updates, step 1 is the state after the first update, etc.
+                if save_dir and i == next_save:
+                    # Wait for the previous save before starting a new one to avoid
+                    # multiple concurrent DCP saves with separate Gloo groups, which
+                    # can deadlock when background threads call distributed
+                    # operations.
+                    if pending_save is not None:
+                        pending_save.result()
+
+                    p = os.path.join(save_dir, f"step_{i}.ckpt")
+
+                    # Write before the DCP save starts, into the same directory.
+                    if optimizer_cfg is not None:
+                        # Local import: at module scope this cycles back into
+                        # magic.trainer via the package __init__.
+                        from ..utils.load_from_optimizer import (
+                            save_second_moments_as_optimizer_pt,
+                        )
+
+                        os.makedirs(p, exist_ok=True)
+                        save_second_moments_as_optimizer_pt(
+                            self.model,
+                            state.opt_state,
+                            os.path.join(p, "optimizer.pt"),
+                            step=i,
+                            **optimizer_cfg,
+                        )
+
+                    pending_save = state.save(p, debug_pbar=pbar if debug else None)
+
+                    next_save = next_save_index(next_save, n, save_mode, save_interval)
+
+                x = data[i]
+                state = self.step(
+                    state,
+                    x,
+                    inplace=inplace,
+                    trace=trace,
+                    fsdp=fsdp,
+                    max_grad_norm=max_grad_norm,
+                    grad_accum_steps=grad_accum_steps,
+                )
+
+                if log_fn is not None:
+                    log_fn(i, self._last_loss)
+        except BaseException:
+            # Await the in-flight async save so its writer thread can't race a
+            # subsequent resume()'s cleanup of incomplete checkpoints.
+            if pending_save is not None:
+                with suppress(Exception):
                     pending_save.result()
-
-                p = os.path.join(save_dir, f"step_{i}.ckpt")
-
-                # Write before the DCP save starts, into the same directory.
-                if optimizer_cfg is not None:
-                    # Local import: at module scope this cycles back into
-                    # magic.trainer via the package __init__.
-                    from ..utils.load_from_optimizer import (
-                        save_second_moments_as_optimizer_pt,
-                    )
-
-                    os.makedirs(p, exist_ok=True)
-                    save_second_moments_as_optimizer_pt(
-                        self.model,
-                        state.opt_state,
-                        os.path.join(p, "optimizer.pt"),
-                        step=i,
-                        **optimizer_cfg,
-                    )
-
-                pending_save = state.save(p, debug_pbar=pbar if debug else None)
-
-                next_save = next_save_index(next_save, n, save_mode, save_interval)
-
-            x = data[i]
-            state = self.step(
-                state,
-                x,
-                inplace=inplace,
-                trace=trace,
-                fsdp=fsdp,
-                max_grad_norm=max_grad_norm,
-                grad_accum_steps=grad_accum_steps,
-            )
-
-            if log_fn is not None:
-                log_fn(i, self._last_loss)
+            raise
 
         if pending_save is not None:
             pending_save.result()

--- a/tests/test_per_query_magic.py
+++ b/tests/test_per_query_magic.py
@@ -11,6 +11,7 @@ the uniform mean of the per-query losses. That identity is the correctness gate.
 
 import tempfile
 
+import pytest
 import torch
 import torchopt
 from datasets import Dataset
@@ -68,7 +69,8 @@ def _aggregate_magic_score(trainer, model, fwd_state, stream, ckpt_dir, query_ds
     return bwd.weight_grads.detach().cpu()
 
 
-def test_per_query_mean_reproduces_aggregate():
+@pytest.mark.parametrize("grad_accum_steps", [1, 2])
+def test_per_query_mean_reproduces_aggregate(grad_accum_steps):
     model = _model()
     optimizer = torchopt.adamw(1e-4, betas=(0.95, 0.975), eps_root=1e-2)
     trainer, fwd_state = Trainer.initialize(model, optimizer)
@@ -84,7 +86,11 @@ def test_per_query_mean_reproduces_aggregate():
         ckpts = f"{run_path}/checkpoints"
         fwd_state = trainer.train(fwd_state, stream, inplace=True, save_dir=ckpts)
 
-        run_cfg = MagicConfig(run_path=run_path, query_method="none")
+        run_cfg = MagicConfig(
+            run_path=run_path,
+            query_method="none",
+            grad_accum_steps=grad_accum_steps,
+        )
         run_cfg.query.prompt_column = "input_ids"
 
         # Snapshot final state so the aggregate reference starts where per-query does.


### PR DESCRIPTION
Fable-ish: Three fixes in the MAGIC per-query / trainer path, all surfaced by running `examples/magic/gpt2_wikitext_tiny.yaml` (GPT-2, 48 GiB GPU) and its tests with gradient accumulation:

1. Use`grad_accum_steps` when computing query gradients
2. Don't do backward passes for padding items added to fill out batches
3 Fix race in async checkpoint save during in-process resume: an exception escaping the training loop left the DCP `async_save` writer thread running; a subsequent `resume()` in the same process raced its `rmtree` cleanup of the incomplete checkpoint against that writer (`OSError: [Errno 39] Directory not empty`). The loop now awaits the in-flight save before re-raising.