### PR TITLE
fix(validate): detect per-query .pt scores via the run config

### DIFF
--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -18,6 +18,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+import yaml
 from peft import PeftModel
 from scipy.stats import pearsonr, spearmanr
 from tqdm import tqdm
@@ -30,7 +31,7 @@ from transformers.utils.logging import (
 )
 
 from .config.config import ScoreConfig, ValidationConfig
-from .config.config_io import load_subconfig, save_run_config
+from .config.config_io import CONFIG_FILENAME, load_subconfig, save_run_config
 from .data import Scores, load_scores, pad_and_tensor
 from .magic.data_stream import DataStream, pad_dataset_to_batch_size
 from .magic.trainer import TrainerState, prepare_trainer
@@ -45,8 +46,10 @@ def load_attribution_scores(score_path: str) -> tuple[torch.Tensor, bool]:
     Returns ``(scores, multi_query)``. Token score directories are per-token,
     with a query dimension when ``num_scores > 1`` (``[docs, seq_len,
     queries]``); plain score directories and ``.npy`` arrays are per-document,
-    with one column per query; 2-D ``.pt`` tensors are per-token MAGIC scores
-    (``[docs, seq_len]``, single-query).
+    with one column per query. A 2-D ``.pt`` tensor is ambiguous — per-token
+    MAGIC scores are ``[docs, seq_len]`` and per-query MAGIC scores are
+    ``[docs, queries]`` — so the run config next to it decides: it is
+    per-query iff the run used ``query_method: none``.
 
     Score directories are negated when their ``score_cfg.higher_is_better`` is
     set, aligning them with the loss-diff convention. ``.npy`` files carry no
@@ -77,7 +80,32 @@ def load_attribution_scores(score_path: str) -> tuple[torch.Tensor, bool]:
         return scores, scores.ndim == 2 and scores.shape[1] > 1
 
     scores = torch.load(score_path, map_location="cpu")
-    return scores, False
+    return scores, _pt_scores_are_per_query(score_path, scores)
+
+
+def _pt_scores_are_per_query(score_path: str, scores: torch.Tensor) -> bool:
+    """Whether a 2-D ``.pt`` tensor is per-query ``[docs, queries]`` rather
+    than per-token ``[docs, seq_len]``. The shape alone cannot tell them
+    apart; the run config written next to ``scores.pt`` records which one
+    ``run_magic`` saved."""
+    if not (isinstance(scores, torch.Tensor) and scores.ndim == 2):
+        return False
+    cfg_path = Path(score_path).parent / CONFIG_FILENAME
+    if not cfg_path.is_file():
+        return False
+    with open(cfg_path) as f:
+        doc = yaml.safe_load(f)
+    if not isinstance(doc, dict):
+        return False
+    steps = doc.get("steps")
+    payload = (
+        next(iter(steps[0].values())) if isinstance(steps, list) and steps else doc
+    )
+    return (
+        isinstance(payload, dict)
+        and payload.get("query_method") == "none"
+        and not payload.get("per_token")
+    )
 
 
 def bank_loss_cache_key(

--- a/tests/test_multi_query_validate.py
+++ b/tests/test_multi_query_validate.py
@@ -153,3 +153,34 @@ def test_metasmoothness_score():
 
     # Zero movement -> defined as perfectly smooth.
     assert metasmoothness_score(theta0, theta0, theta0) == 1.0
+
+
+def test_load_attribution_scores_pt_per_query(tmp_path):
+    """A per-query [docs, queries] scores.pt is flagged multi-query when the
+    run config beside it says query_method: none; per-token and configless
+    tensors stay single-query."""
+    import yaml
+
+    values = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+    torch.save(values, tmp_path / "scores.pt")
+
+    # No config.yaml: ambiguous, keep the per-token interpretation.
+    _, multi_query = load_attribution_scores(str(tmp_path / "scores.pt"))
+    assert not multi_query
+
+    cfg = {"steps": [{"magic": {"query_method": "none", "per_token": False}}]}
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg))
+    scores, multi_query = load_attribution_scores(str(tmp_path / "scores.pt"))
+    assert multi_query
+    torch.testing.assert_close(scores, values)
+
+    # Per-token runs save [docs, seq_len]; never multi-query.
+    cfg = {"steps": [{"magic": {"query_method": "none", "per_token": True}}]}
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg))
+    _, multi_query = load_attribution_scores(str(tmp_path / "scores.pt"))
+    assert not multi_query
+
+    cfg = {"steps": [{"magic": {"query_method": "mean"}}]}
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg))
+    _, multi_query = load_attribution_scores(str(tmp_path / "scores.pt"))
+    assert not multi_query


### PR DESCRIPTION
Standalone `validate` with `retrained_dir` fails on per-query MAGIC scores: `load_attribution_scores` returns `multi_query=False` for every `.pt` file, so a `[docs, queries]` matrix from `query_method: none` hits the `evaluate_retrained expects per-doc (1D) scores` assertion.

Shape alone can't distinguish per-query `[docs, queries]` from per-token `[docs, seq_len]`, so this reads the `config.yaml` that `run_magic` writes next to `scores.pt`: the tensor is per-query iff the run used `query_method: none` (and not `per_token`). Falls back to the per-token interpretation when no config is present.

Longer-term the cleaner path is routing per-query MAGIC scores through the unified score-directory writer, but this unblocks validating existing runs' `scores.pt` artifacts.