### PR TITLE
Custom GPT-2 with optional QK-norm and MLP pre-activation LayerNorm

### DIFF
--- a/bergson/models/modeling_gpt2_custom.py
+++ b/bergson/models/modeling_gpt2_custom.py
@@ -1,0 +1,84 @@
+"""GPT-2 with optional architecture modifications, for attribution experiments.
+
+One class, three architectures selected by ``config.arch_mod``:
+
+- ``"none"``: exactly stock GPT-2. No extra modules, no extra parameters; stock
+  ``gpt2`` checkpoints load with zero missing/unexpected keys, and logits match
+  ``GPT2LMHeadModel`` bit-for-bit (tested).
+- ``"qk_norm"``: the OLMo 2 convention — RMSNorm applied to the query and key
+  projections over their full width, before the head split, one norm pair per
+  layer.
+- ``"preact_layernorm"``: LayerNorm on the MLP pre-activation (between ``c_fc``
+  and the GELU), one per layer.
+
+The modifications attach as forward hooks on the existing ``c_attn`` / ``c_fc``
+modules rather than replacing any module or copying any forward method, so the
+stock state-dict layout, cache handling, and attention implementation are
+inherited unchanged from the installed ``transformers`` — the diff against
+stock GPT-2 is exactly the new norm parameters and nothing else. This is what
+makes the "effect of the modification" separable from "effect of
+reimplementing GPT-2" (metasmoothness DECISIONS.md, D10).
+"""
+
+import torch
+from torch import nn
+from transformers import AutoConfig, AutoModelForCausalLM
+from transformers.models.gpt2.modeling_gpt2 import GPT2Config, GPT2LMHeadModel
+
+ARCH_MODS = ("none", "qk_norm", "preact_layernorm")
+
+
+class GPT2CustomConfig(GPT2Config):
+    model_type = "gpt2_custom"
+
+    def __init__(self, arch_mod: str = "none", qk_norm_eps: float = 1e-6, **kwargs):
+        if arch_mod not in ARCH_MODS:
+            raise ValueError(f"arch_mod must be one of {ARCH_MODS}, got {arch_mod!r}")
+        self.arch_mod = arch_mod
+        self.qk_norm_eps = qk_norm_eps
+        super().__init__(**kwargs)
+
+
+class GPT2CustomLMHeadModel(GPT2LMHeadModel):
+    config_class = GPT2CustomConfig
+
+    def __init__(self, config: GPT2CustomConfig):
+        super().__init__(config)
+        if config.arch_mod == "qk_norm":
+            for block in self.transformer.h:
+                attn = block.attn
+                # OLMo 2 applies the norm to the full projected q/k vectors
+                # before the head reshape; c_attn packs [q | k | v] along the
+                # last dim, so norming the first two thirds of its output is
+                # the same placement.
+                attn.q_norm = nn.RMSNorm(attn.embed_dim, eps=config.qk_norm_eps)
+                attn.k_norm = nn.RMSNorm(attn.embed_dim, eps=config.qk_norm_eps)
+                attn.c_attn.register_forward_hook(_qk_norm_hook(attn))
+        elif config.arch_mod == "preact_layernorm":
+            inner = config.n_inner if config.n_inner is not None else 4 * config.n_embd
+            for block in self.transformer.h:
+                block.mlp.preact_ln = nn.LayerNorm(inner, eps=config.layer_norm_epsilon)
+                block.mlp.c_fc.register_forward_hook(_preact_ln_hook(block.mlp))
+        # Re-run weight init so freshly added norms get their documented init;
+        # existing weights are re-initialized identically (init is deterministic
+        # per-module) and overwritten anyway when loading a checkpoint.
+        self.post_init()
+
+
+def _qk_norm_hook(attn):
+    def hook(module, args, output):
+        q, k, v = output.split(attn.split_size, dim=2)
+        return torch.cat([attn.q_norm(q), attn.k_norm(k), v], dim=2)
+
+    return hook
+
+
+def _preact_ln_hook(mlp):
+    def hook(module, args, output):
+        return mlp.preact_ln(output)
+
+    return hook
+
+
+AutoConfig.register("gpt2_custom", GPT2CustomConfig)
+AutoModelForCausalLM.register(GPT2CustomConfig, GPT2CustomLMHeadModel)

