### PR TITLE
fix(magic): let worker() run on CPU-only machines

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -308,7 +308,8 @@ def worker(
     run_cfg: TrainingConfig,
     score_path: str = "",
 ):
-    torch.cuda.set_device(get_device_index(rank))
+    if torch.cuda.is_available():
+        torch.cuda.set_device(get_device_index(rank))
 
     # For each non-main local rank, suppress HF info and warning messages
     if rank != 0:


### PR DESCRIPTION
## Problem

`worker()` calls `torch.cuda.set_device()` as its very first statement, unconditionally. On a CPU-only machine every `bergson magic` invocation dies immediately:

```
File "bergson/magic/cli.py", line 311, in worker
    torch.cuda.set_device(get_device_index(rank))
AttributeError: module 'torch._C' has no attribute '_cuda_setDevice'
```

Every other device lookup in this file already degrades gracefully — `get_device()` returns `"cpu"` when CUDA is unavailable — so this single call was the only thing standing between MAGIC and a working CPU run.

## Fix

Guard the call on `torch.cuda.is_available()`. One line, no behaviour change on GPU.

## Why it's worth fixing

Two things fall out:

1. Contributors without a GPU can exercise the MAGIC CLI on small models.
2. **MAGIC's on-disk output becomes testable in CI without a GPU runner.** This matters more than it sounds: the existing tests in `tests/test_magic.py` go through `_run_magic_cli`, which *reimplements* `worker()`'s pad/train/backward/trim sequence rather than calling it. Nothing asserts on what `worker()` actually writes to a run directory, which is how #(doc_ids regression) went unnoticed. #(follow-up PR) stacks on this branch and adds the first test that calls `worker()` for real.

## Testing

Full per-token attribution run on CPU (macOS, no CUDA), trains and backprops through the trajectory to completion:

```
bergson magic <run> --data.dataset NeelNanda/pile-10k \
    --data.split "train[:16]" --data.chunk_length 64 \
    --query.dataset NeelNanda/pile-10k --query.split "train[:4]" \
    --query.chunk_length 64 --model EleutherAI/pythia-14m \
    --batch_size 4 --attribute_tokens true --query_method mean \
    --skip_validation true
```

```
Baseline loss: 3.709878112140455
Saved attribution scores to <run>/scores.pt
```

`pytest tests/test_magic.py tests/test_per_query_magic.py` — 43 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)