### PR TITLE
Add weighted leave-k-out validation

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -461,6 +461,11 @@ class ValidationConfig(TrainingConfig, ABC):
     """Training weight assigned to each subset's documents during the retrain
     (the rest stay at 1.0). ``0.0`` (default) is standard leave-k-out removal."""
 
+    weight_lrs: list[float] = field(default_factory=list)
+    """Gradient step on the data weights: for each lr, retrain once with doc
+    weights ``1 - lr * score`` (mean over query columns) instead of leave-k-out
+    subsets, and compare the query loss change to its first-order prediction."""
+
     exclude_zero_scores: bool = False
     """When True, drop doc_ids with score == 0 from the validation
     permutation. These scores may be produced by items with fewer than

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -457,6 +457,10 @@ class ValidationConfig(TrainingConfig, ABC):
     subset_strategy: Literal["random"] = "random"
     """Strategy for selecting leave-k-out subsets for validation."""
 
+    subset_weight: float = 0.0
+    """Training weight assigned to each subset's documents during the retrain
+    (the rest stay at 1.0). ``0.0`` (default) is standard leave-k-out removal."""
+
     exclude_zero_scores: bool = False
     """When True, drop doc_ids with score == 0 from the validation
     permutation. These scores may be produced by items with fewer than

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -234,6 +234,13 @@ def compute_per_query_magic_scores(
         if main:
             print(f"[per-query MAGIC] scored query {qi + 1}/{num_query_docs}")
 
+    # The last backward walked fwd_state down the trajectory; validate_scores
+    # needs the trained state for the multi-query baseline.
+    fwd_state.detach_()
+    restored = final_state.to(device)
+    fwd_state.copy_(restored)
+    del restored
+
     # [num_train_docs, num_query_docs] — the layout validate_scores expects
     # (rows are leave-out docs; columns are queries).
     return torch.stack(per_query, dim=1)

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -356,7 +356,7 @@ def validate_scores(
                 stream.weights.data[-weight_pad_count:] = 0.0
             else:
                 stream.weights.data[-pad_count:] = 0.0
-        stream.weights.view(-1)[subset] = 0.0
+        stream.weights.view(-1)[subset] = run_cfg.subset_weight
 
         for x in stream:
             fwd_state = trainer.step(

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -282,6 +282,80 @@ def validate_scores(
     num_queries = scores.shape[-1] if multi_query else 1
     flat_scores = scores.reshape(-1, num_queries)
 
+    if run_cfg.weight_lrs:
+        # Gradient step on the data weights: retrain with w = 1 - lr * score
+        # for each lr and compare the query loss change to the first-order
+        # prediction lr * <s_q, s_step>.
+        step_scores = flat_scores.mean(dim=1)
+        predicted = flat_scores.mul(step_scores[:, None]).sum(dim=0)
+        csv_path = os.path.join(run_cfg.run_path, "weight_step.csv")
+        csv_writer = CSVWriter(
+            csv_path,
+            columns=(
+                ["lr", "query", "diff", "predicted_diff"]
+                if multi_query
+                else ["lr", "diff", "predicted_diff"]
+            ),
+            enabled=global_rank == 0,
+        )
+
+        for lr in run_cfg.weight_lrs:
+            trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
+            fwd_state.detach_()
+
+            stream.weights.fill_(1.0)
+            if pad_count:
+                if stream.weights.ndim == 1:
+                    stream.weights.data[-weight_pad_count:] = 0.0
+                else:
+                    stream.weights.data[-pad_count:] = 0.0
+            flat_w = stream.weights.view(-1)
+            flat_w[: len(step_scores)] -= lr * step_scores.to(flat_w)
+
+            for x in stream:
+                fwd_state = trainer.step(
+                    fwd_state,
+                    x,
+                    inplace=True,
+                    fsdp=run_cfg.fsdp,
+                    max_grad_norm=run_cfg.max_grad_norm,
+                    grad_accum_steps=run_cfg.grad_accum_steps,
+                )
+
+            if multi_query:
+                with fwd_state.activate(model):
+                    per_doc = per_doc_query_losses(model, query_stream, num_query_docs)
+                diff_vec = baseline_per_doc - per_doc[:num_real_query_docs].cpu()
+                for q in range(num_real_query_docs):
+                    csv_writer.writerow(
+                        lr, q, diff_vec[q].item(), lr * predicted[q].item()
+                    )
+                if global_rank == 0:
+                    print(
+                        f"lr {lr:g}: mean diff {diff_vec.mean():.6f} "
+                        f"(predicted {lr * predicted.mean().item():.6f})"
+                    )
+            else:
+                with fwd_state.activate(model), torch.no_grad():
+                    loss = torch.tensor(0.0, device=stream.weights.device)
+                    for batch in query_stream:
+                        del batch["example_weight"]
+                        loss += model(**batch).loss.detach() / len(query_stream)
+                if world_size > 1:
+                    dist.all_reduce(loss, op=dist.ReduceOp.AVG)
+                diff = baseline - loss.item()
+                csv_writer.writerow(lr, diff, lr * predicted.mean().item())
+                if global_rank == 0:
+                    print(
+                        f"lr {lr:g}: diff {diff:.6f} "
+                        f"(predicted {lr * predicted.mean().item():.6f})"
+                    )
+
+        csv_writer.close()
+        if global_rank == 0:
+            print(f"Saved weight-step validation to {csv_path}")
+        return
+
     if run_cfg.exclude_zero_scores:
         valid_indices = torch.nonzero((flat_scores != 0).any(dim=1), as_tuple=True)[0]
     else:


### PR DESCRIPTION
Adds two data-reweighting knobs to `ValidationConfig`:

- `subset_weight`: the retrain sets each subset's documents to this weight instead of removing them. `0.0` (default) is standard leave-k-out; `2.0` up-weights the subset — a MAGIC-compatible +1 bump.
- `weight_lrs`: gradient step on the data weights. For each lr, retrain once with doc weights `1 - lr * score` (mean over query columns) instead of leave-k-out subsets, and compare the query loss change to its first-order prediction `lr * <s_q, s_step>`. Results go to `weight_step.csv`.

Also fixes a latent bug from #401: the last per-query backward leaves `fwd_state` walked back to the start of the trajectory, so `validate_scores` computed the multi-query baseline at the wrong state. Spearman was unaffected (constant shift per query), but absolute diffs in `validation.csv` were wrong.

The original branch also carried a `subsets_path` field; dropped here since `subsets` on main already covers explicit subset lists.

Tested: MAGIC + per-token LDS + per-query suites pass. End-to-end tiny-Phi3/WikiText runs: `subset_weight: 2.0` completes with the expected inverted correlation; `weight_lrs: [0.0, 100.0]` gives diff ≈ 0 at lr=0 (exact null control after the state-restore fix) and a query-loss improvement of 0.012 at lr=100 (first-order prediction 0.054, same sign).