--- a/examples/gpt2_custom/push_to_hub.py
+++ b/examples/gpt2_custom/push_to_hub.py
@@ -1,0 +1,43 @@
+"""Upload the custom GPT-2 to the Hub with its modeling code.
+
+Usage:
+    python examples/gpt2_custom/push_to_hub.py [--repo EleutherAI/gpt2-custom] [--public]
+
+Publishes stock ``gpt2`` weights wrapped in ``GPT2CustomLMHeadModel`` with
+``arch_mod="none"`` plus the modeling module (``trust_remote_code``). Variants
+load from the same repo by overriding the config at load time:
+
+    AutoModelForCausalLM.from_pretrained(repo, arch_mod="qk_norm",
+                                         trust_remote_code=True)
+
+``arch_mod="none"`` is bit-identical to stock ``gpt2`` (tested at both toy and
+124M scale), so this repo is a drop-in base for the architecture-modification
+experiments and their control row.
+"""
+
+import argparse
+
+from transformers import GPT2LMHeadModel
+
+from bergson.models.modeling_gpt2_custom import GPT2CustomConfig, GPT2CustomLMHeadModel
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default="EleutherAI/gpt2-custom")
+    ap.add_argument("--public", action="store_true")
+    args = ap.parse_args()
+
+    stock = GPT2LMHeadModel.from_pretrained("gpt2")
+    cfg = GPT2CustomConfig(arch_mod="none", **stock.config.to_diff_dict())
+    model = GPT2CustomLMHeadModel(cfg)
+    model.load_state_dict(stock.state_dict(), strict=True)
+
+    GPT2CustomConfig.register_for_auto_class()
+    GPT2CustomLMHeadModel.register_for_auto_class("AutoModelForCausalLM")
+    model.push_to_hub(args.repo, private=not args.public)
+    print(f"pushed {args.repo} (private={not args.public})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gpt2_custom.py
+++ b/tests/test_gpt2_custom.py
@@ -51,7 +51,9 @@ def test_mods_add_params_change_output_and_train(mod, param_frag, n_added):
     custom.train()
     loss = custom(x, labels=x).loss
     loss.backward()
-    grads = [p.grad for n, p in custom.named_parameters() if any(f in n for f in param_frag)]
+    grads = [
+        p.grad for n, p in custom.named_parameters() if any(f in n for f in param_frag)
+    ]
     assert grads and all(g is not None and g.abs().sum() > 0 for g in grads)
 
 

--- a/tests/test_gpt2_custom.py
+++ b/tests/test_gpt2_custom.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.models.gpt2.modeling_gpt2 import GPT2Config, GPT2LMHeadModel
+
+from bergson.models.modeling_gpt2_custom import GPT2CustomConfig, GPT2CustomLMHeadModel
+
+SMALL = dict(n_embd=32, n_head=4, n_layer=2, n_positions=64, vocab_size=97)
+
+
+def small_custom(arch_mod: str) -> GPT2CustomLMHeadModel:
+    torch.manual_seed(0)
+    return GPT2CustomLMHeadModel(GPT2CustomConfig(arch_mod=arch_mod, **SMALL)).eval()
+
+
+def test_none_mod_is_bit_identical_to_stock():
+    """arch_mod='none' must be exactly stock GPT-2: same parameter set, and a
+    stock checkpoint's weights produce bit-identical logits."""
+    torch.manual_seed(0)
+    stock = GPT2LMHeadModel(GPT2Config(**SMALL)).eval()
+    custom = small_custom("none")
+    assert set(custom.state_dict()) == set(stock.state_dict())
+    custom.load_state_dict(stock.state_dict())
+    x = torch.randint(0, SMALL["vocab_size"], (2, 16))
+    with torch.no_grad():
+        assert torch.equal(custom(x).logits, stock(x).logits)
+
+
+@pytest.mark.parametrize(
+    "mod,param_frag,n_added",
+    [
+        # RMSNorm is weight-only: 2 layers x (q_norm + k_norm) = 4 tensors.
+        ("qk_norm", ("q_norm", "k_norm"), 4),
+        # LayerNorm has weight + bias: 2 layers x 2 = 4 tensors.
+        ("preact_layernorm", ("preact_ln",), 4),
+    ],
+)
+def test_mods_add_params_change_output_and_train(mod, param_frag, n_added):
+    torch.manual_seed(0)
+    stock = GPT2LMHeadModel(GPT2Config(**SMALL)).eval()
+    custom = small_custom(mod)
+    added = [n for n in custom.state_dict() if any(f in n for f in param_frag)]
+    assert len(added) == n_added, added
+    # Stock weights still load (norms keep their init).
+    missing, unexpected = custom.load_state_dict(stock.state_dict(), strict=False)
+    assert not unexpected and all(any(f in n for f in param_frag) for n in missing)
+    x = torch.randint(0, SMALL["vocab_size"], (2, 16))
+    with torch.no_grad():
+        assert not torch.equal(custom(x).logits, stock(x).logits)
+    # Gradients reach the new norms.
+    custom.train()
+    loss = custom(x, labels=x).loss
+    loss.backward()
+    grads = [p.grad for n, p in custom.named_parameters() if any(f in n for f in param_frag)]
+    assert grads and all(g is not None and g.abs().sum() > 0 for g in grads)
+
+
+@pytest.mark.parametrize("mod", ["none", "qk_norm", "preact_layernorm"])
+def test_save_load_roundtrip_preserves_arch_and_function(tmp_path, mod):
+    m = small_custom(mod)
+    x = torch.randint(0, SMALL["vocab_size"], (2, 16))
+    with torch.no_grad():
+        before = m(x).logits
+    m.save_pretrained(tmp_path)
+    m2 = AutoModelForCausalLM.from_pretrained(tmp_path).eval()
+    assert isinstance(m2, GPT2CustomLMHeadModel)
+    assert m2.config.arch_mod == mod
+    with torch.no_grad():
+        assert torch.equal(m2(x).logits, before)


### PR DESCRIPTION
## Why

The metasmoothness paper's architecture axis needs GPT-2 variants (OLMo-style QK-norm; pre-activation norm) whose effects are separable from "effect of reimplementing GPT-2" (design ruling D10 in the experiment repo).

## What

One class, three architectures via `config.arch_mod` (`none` / `qk_norm` / `preact_layernorm`):

- Modifications attach as **forward hooks on the stock `c_attn` / `c_fc` modules** — no module replacement, no forward-method copying — so the stock state-dict layout, cache handling, and attention implementation are inherited unchanged from the installed transformers.
- `arch_mod="none"` is therefore structurally stock GPT-2: identical parameter set, and **bit-identical logits under real gpt2-124M weights** (tested).
- `qk_norm` follows the OLMo 2 convention: RMSNorm on the full q/k projections before the head split, one pair per layer.
- `preact_layernorm`: LayerNorm on the MLP pre-activation, between `c_fc` and the GELU.
- Variants select at load time — `from_pretrained(..., arch_mod="qk_norm")` — which is exactly what bergson's `model_kwargs` plumbing passes through; no bergson code changes needed to train them.
- `examples/gpt2_custom/push_to_hub.py` published the model with remote code as `EleutherAI/gpt2-custom` (private); Hub round-trip with an `arch_mod` override is verified.

## Testing

`tests/test_gpt2_custom.py`: 6 passed — none-mod state-dict + bit-identical-logit equivalence, per-mod parameter counts, gradient flow to the new norms, save/load round-trips preserving architecture and function; plus the full-size gpt2-124M bit-identity check and a Hub `trust_remote_code` load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)