### PR TITLE
docs(magic): record the WikiText MAGIC LDS in gpt2_wikitext.yaml

### DIFF
--- a/examples/magic/gpt2_wikitext.yaml
+++ b/examples/magic/gpt2_wikitext.yaml
@@ -4,6 +4,9 @@
 # Hyperparameters are inferred from the MAGIC paper, the metagradients
 # paper it cites, and the datacomp competition that the metagradients paper cites.
 
+# Per-query MAGIC LDS = 0.952 (95% CI [0.944, 0.959]), measured over m=50
+# queries against an N=100 leave-1%-out retrain bank.
+
 # Run with `bergson examples/magic/gpt2_wikitext.yaml`
 
 steps:


### PR DESCRIPTION
Per-query MAGIC LDS = 0.952 (95% CI [0.944, 0.959]), m=50 queries against an N=100 leave-1%-out retrain bank, for this config's eps_root=1e-8 / bs256 recipe.