### PR TITLE
Remove the stale torch<2.10 upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,15 @@ dependencies = [
     "pyarrow",
     "pyyaml",
     "simple-parsing",
-    "torch>=2.5,<2.10",
+    "torch>=2.5",
     # torchvision/torchaudio aren't used by bergson directly, but transformers'
     # image_utils does an unconditional `from torchvision.io import ...` at
     # import time when torchvision is present. RunPod (and most CUDA base
     # images) ship a torchvision built against torch 2.4; once we bump torch
-    # to >=2.5, the stale torchvision crashes at import. Pin both to a range
-    # compatible with the torch bound above.
-    "torchvision>=0.20,<0.25",
-    "torchaudio>=2.5,<2.10",
+    # to >=2.5, the stale torchvision crashes at import. Keep a lower bound so
+    # a stale torchvision cannot be resolved.
+    "torchvision>=0.20",
+    "torchaudio>=2.5",
     "torchopt",
     "transformers>=5.0",
     "bitsandbytes",


### PR DESCRIPTION
## Why

`pyproject.toml` caps `torch>=2.5,<2.10` (with matching torchvision/torchaudio caps). Traced to `eb34d550` (2026-05-03), where a `fast-jl` uv build-dep declaration (`torch>=2.4,<2.10`) propagated into the main dependency list. The cap was never tied to a known incompatibility — torch 2.10 did not exist when it was written — and it blocks `pip install bergson` alongside current torch (2.11+/2.13), which multi-node experiment fleets now run.

## What

Removes the upper bounds, keeping the lower bounds (which encode the real constraints). Authored by the bellflower-0 experiment node (branch relayed and pushed from lotus-0, since worker nodes have no GitHub auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)