### PR TITLE
Record the runtime NCCL version in run metadata

### DIFF
--- a/bergson/config/config_io.py
+++ b/bergson/config/config_io.py
@@ -35,8 +35,26 @@ def _git_sha() -> str | None:
         return None
 
 
+def _nccl_version() -> str | None:
+    """Version of the NCCL library torch actually loaded, or ``None``.
+
+    Reported from the runtime (``torch.cuda.nccl.version()``), not package
+    metadata: the two can disagree, and NCCL selects the gradient all-reduce
+    algorithms, so its version is part of what makes a multi-GPU run
+    bit-reproducible.
+    """
+    try:
+        import torch
+
+        if torch.distributed.is_nccl_available():
+            return ".".join(map(str, torch.cuda.nccl.version()))
+    except Exception:
+        return None
+    return None
+
+
 def make_metadata() -> dict[str, Any]:
-    """Run metadata: version, time, git sha."""
+    """Run metadata: version, time, git sha, NCCL version."""
     try:
         version: str | None = _pkg_version("bergson")
     except PackageNotFoundError:
@@ -48,6 +66,9 @@ def make_metadata() -> dict[str, Any]:
     sha = _git_sha()
     if sha is not None:
         meta["git_sha"] = sha
+    nccl = _nccl_version()
+    if nccl is not None:
+        meta["nccl_version"] = nccl
     return meta
 
 

--- a/bergson/config/config_io.py
+++ b/bergson/config/config_io.py
@@ -45,6 +45,7 @@ def _nccl_version() -> str | None:
     """
     try:
         import torch
+        import torch.cuda.nccl
 
         if torch.distributed.is_nccl_available():
             return ".".join(map(str, torch.cuda.nccl.version()))

--- a/tests/test_config_runner.py
+++ b/tests/test_config_runner.py
@@ -269,3 +269,23 @@ steps:
     _, cmd = steps[0]
     assert isinstance(cmd, Hessian)
     assert cmd.hessian_cfg.method == "autocorrelation"
+
+
+def test_metadata_records_runtime_nccl_version():
+    """Run metadata carries the NCCL version torch actually loaded.
+
+    NCCL selects the all-reduce algorithms, so its version is part of what
+    makes a multi-GPU run bit-reproducible; the runtime report can disagree
+    with pip metadata, which is why the loaded version is the one recorded.
+    """
+    import torch
+
+    from bergson.config.config_io import make_metadata
+
+    meta = make_metadata()
+    if torch.distributed.is_nccl_available():
+        parts = meta["nccl_version"].split(".")
+        assert len(parts) >= 2 and all(p.isdigit() for p in parts)
+        assert tuple(map(int, parts)) == tuple(torch.cuda.nccl.version())
+    else:
+        assert "nccl_version" not in meta

--- a/tests/test_config_runner.py
+++ b/tests/test_config_runner.py
@@ -279,6 +279,7 @@ def test_metadata_records_runtime_nccl_version():
     with pip metadata, which is why the loaded version is the one recorded.
     """
     import torch
+    import torch.cuda.nccl
 
     from bergson.config.config_io import make_metadata
 


### PR DESCRIPTION
## Why

While investigating why re-training a stored retrain-bank's base model no longer reproduces it bit-exactly (same bergson commit, config, seed, and world size), we found that recorded package lists cannot be trusted to describe the runtime: a 2026-08-03 run's pip snapshot claims `nvidia-nccl-cu12==2.26.2`, but the same torch binary hard-requires NCCL 2.28 symbols (`ncclCommShrink`) — what pip metadata says and what the runtime loaded can differ. NCCL selects gradient all-reduce algorithms, so its version is part of what makes a multi-GPU run bit-reproducible.

## What

- `make_metadata()` now records `nccl_version` from `torch.cuda.nccl.version()` — the actually-loaded library.
- Emitted only when NCCL is available; CPU-only runs get no new key.
- Test asserts the recorded value matches the runtime report and is absent without NCCL.

## Testing

`tests/test_config_runner.py`: 15 passed (includes the new test; verified live on an 8x A100 node reporting `2.28.9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)