### PR TITLE
Add tail-filter validation methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 Always test your changes. Ensure your scripts or CLI commands run without issues for 3 minutes+ (at minimum). If you find an error unrelated to your task, at minimum communicate the exact error when you have completed your task and offer to investigate and fix it.
 
-Compare comments to human-written examples in the codebase and match style: imperative summary line, second paragraph only for a mechanism you can't derive. 
+Compare comments to human-written examples in the codebase and match style: imperative summary line, second paragraph only for a mechanism you can't derive.
 
 ## Project Structure and Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 Always test your changes. Ensure your scripts or CLI commands run without issues for 3 minutes+ (at minimum). If you find an error unrelated to your task, at minimum communicate the exact error when you have completed your task and offer to investigate and fix it.
 
+Compare comments to human-written examples in the codebase and match style: imperative summary line, second paragraph only for a mechanism you can't derive. 
+
 ## Project Structure and Conventions
 
 Consider writing a new CLI tool if you add a standalone, complex feature used in more than one place.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@ Always test your changes. Ensure your scripts or CLI commands run without issues
 
 Compare comments to human-written examples in the codebase and match style: imperative summary line, second paragraph only for a mechanism you can't derive.
 
+Don't coin terms or use jargon. Don't write code or comments containing specialized terms not already in the codebase without permission.
+
 ## Project Structure and Conventions
 
 Consider writing a new CLI tool if you add a standalone, complex feature used in more than one place.

--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -315,15 +315,14 @@ class Validate(ValidationConfig):
     def execute(self):
         """Run the validation."""
         assert self.scores, "Path to attribution scores must be provided."
-        dirs = self.retrained_dirs
-        # A filter-* run always retrains its score-based filter.
-        if dirs and self.method == "lds":
-            evaluate_retrained(self, dirs, score_path=self.scores)
+
+        if self.retrained_dirs and self.method == "lds":
+            evaluate_retrained(self, self.retrained_dirs, score_path=self.scores)
         else:
             run_magic(
                 self,
                 score_path=self.scores,
                 validate=True,
                 baseline_model=self.baseline_model,
-                retrained_dir=dirs,
+                retrained_dir=self.retrained_dirs,
             )

--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -306,18 +306,25 @@ class Validate(ValidationConfig):
     baseline_model: str = ""
     """Optional path to baseline model trained on the full dataset."""
 
+    @property
+    def retrained_dirs(self) -> list[str]:
+        """``retrained_dir`` normalized to a list of paths."""
+        if isinstance(self.retrained_dir, str):
+            return [d for d in self.retrained_dir.split(",") if d]
+        return list(self.retrained_dir)
+
     def execute(self):
         """Run the validation."""
         assert self.scores, "Path to attribution scores must be provided."
-        if self.retrained_dir:
-            retrained_dir = self.retrained_dir
-            if isinstance(retrained_dir, str) and "," in retrained_dir:
-                retrained_dir = retrained_dir.split(",")
-            evaluate_retrained(self, retrained_dir, score_path=self.scores)
+        dirs = self.retrained_dirs
+        # A filter-* run always retrains its score-dependent arm.
+        if dirs and self.method == "lds":
+            evaluate_retrained(self, dirs, score_path=self.scores)
         else:
             run_magic(
                 self,
                 score_path=self.scores,
                 validate=True,
                 baseline_model=self.baseline_model,
+                retrained_dir=dirs,
             )

--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -308,7 +308,6 @@ class Validate(ValidationConfig):
 
     @property
     def retrained_dirs(self) -> list[str]:
-        """``retrained_dir`` normalized to a list of paths."""
         if isinstance(self.retrained_dir, str):
             return [d for d in self.retrained_dir.split(",") if d]
         return list(self.retrained_dir)
@@ -317,7 +316,7 @@ class Validate(ValidationConfig):
         """Run the validation."""
         assert self.scores, "Path to attribution scores must be provided."
         dirs = self.retrained_dirs
-        # A filter-* run always retrains its score-dependent arm.
+        # A filter-* run always retrains its score-based filter.
         if dirs and self.method == "lds":
             evaluate_retrained(self, dirs, score_path=self.scores)
         else:

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -458,7 +458,9 @@ class ValidationConfig(TrainingConfig, ABC):
     ``none`` will perform one backward per query."""
 
     num_subsets: int = 100
-    """Number of leave-k-out subsets for Spearman correlation."""
+    """Number of leave-k-out subsets for Spearman correlation, or for a
+    filter-* method the number of random filters it is compared against;
+    ``0`` skips them, as does a bank of retrained models."""
 
     subset_weight: float = 0.0
     """Training weight assigned to each subset's documents during the retrain
@@ -498,7 +500,7 @@ class ValidationConfig(TrainingConfig, ABC):
     correlates the query loss change with the summed attribution scores.
     ``filter`` methods filter either the top- or bottom-scoring
     ``subset_fraction`` of data, then retrain and measure the query loss
-    change, suitable for comparison with a random subset filter re-train."""
+    change against ``num_subsets`` random filters of the same size."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -486,36 +486,22 @@ class ValidationConfig(TrainingConfig, ABC):
     """One past the last subset index to retrain; ``None`` means ``num_subsets``."""
 
     subset_fraction: float = 0.0
-    """When > 0, each of the ``num_subsets`` leave-k-out subsets is an
-    independent draw (without replacement within a subset, overlapping across
-    subsets) of ``round(subset_fraction * pool)`` docs from the validation
-    pool — e.g. 0.05 drops 5 percent of the data per subset."""
+    """Fraction of data filtered during a retrain. When 0.0, the dataset is
+    randomly partitioned into ``num_subsets`` disjoint subsets. Otherwise
+    each subset is sampled independently without replacement within a
+    subset, but with replacement across subsets, and contains
+    ``round(subset_fraction * pool)`` documents — e.g. 0.05 filters 5 percent
+    of documents per subset."""
 
     method: Literal["lds", "filter-proponents", "filter-detractors"] = "lds"
     """Validation estimator.
 
-    ``lds`` (default) is leave-k-out linear datamodelling: retrain on many
-    random subsets and correlate the query loss change with the summed
-    attribution scores.
+    The ``lds`` method filters ```num_subsets``` random subsets of the data and
+    correlates the query loss change with the summed attribution scores.
 
-    The ``filter-*`` methods are the tail-filter estimator: for each query,
-    remove the ``filter_fraction`` slice at one end of that query's score
-    ranking, retrain once, and measure the query's loss change against the
-    unablated baseline. ``filter-proponents`` removes the documents the
-    scores say help the query most (performance suppression);
-    ``filter-detractors`` removes the ones they say hurt it most.
-
-    Tail-filter values are meaningful only *relative* to another method's
-    number on the same config -- a larger loss change means the attribution
-    method identified the influential documents better. No absolute meaning
-    is claimed. The matched control is a random removal of the same size,
-    which a leave-k-out bank already provides: its subsets are random
-    ``subset_fraction`` removals, so their loss changes are the reference."""
-
-    filter_fraction: float = 0.01
-    """Fraction of the scored documents to remove per query when ``method``
-    is one of the ``filter-*`` estimators. A fraction, not a count, so the
-    perturbation stays proportional across dataset sizes."""
+    The ``filter`` methods filter either the top- or bottom-scoring
+    ``subset_fraction`` of data, then retrain and measure the query loss
+    change. Suitable for comparison with a random subset filter re-train."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -486,22 +486,19 @@ class ValidationConfig(TrainingConfig, ABC):
     """One past the last subset index to retrain; ``None`` means ``num_subsets``."""
 
     subset_fraction: float = 0.0
-    """Fraction of data filtered during a retrain. When 0.0, the dataset is
-    randomly partitioned into ``num_subsets`` disjoint subsets. Otherwise
-    each subset is sampled independently without replacement within a
-    subset, but with replacement across subsets, and contains
-    ``round(subset_fraction * pool)`` documents — e.g. 0.05 filters 5 percent
-    of documents per subset."""
+    """Fraction of data filtered during a retrain. When > 0 subsets are sampled 
+    independently without replacement within a subset, but with replacement 
+    across subsets, and contain ``round(subset_fraction * pool)`` documents
+    — e.g. 0.05 filters 5 percent of documents per subset. When 0.0, the 
+    dataset is randomly partitioned into ``num_subsets`` disjoint subsets
+    for ```lds```, or for a filter-* method the size is 1 / num_subsets."""
 
     method: Literal["lds", "filter-proponents", "filter-detractors"] = "lds"
-    """Validation estimator.
-
-    The ``lds`` method filters ```num_subsets``` random subsets of the data and
+    """``lds`` filters ```num_subsets``` random subsets of the data and
     correlates the query loss change with the summed attribution scores.
-
-    The ``filter`` methods filter either the top- or bottom-scoring
+    ``filter`` methods filter either the top- or bottom-scoring
     ``subset_fraction`` of data, then retrain and measure the query loss
-    change. Suitable for comparison with a random subset filter re-train."""
+    change, suitable for comparison with a random subset filter re-train."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -486,10 +486,10 @@ class ValidationConfig(TrainingConfig, ABC):
     """One past the last subset index to retrain; ``None`` means ``num_subsets``."""
 
     subset_fraction: float = 0.0
-    """Fraction of data filtered during a retrain. When > 0 subsets are sampled 
-    independently without replacement within a subset, but with replacement 
+    """Fraction of data filtered during a retrain. When > 0 subsets are sampled
+    independently without replacement within a subset, but with replacement
     across subsets, and contain ``round(subset_fraction * pool)`` documents
-    — e.g. 0.05 filters 5 percent of documents per subset. When 0.0, the 
+    — e.g. 0.05 filters 5 percent of documents per subset. When 0.0, the
     dataset is randomly partitioned into ``num_subsets`` disjoint subsets
     for ```lds```, or for a filter-* method the size is 1 / num_subsets."""
 

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -491,6 +491,32 @@ class ValidationConfig(TrainingConfig, ABC):
     subsets) of ``round(subset_fraction * pool)`` docs from the validation
     pool — e.g. 0.05 drops 5 percent of the data per subset."""
 
+    method: Literal["lds", "filter-proponents", "filter-detractors"] = "lds"
+    """Validation estimator.
+
+    ``lds`` (default) is leave-k-out linear datamodelling: retrain on many
+    random subsets and correlate the query loss change with the summed
+    attribution scores.
+
+    The ``filter-*`` methods are the tail-filter estimator: for each query,
+    remove the ``filter_fraction`` slice at one end of that query's score
+    ranking, retrain once, and measure the query's loss change against the
+    unablated baseline. ``filter-proponents`` removes the documents the
+    scores say help the query most (performance suppression);
+    ``filter-detractors`` removes the ones they say hurt it most.
+
+    Tail-filter values are meaningful only *relative* to another method's
+    number on the same config -- a larger loss change means the attribution
+    method identified the influential documents better. No absolute meaning
+    is claimed. The matched control is a random removal of the same size,
+    which a leave-k-out bank already provides: its subsets are random
+    ``subset_fraction`` removals, so their loss changes are the reference."""
+
+    filter_fraction: float = 0.01
+    """Fraction of the scored documents to remove per query when ``method``
+    is one of the ``filter-*`` estimators. A fraction, not a count, so the
+    perturbation stays proportional across dataset sizes."""
+
 
 @dataclass
 class RecallDataConfig(Serializable):

--- a/bergson/config/config_io.py
+++ b/bergson/config/config_io.py
@@ -177,6 +177,19 @@ def load_subconfig(
     return None
 
 
+def get_config_field(dir: Path, field: str):
+    """Value of ``field`` in a saved run config."""
+    try:
+        doc = read_config(dir)
+    except (OSError, ValueError):
+        return None
+    for step in doc.get("steps", []):
+        for cmd in step.values():
+            if cmd and field in cmd:
+                return cmd[field]
+    return None
+
+
 def expand_matrix(cmd_dict: dict) -> list[dict]:
     """Expand a step's ``matrix`` mapping into one config per grid cell.
 

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import time
+from collections.abc import Sequence
 from dataclasses import asdict, replace
 from pathlib import Path
 
@@ -363,6 +364,7 @@ def worker(
     score_path: str = "",
     validate: bool = False,
     baseline_model: str = "",
+    retrained_dir: Sequence[str] = (),
 ):
     if torch.cuda.is_available():
         torch.cuda.set_device(get_device_index(rank))
@@ -631,6 +633,7 @@ def worker(
         run_cfg,
         scores,
         multi_query,
+        retrained_dir=retrained_dir,
         global_rank=global_rank,
         rank=rank,
         schedule=schedule,
@@ -652,6 +655,7 @@ def run_magic(
     score_path: str = "",
     validate: bool = False,
     baseline_model: str = "",
+    retrained_dir: Sequence[str] = (),
 ):
     """Train ``run_cfg``, score the query set, and validate those scores."""
     if validate and not isinstance(run_cfg, ValidationConfig):
@@ -707,6 +711,7 @@ def run_magic(
             score_path,
             validate,
             baseline_model,
+            retrained_dir,
         ],
         run_cfg.distributed,
     )

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -210,14 +210,18 @@ def report_multi_query_validation(
     print(f"Mean Spearman across {num_queries} queries: {np.mean(rhos):.4f}")
 
 
-def _filter_slice_size(pool: int, fraction: float) -> int:
+def _filter_slice_size(pool: int, fraction: float, num_subsets: int) -> int:
     """Number of documents to remove per query for the tail-filter estimator.
 
     A fraction rather than a count, so the perturbation stays proportional
-    across dataset sizes. Always at least one document.
+    across dataset sizes. Always at least one document. ``subset_fraction``
+    of 0.0 means the LDS path chunks the pool into ``num_subsets``
+    non-overlapping subsets, so the matching removal is ``1 / num_subsets``.
     """
+    if fraction == 0.0:
+        fraction = 1 / num_subsets
     if not 0.0 < fraction <= 1.0:
-        raise ValueError(f"filter_fraction must be in (0, 1], got {fraction}")
+        raise ValueError(f"subset_fraction must be in [0, 1], got {fraction}")
     return max(1, round(fraction * pool))
 
 
@@ -267,7 +271,7 @@ def _validate_filter(
 ):
     """Tail-filter estimator: retrain with one end of the score ranking removed.
 
-    For each query, the ``filter_fraction`` highest-ranked documents at the
+    For each query, the ``subset_fraction`` highest-ranked documents at the
     selected end of that query's ranking are dropped, the model is retrained
     once, and the query's loss change against the unablated baseline is
     recorded. The mean over queries is the estimator's value.
@@ -286,7 +290,9 @@ def _validate_filter(
     else:
         valid_indices = torch.arange(flat_scores.shape[0])
 
-    k = _filter_slice_size(len(valid_indices), run_cfg.filter_fraction)
+    k = _filter_slice_size(
+        len(valid_indices), run_cfg.subset_fraction, run_cfg.num_subsets
+    )
 
     csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
     filter_csv = CSVWriter(
@@ -353,7 +359,7 @@ def _validate_filter(
             f"{run_cfg.method}: mean loss change {float(np.mean(changes)):.6f} "
             f"over {len(changes)} quer{'y' if len(changes) == 1 else 'ies'} "
             f"({k} of {len(valid_indices)} docs removed per query, "
-            f"{run_cfg.filter_fraction:.3%})"
+            f"{k / len(valid_indices):.3%})"
         )
         print(f"Saved tail-filter data to {csv_path}")
 

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -31,7 +31,7 @@ from transformers.utils.logging import (
 )
 
 from .config.config import ValidationConfig
-from .config.config_io import read_config, save_run_config
+from .config.config_io import get_config_field, save_run_config
 from .data import load_scores_loss_signed, pad_and_tensor
 from .magic.data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
 from .magic.grad_accum import loss_denom, split_batch
@@ -211,66 +211,42 @@ def report_multi_query_validation(
     print(f"Mean Spearman across {num_queries} queries: {np.mean(rhos):.4f}")
 
 
-def _bank_config_field(bank_dir: Path, field: str):
-    """Value of ``field`` in a bank's saved run config, or ``None`` if absent."""
-    try:
-        doc = read_config(bank_dir)
-    except (OSError, ValueError):
-        return None
-    for step in doc.get("steps", []):
-        for cmd in step.values():
-            if cmd and field in cmd:
-                return cmd[field]
-    return None
-
-
-def load_baseline_bank_subsets(
-    run_cfg: ValidationConfig, dirs: list[Path], k: int
+def load_and_validate_subsets_match(
+    run_cfg: ValidationConfig, dirs: list[Path], num_filtered: int
 ) -> list[torch.Tensor]:
-    """Load a bank's removal sets, rejecting one the filter cannot match."""
-    subsets: list[list[int]] | None = None
+    """Load a list of subsets filtered during re-training runs.
+    Validate subsets and that they match."""
+    first_dir_subsets: list[list[int]] | None = None
     for d in dirs:
-        if not (d / "retrained" / "base").exists():
-            raise FileNotFoundError(
-                f"{d / 'retrained' / 'base'} not found; the random filters' "
-                "loss change is measured against the bank's no-leave-out model"
-            )
-        path = d / "subsets.json"
-        if not path.exists():
-            raise FileNotFoundError(
-                f"{path} not found; retrained_dir must point at a run directory "
-                "written with save_models=true"
-            )
-        with open(path) as f:
-            found = json.load(f)
-        if subsets is None:
-            subsets = found
-        elif found != subsets:
+        assert (d / "retrained" / "base").exists(), f"Retrain bank {d} not valid."
+        with open(d / "subsets.json") as f:
+            dir_subsets = json.load(f)
+
+        if first_dir_subsets is None:
+            first_dir_subsets = dir_subsets
+        assert dir_subsets == first_dir_subsets, f"Bank {d} doesn't match others."
+
+        sizes = sorted({len(x) for x in dir_subsets})
+        # LDS chunks the pool, so its sizes differ by at most one.
+        if max(abs(n - num_filtered) for n in sizes) > 1:
             raise ValueError(
-                f"{path} lists different removal sets to {dirs[0] / 'subsets.json'}; "
-                "averaging query losses over banks requires the same subsets"
-            )
-        sizes = sorted({len(x) for x in found})
-        if max(abs(n - k) for n in sizes) > 1:
-            raise ValueError(
-                f"{path} removes {sizes} docs per subset but the filter removes "
-                f"{k}; a different removal size is not a comparable baseline. Set "
-                "subset_fraction (or num_subsets, when it is 0) to match the bank."
+                f"{d} removes {sizes} docs per subset but the filter removes "
+                f"{num_filtered}; set subset_fraction to match."
             )
         for field, ours in [
             ("model", run_cfg.model),
             ("subset_weight", run_cfg.subset_weight),
             ("exclude_zero_scores", run_cfg.exclude_zero_scores),
         ]:
-            theirs = _bank_config_field(d, field)
+            theirs = get_config_field(d, field)
             if theirs is not None and theirs != ours:
                 raise ValueError(
                     f"{d} was written with {field}={theirs!r} but this run uses "
                     f"{ours!r}; the bank is not a comparable baseline"
                 )
 
-    assert subsets is not None
-    return [torch.tensor(x, dtype=torch.long) for x in subsets]
+    assert first_dir_subsets is not None
+    return [torch.tensor(x, dtype=torch.long) for x in first_dir_subsets]
 
 
 def load_bank_losses(
@@ -285,12 +261,10 @@ def load_bank_losses(
     query_losses_per_doc: Callable[[torch.nn.Module], torch.Tensor],
     write_cache: bool = True,
 ) -> tuple[float, torch.Tensor, torch.Tensor]:
-    """Query losses of every banked model, averaged over ``dirs``.
+    """Query losses of every banked model. Averaged over ``dirs``.
 
-    ``per_subset`` is ``[num_subsets, num_real_query_docs]`` for multi-query,
-    else ``[num_subsets]``. ``retrained/base`` gives the baseline; absent it
-    the baseline stays 0 (correlation-safe). The losses do not depend on the
-    scores, so each dir caches them for later methods on the same bank.
+    The baselines are 0 if ``retrained/base`` is not present - this
+    is correlation-safe. Query losses are cached under each bank.
     """
 
     def compute(models_root: Path) -> tuple[float, torch.Tensor, torch.Tensor]:
@@ -352,22 +326,7 @@ def load_bank_losses(
 def _baseline_subsets(
     run_cfg: ValidationConfig, valid_indices: torch.Tensor, k: int
 ) -> list[torch.Tensor]:
-    """Random removal sets of ``k`` documents to compare the filter against.
-
-    A ``subsets`` path pairs the baseline with an existing LDS run's draws.
-    """
-    path = run_cfg.subsets
-    if path and os.path.exists(path):
-        with open(path) as f:
-            subsets = [torch.tensor(x, dtype=torch.long) for x in json.load(f)]
-        sizes = sorted({len(x) for x in subsets})
-        if max(abs(n - k) for n in sizes) > 1:
-            raise ValueError(
-                f"{path} removes {sizes} docs per subset but the filter removes "
-                f"{k}; a different removal size is not a comparable baseline"
-            )
-        return subsets[: run_cfg.num_subsets]
-
+    """Random removal sets of ``k`` documents to compare the filter against."""
     rng = torch.Generator().manual_seed(run_cfg.seed)
     return [
         valid_indices[torch.randperm(len(valid_indices), generator=rng)[:k]]
@@ -420,7 +379,7 @@ def _select_filter_slice(
     flat_scores: torch.Tensor,
     valid_indices: torch.Tensor,
     query_col: int,
-    k: int,
+    num_filtered: int,
     method: str,
 ) -> torch.Tensor:
     """Get row indices of the documents to remove for one query.
@@ -438,11 +397,11 @@ def _select_filter_slice(
         raise ValueError(f"{method} is not a tail-filter method")
 
     col = flat_scores[valid_indices, query_col]
-    chosen = torch.topk(col, min(k, len(col)), largest=largest).indices
+    chosen = torch.topk(col, min(num_filtered, len(col)), largest=largest).indices
     return valid_indices[chosen]
 
 
-def _validate_filter(
+def tail_filter_retrain(
     run_cfg: ValidationConfig,
     flat_scores: torch.Tensor,
     multi_query: bool,
@@ -481,7 +440,7 @@ def _validate_filter(
                 "no leave-k-out chunk size for the filter to match"
             )
         run_cfg.subset_fraction = 1 / run_cfg.num_subsets
-    k = max(1, round(run_cfg.subset_fraction * pool))
+    num_filtered = max(1, round(run_cfg.subset_fraction * pool))
 
     baseline_vec = (
         baseline_per_doc[:num_queries] if multi_query else torch.tensor([baseline])
@@ -537,7 +496,9 @@ def _validate_filter(
     filter_changes = torch.zeros(num_queries)
     pbar = tqdm(range(num_queries), desc=run_cfg.method, disable=global_rank != 0)
     for q in pbar:
-        removed = _select_filter_slice(flat_scores, valid_indices, q, k, run_cfg.method)
+        removed = _select_filter_slice(
+            flat_scores, valid_indices, q, num_filtered, run_cfg.method
+        )
         losses = retrain_and_eval(removed)
 
         base_loss = baseline_vec[q].item()
@@ -556,14 +517,16 @@ def _validate_filter(
         print(
             f"{run_cfg.method}: mean loss change {filter_changes.mean():.6f} "
             f"over {num_queries} quer{'y' if num_queries == 1 else 'ies'} "
-            f"({k} of {pool} docs removed per query, {k / pool:.3%})"
+            f"({num_filtered} of {pool} docs removed per query, "
+            f"{num_filtered / pool:.3%})"
         )
         print(f"Saved tail-filter data to {csv_path}")
 
-    # A random filter ignores the scores, so one retrain serves every query.
+    # Load existing baseline if it exists - a random filter retrain.
+    # Otherwise compute the baseline.
     dirs = [Path(d) for d in retrained_dir]
     if dirs:
-        subsets = load_baseline_bank_subsets(run_cfg, dirs, k)
+        subsets = load_and_validate_subsets_match(run_cfg, dirs, num_filtered)
         bank_base, bank_base_per_doc, per_subset = load_bank_losses(
             run_cfg,
             dirs,
@@ -581,9 +544,9 @@ def _validate_filter(
         random_losses = per_subset.reshape(len(subsets), num_queries)
         source = "bank " + ", ".join(str(d) for d in dirs)
     elif run_cfg.num_subsets > 0:
-        subsets = _baseline_subsets(run_cfg, valid_indices, k)
+        subsets = _baseline_subsets(run_cfg, valid_indices, num_filtered)
         if global_rank == 0:
-            print(f"Retraining {len(subsets)} random baseline subsets of {k} docs")
+            print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
         random_baseline = baseline_vec
         random_losses = torch.stack(
             [
@@ -596,7 +559,7 @@ def _validate_filter(
         if global_rank == 0:
             print(
                 "No random baseline: set num_subsets > 0, or retrained_dir to a "
-                "bank of random-subset retrains"
+                "path to random-subset retrains"
             )
         return
 
@@ -628,7 +591,12 @@ def _validate_filter(
     random_csv.close()
 
     _report_filter_baseline(
-        run_cfg.run_path, run_cfg.method, filter_changes, random_changes, k, source
+        run_cfg.run_path,
+        run_cfg.method,
+        filter_changes,
+        random_changes,
+        num_filtered,
+        source,
     )
 
 
@@ -687,7 +655,7 @@ def validate_scores(
     flat_scores = scores.reshape(-1, num_queries)
 
     if run_cfg.method != "lds":
-        _validate_filter(
+        tail_filter_retrain(
             run_cfg,
             flat_scores,
             multi_query,

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -210,7 +210,6 @@ def report_multi_query_validation(
     print(f"Mean Spearman across {num_queries} queries: {np.mean(rhos):.4f}")
 
 
-
 def _select_filter_slice(
     flat_scores: torch.Tensor,
     valid_indices: torch.Tensor,
@@ -230,7 +229,7 @@ def _select_filter_slice(
     elif method == "filter-detractors":
         largest = True
     else:
-        raise ValueError(f"Not a tail-filter method: {method}")
+        raise ValueError(f"{method} is not a tail-filter method")
 
     col = flat_scores[valid_indices, query_col]
     chosen = torch.topk(col, min(k, len(col)), largest=largest).indices
@@ -255,12 +254,12 @@ def _validate_filter(
     pad_count: int,
     weight_pad_count: int,
 ):
-    """Retrain with documents corresponding to one end of the score ranking 
+    """Retrain with documents corresponding to one end of the score ranking
     filtered.
 
     Note that ``load_scores_loss_signed`` signs such that proponents are
     negative (reduce query loss), and that a positive ``loss_change`` means
-    the filter worsened query performance. This is the opposite sign to the 
+    the filter worsened query performance. This is the opposite sign to the
     LDS ``diff`` column.
     """
     if run_cfg.exclude_zero_scores:

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import os
 import random
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Callable
 
@@ -30,7 +31,7 @@ from transformers.utils.logging import (
 )
 
 from .config.config import ValidationConfig
-from .config.config_io import save_run_config
+from .config.config_io import read_config, save_run_config
 from .data import load_scores_loss_signed, pad_and_tensor
 from .magic.data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
 from .magic.grad_accum import loss_denom, split_batch
@@ -210,6 +211,211 @@ def report_multi_query_validation(
     print(f"Mean Spearman across {num_queries} queries: {np.mean(rhos):.4f}")
 
 
+def _bank_config_field(bank_dir: Path, field: str):
+    """Value of ``field`` in a bank's saved run config, or ``None`` if absent."""
+    try:
+        doc = read_config(bank_dir)
+    except (OSError, ValueError):
+        return None
+    for step in doc.get("steps", []):
+        for cmd in step.values():
+            if cmd and field in cmd:
+                return cmd[field]
+    return None
+
+
+def load_baseline_bank_subsets(
+    run_cfg: ValidationConfig, dirs: list[Path], k: int
+) -> list[torch.Tensor]:
+    """Load a bank's removal sets, rejecting one the filter cannot match."""
+    subsets: list[list[int]] | None = None
+    for d in dirs:
+        if not (d / "retrained" / "base").exists():
+            raise FileNotFoundError(
+                f"{d / 'retrained' / 'base'} not found; the random arm's loss "
+                "change is measured against the bank's own no-leave-out model"
+            )
+        path = d / "subsets.json"
+        if not path.exists():
+            raise FileNotFoundError(
+                f"{path} not found; retrained_dir must point at a run directory "
+                "written with save_models=true"
+            )
+        with open(path) as f:
+            found = json.load(f)
+        if subsets is None:
+            subsets = found
+        elif found != subsets:
+            raise ValueError(
+                f"{path} lists different removal sets to {dirs[0] / 'subsets.json'}; "
+                "averaging query losses over banks requires the same subsets"
+            )
+        sizes = sorted({len(x) for x in found})
+        if max(abs(n - k) for n in sizes) > 1:
+            raise ValueError(
+                f"{path} removes {sizes} docs per subset but the filter removes "
+                f"{k}; a different removal size is not a comparable baseline. Set "
+                "subset_fraction (or num_subsets, when it is 0) to match the bank."
+            )
+        for field, ours in [
+            ("model", run_cfg.model),
+            ("subset_weight", run_cfg.subset_weight),
+            ("exclude_zero_scores", run_cfg.exclude_zero_scores),
+        ]:
+            theirs = _bank_config_field(d, field)
+            if theirs is not None and theirs != ours:
+                raise ValueError(
+                    f"{d} was written with {field}={theirs!r} but this run uses "
+                    f"{ours!r}; the bank is not a comparable baseline"
+                )
+
+    assert subsets is not None
+    return [torch.tensor(x, dtype=torch.long) for x in subsets]
+
+
+def load_bank_losses(
+    run_cfg: ValidationConfig,
+    dirs: list[Path],
+    num_subsets: int,
+    *,
+    multi_query: bool,
+    num_real_query_docs: int,
+    device: torch.device | str,
+    query_loss: Callable[[torch.nn.Module], float],
+    query_losses_per_doc: Callable[[torch.nn.Module], torch.Tensor],
+    write_cache: bool = True,
+) -> tuple[float, torch.Tensor, torch.Tensor]:
+    """Query losses of every banked model, averaged over ``dirs``.
+
+    ``per_subset`` is ``[num_subsets, num_real_query_docs]`` for multi-query,
+    else ``[num_subsets]``. ``retrained/base`` gives the baseline; absent it
+    the baseline stays 0 (correlation-safe). The losses do not depend on the
+    scores, so each dir caches them for later methods on the same bank.
+    """
+
+    def compute(models_root: Path) -> tuple[float, torch.Tensor, torch.Tensor]:
+        base_dir = models_root / "base"
+        base_scalar = 0.0
+        base_per_doc = torch.zeros(num_real_query_docs)
+        if base_dir.exists():
+            base = _load_banked_model(run_cfg, str(base_dir), device)
+            if multi_query:
+                base_per_doc = query_losses_per_doc(base)
+            else:
+                base_scalar = query_loss(base)
+            del base
+
+        if multi_query:
+            per_subset = torch.zeros(num_subsets, num_real_query_docs)
+        else:
+            per_subset = torch.zeros(num_subsets)
+        for i in tqdm(range(num_subsets), desc="Evaluating bank"):
+            model = _load_banked_model(
+                run_cfg, str(models_root / f"subset_{i}"), device
+            )
+            if multi_query:
+                per_subset[i] = query_losses_per_doc(model)
+            else:
+                per_subset[i] = query_loss(model)
+            del model
+        return base_scalar, base_per_doc, per_subset
+
+    per_dir = []
+    for d in dirs:
+        cache_path = (
+            d
+            / "query_loss_cache"
+            / bank_loss_cache_key(run_cfg, multi_query, num_subsets)
+        )
+        if cache_path.exists():
+            print(f"Reusing cached bank losses from {cache_path}")
+            blob = torch.load(cache_path, map_location="cpu")
+        else:
+            base_scalar, base_per_doc, per_subset = compute(d / "retrained")
+            blob = {
+                "baseline": base_scalar,
+                "baseline_per_doc": base_per_doc,
+                "per_subset": per_subset,
+            }
+            if write_cache:
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                torch.save(blob, cache_path)
+                print(f"Saved bank losses to {cache_path}")
+        per_dir.append(blob)
+
+    baseline = float(np.mean([b["baseline"] for b in per_dir]))
+    baseline_per_doc = torch.stack([b["baseline_per_doc"] for b in per_dir]).mean(0)
+    per_subset_losses = torch.stack([b["per_subset"] for b in per_dir]).mean(0)
+    return baseline, baseline_per_doc, per_subset_losses
+
+
+def _baseline_subsets(
+    run_cfg: ValidationConfig, valid_indices: torch.Tensor, k: int
+) -> list[torch.Tensor]:
+    """Random removal sets of ``k`` documents for the filter baseline arm.
+
+    A ``subsets`` path pairs the baseline with an existing LDS run's draws.
+    """
+    path = run_cfg.subsets
+    if path and os.path.exists(path):
+        with open(path) as f:
+            subsets = [torch.tensor(x, dtype=torch.long) for x in json.load(f)]
+        sizes = sorted({len(x) for x in subsets})
+        if max(abs(n - k) for n in sizes) > 1:
+            raise ValueError(
+                f"{path} removes {sizes} docs per subset but the filter removes "
+                f"{k}; a different removal size is not a comparable baseline"
+            )
+        return subsets[: run_cfg.num_subsets]
+
+    rng = torch.Generator().manual_seed(run_cfg.seed)
+    return [
+        valid_indices[torch.randperm(len(valid_indices), generator=rng)[:k]]
+        for _ in range(run_cfg.num_subsets)
+    ]
+
+
+def _report_filter_baseline(
+    run_path: str,
+    method: str,
+    filter_changes: torch.Tensor,
+    random_changes: torch.Tensor,
+    k: int,
+    source: str,
+):
+    """Print and save the filter arm's loss change against the random arm."""
+    n, num_queries = random_changes.shape
+    print(
+        f"Random baseline ({n} subsets of {k} docs, {source}): "
+        f"mean loss change {random_changes.mean():.6f}"
+    )
+    summary_path = os.path.join(run_path, "filter_summary.csv")
+    summary = CSVWriter(
+        summary_path,
+        columns=[
+            "query",
+            "n_removed",
+            "filter_change",
+            "random_mean",
+            "random_sd",
+            "random_n",
+            "rank",
+        ],
+    )
+    for q in range(num_queries):
+        col = random_changes[:, q].numpy()
+        # Rank 1 is the largest loss increase, i.e. the most damaging removal.
+        rank = 1 + int((col > filter_changes[q].item()).sum())
+        sd = float(np.std(col, ddof=1)) if n > 1 else float("nan")
+        print(
+            f"Query {q}: {method} {filter_changes[q]:+.6f}  "
+            f"random {col.mean():+.6f} +/- {sd:.6f}  rank {rank}/{n + 1}"
+        )
+        summary.writerow(q, k, filter_changes[q].item(), float(col.mean()), sd, n, rank)
+    summary.close()
+    print(f"Saved filter/baseline comparison to {summary_path}")
+
+
 def _select_filter_slice(
     flat_scores: torch.Tensor,
     valid_indices: torch.Tensor,
@@ -252,40 +458,48 @@ def _validate_filter(
     num_queries: int,
     pad_count: int,
     weight_pad_count: int,
+    retrained_dir: Sequence[str],
 ):
-    """Retrain with documents corresponding to one end of the score ranking
-    filtered.
+    """Retrain with one tail of the score ranking filtered out.
 
-    Note that ``load_scores_loss_signed`` signs such that proponents are
-    negative (reduce query loss), and that a positive ``loss_change`` means
-    the filter worsened query performance. This is the opposite sign to the
-    LDS ``diff`` column.
+    A random arm removing the same number of documents runs alongside it,
+    retrained here or read from a bank; ``num_subsets = 0`` and no bank skips
+    it. ``load_scores_loss_signed`` signs proponents negative (they reduce
+    query loss), so a positive ``loss_change`` means the filter worsened query
+    performance -- the opposite sign to the LDS ``diff`` column.
     """
     if run_cfg.exclude_zero_scores:
         valid_indices = torch.nonzero((flat_scores != 0).any(dim=1), as_tuple=True)[0]
     else:
         valid_indices = torch.arange(flat_scores.shape[0])
 
-    # Get filtered subset size
+    pool = len(valid_indices)
     if run_cfg.subset_fraction == 0.0:
+        if run_cfg.num_subsets <= 0:
+            raise ValueError(
+                "subset_fraction must be positive when num_subsets is 0: there is "
+                "no leave-k-out chunk size for the filter to match"
+            )
         run_cfg.subset_fraction = 1 / run_cfg.num_subsets
-    k = max(1, round(run_cfg.subset_fraction * len(valid_indices)))
+    k = max(1, round(run_cfg.subset_fraction * pool))
 
-    csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
-    filter_csv = CSVWriter(
-        csv_path,
-        columns=["query", "n_removed", "baseline_loss", "filtered_loss", "loss_change"],
-        enabled=global_rank == 0,
+    baseline_vec = (
+        baseline_per_doc[:num_queries] if multi_query else torch.tensor([baseline])
     )
 
-    hf_disable_pbar()
-    hf_set_verbosity_error()
+    def eval_losses(model: torch.nn.Module) -> torch.Tensor:
+        """Query losses of an activated model, ``[num_queries]`` on the CPU."""
+        if multi_query:
+            per_doc = per_doc_query_losses(
+                model, query_stream, num_query_docs, run_cfg.grad_accum_steps
+            )
+            return per_doc[:num_queries].cpu()
 
-    changes = []
-    pbar = tqdm(range(num_queries), desc=run_cfg.method, disable=global_rank != 0)
-    for q in pbar:
-        removed = _select_filter_slice(flat_scores, valid_indices, q, k, run_cfg.method)
+        loss = mean_query_loss(model, query_stream, run_cfg.grad_accum_steps)
+        return loss.reshape(1).cpu()
 
+    def retrain_and_eval(removed: torch.Tensor) -> torch.Tensor:
+        """Query losses after retraining with ``removed`` down-weighted."""
         trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
         fwd_state.detach_()
 
@@ -307,33 +521,113 @@ def _validate_filter(
                 grad_accum_steps=run_cfg.grad_accum_steps,
             )
 
-        if multi_query:
-            with fwd_state.activate(model):
-                per_doc = per_doc_query_losses(model, query_stream, num_query_docs)
-            filtered_loss = per_doc[q].item()
-            base_loss = baseline_per_doc[q].item()
-        else:
-            with fwd_state.activate(model):
-                loss = mean_query_loss(model, query_stream, run_cfg.grad_accum_steps)
-            filtered_loss = loss.item()
-            base_loss = baseline
+        with fwd_state.activate(model):
+            return eval_losses(model)
 
-        change = filtered_loss - base_loss
-        filter_csv.writerow(q, len(removed), base_loss, filtered_loss, change)
+    hf_disable_pbar()
+    hf_set_verbosity_error()
 
+    csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
+    filter_csv = CSVWriter(
+        csv_path,
+        columns=["query", "n_removed", "baseline_loss", "filtered_loss", "loss_change"],
+        enabled=global_rank == 0,
+    )
+
+    filter_changes = torch.zeros(num_queries)
+    pbar = tqdm(range(num_queries), desc=run_cfg.method, disable=global_rank != 0)
+    for q in pbar:
+        removed = _select_filter_slice(flat_scores, valid_indices, q, k, run_cfg.method)
+        losses = retrain_and_eval(removed)
+
+        base_loss = baseline_vec[q].item()
+        filtered_loss = losses[q].item()
+        filter_changes[q] = filtered_loss - base_loss
+        filter_csv.writerow(
+            q, len(removed), base_loss, filtered_loss, filter_changes[q].item()
+        )
         if global_rank == 0:
-            changes.append(change)
-            pbar.set_postfix({"mean_loss_change": float(np.mean(changes))})
+            pbar.set_postfix(
+                {"mean_loss_change": filter_changes[: q + 1].mean().item()}
+            )
 
     filter_csv.close()
     if global_rank == 0:
         print(
-            f"{run_cfg.method}: mean loss change {float(np.mean(changes)):.6f} "
-            f"over {len(changes)} quer{'y' if len(changes) == 1 else 'ies'} "
-            f"({k} of {len(valid_indices)} docs removed per query, "
-            f"{k / len(valid_indices):.3%})"
+            f"{run_cfg.method}: mean loss change {filter_changes.mean():.6f} "
+            f"over {num_queries} quer{'y' if num_queries == 1 else 'ies'} "
+            f"({k} of {pool} docs removed per query, {k / pool:.3%})"
         )
         print(f"Saved tail-filter data to {csv_path}")
+
+    # The random arm ignores the scores, so one retrain serves every query.
+    dirs = [Path(d) for d in retrained_dir]
+    if dirs:
+        subsets = load_baseline_bank_subsets(run_cfg, dirs, k)
+        bank_base, bank_base_per_doc, per_subset = load_bank_losses(
+            run_cfg,
+            dirs,
+            len(subsets),
+            multi_query=multi_query,
+            num_real_query_docs=num_queries,
+            device=stream.weights.device,
+            query_loss=lambda m: float(eval_losses(m.eval())[0]),
+            query_losses_per_doc=lambda m: eval_losses(m.eval()),
+            write_cache=global_rank == 0,
+        )
+        arm_baseline = bank_base_per_doc if multi_query else torch.tensor([bank_base])
+        random_losses = per_subset.reshape(len(subsets), num_queries)
+        source = "bank " + ", ".join(str(d) for d in dirs)
+    elif run_cfg.num_subsets > 0:
+        subsets = _baseline_subsets(run_cfg, valid_indices, k)
+        if global_rank == 0:
+            print(f"Retraining {len(subsets)} random baseline subsets of {k} docs")
+        arm_baseline = baseline_vec
+        random_losses = torch.stack(
+            [
+                retrain_and_eval(x)
+                for x in tqdm(subsets, desc="random", disable=global_rank != 0)
+            ]
+        )
+        source = "retrained here"
+    else:
+        if global_rank == 0:
+            print(
+                "No random baseline: set num_subsets > 0, or retrained_dir to a "
+                "bank of random-subset retrains"
+            )
+        return
+
+    if global_rank != 0:
+        return
+
+    random_changes = random_losses - arm_baseline
+    random_csv = CSVWriter(
+        os.path.join(run_cfg.run_path, "random_filter.csv"),
+        columns=[
+            "subset",
+            "query",
+            "n_removed",
+            "baseline_loss",
+            "filtered_loss",
+            "loss_change",
+        ],
+    )
+    for i, subset in enumerate(subsets):
+        for q in range(num_queries):
+            random_csv.writerow(
+                i,
+                q,
+                len(subset),
+                arm_baseline[q].item(),
+                random_losses[i, q].item(),
+                random_changes[i, q].item(),
+            )
+    random_csv.close()
+
+    _report_filter_baseline(
+        run_cfg.run_path, run_cfg.method, filter_changes, random_changes, k, source
+    )
 
 
 def validate_scores(
@@ -353,6 +647,7 @@ def validate_scores(
     query_weight_pad_count: int,
     pad_count: int,
     weight_pad_count: int,
+    retrained_dir: Sequence[str] = (),
 ):
     """Validate attribution scores via leave-subset-out retraining.
 
@@ -405,6 +700,7 @@ def validate_scores(
             num_queries=num_queries,
             pad_count=pad_count,
             weight_pad_count=weight_pad_count,
+            retrained_dir=retrained_dir,
         )
         return
 
@@ -765,69 +1061,16 @@ def evaluate_retrained(
             model, query_stream, query_n, run_cfg.grad_accum_steps
         )[:num_real_query_docs].cpu()
 
-    def compute_bank_losses(
-        models_root: Path,
-    ) -> tuple[float, torch.Tensor, torch.Tensor]:
-        """Evaluate every banked model, returning baseline + per-subset losses.
-
-        ``per_subset`` is ``[num_subsets, num_real_query_docs]`` for multi-query
-        or ``[num_subsets]`` for single-query. The bank's no-leave-out model
-        (``retrained/base``) gives the baseline; absent it the baseline stays 0
-        (correlation-safe).
-        """
-        base_dir = models_root / "base"
-        base_scalar = 0.0
-        base_per_doc = torch.zeros(num_real_query_docs)
-        if base_dir.exists():
-            base = _load_banked_model(run_cfg, str(base_dir), device)
-            if multi_query:
-                base_per_doc = query_losses_per_doc(base)
-            else:
-                base_scalar = query_loss(base)
-            del base
-
-        if multi_query:
-            per_subset = torch.zeros(len(subsets), num_real_query_docs)
-        else:
-            per_subset = torch.zeros(len(subsets))
-        for i in tqdm(range(len(subsets)), desc="Evaluating bank"):
-            model = _load_banked_model(
-                run_cfg, str(models_root / f"subset_{i}"), device
-            )
-            if multi_query:
-                per_subset[i] = query_losses_per_doc(model)
-            else:
-                per_subset[i] = query_loss(model)
-            del model
-        return base_scalar, base_per_doc, per_subset
-
-    # Cache per-subset query losses for re-use with different attribution methods.
-    per_dir = []
-    for d in dirs:
-        cache_path = (
-            d
-            / "query_loss_cache"
-            / bank_loss_cache_key(run_cfg, multi_query, len(subsets))
-        )
-        if cache_path.exists():
-            print(f"Reusing cached bank losses from {cache_path}")
-            blob = torch.load(cache_path, map_location="cpu")
-        else:
-            base_scalar, base_per_doc, per_subset = compute_bank_losses(d / "retrained")
-            blob = {
-                "baseline": base_scalar,
-                "baseline_per_doc": base_per_doc,
-                "per_subset": per_subset,
-            }
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            torch.save(blob, cache_path)
-            print(f"Saved bank losses to {cache_path}")
-        per_dir.append(blob)
-
-    baseline = float(np.mean([b["baseline"] for b in per_dir]))
-    baseline_per_doc = torch.stack([b["baseline_per_doc"] for b in per_dir]).mean(0)
-    per_subset_losses = torch.stack([b["per_subset"] for b in per_dir]).mean(0)
-
+    baseline, baseline_per_doc, per_subset_losses = load_bank_losses(
+        run_cfg,
+        dirs,
+        len(subsets),
+        multi_query=multi_query,
+        num_real_query_docs=num_real_query_docs,
+        device=device,
+        query_loss=query_loss,
+        query_losses_per_doc=query_losses_per_doc,
+    )
     if multi_query:
         print(f"Baseline per-query losses (no leave-out): {baseline_per_doc.tolist()}")
     else:

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -243,7 +243,6 @@ def _validate_filter(
     *,
     global_rank: int,
     rank: int,
-    world_size: int,
     schedule: Callable,
     stream: DataStream,
     query_stream: DataStream,
@@ -314,13 +313,8 @@ def _validate_filter(
             filtered_loss = per_doc[q].item()
             base_loss = baseline_per_doc[q].item()
         else:
-            with fwd_state.activate(model), torch.no_grad():
-                loss = torch.tensor(0.0, device=stream.weights.device)
-                for batch in query_stream:
-                    del batch["example_weight"]
-                    loss += model(**batch).loss.detach() / len(query_stream)
-            if world_size > 1:
-                dist.all_reduce(loss, op=dist.ReduceOp.AVG)
+            with fwd_state.activate(model):
+                loss = mean_query_loss(model, query_stream, run_cfg.grad_accum_steps)
             filtered_loss = loss.item()
             base_loss = baseline
 
@@ -402,7 +396,6 @@ def validate_scores(
             multi_query,
             global_rank=global_rank,
             rank=rank,
-            world_size=world_size,
             schedule=schedule,
             stream=stream,
             query_stream=query_stream,

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -232,8 +232,8 @@ def load_baseline_bank_subsets(
     for d in dirs:
         if not (d / "retrained" / "base").exists():
             raise FileNotFoundError(
-                f"{d / 'retrained' / 'base'} not found; the random arm's loss "
-                "change is measured against the bank's own no-leave-out model"
+                f"{d / 'retrained' / 'base'} not found; the random filters' "
+                "loss change is measured against the bank's no-leave-out model"
             )
         path = d / "subsets.json"
         if not path.exists():
@@ -352,7 +352,7 @@ def load_bank_losses(
 def _baseline_subsets(
     run_cfg: ValidationConfig, valid_indices: torch.Tensor, k: int
 ) -> list[torch.Tensor]:
-    """Random removal sets of ``k`` documents for the filter baseline arm.
+    """Random removal sets of ``k`` documents to compare the filter against.
 
     A ``subsets`` path pairs the baseline with an existing LDS run's draws.
     """
@@ -383,7 +383,7 @@ def _report_filter_baseline(
     k: int,
     source: str,
 ):
-    """Print and save the filter arm's loss change against the random arm."""
+    """Print and save the filter's loss change against the random filters'."""
     n, num_queries = random_changes.shape
     print(
         f"Random baseline ({n} subsets of {k} docs, {source}): "
@@ -462,9 +462,9 @@ def _validate_filter(
 ):
     """Retrain with one tail of the score ranking filtered out.
 
-    A random arm removing the same number of documents runs alongside it,
+    Random filters removing the same number of documents run alongside it,
     retrained here or read from a bank; ``num_subsets = 0`` and no bank skips
-    it. ``load_scores_loss_signed`` signs proponents negative (they reduce
+    them. ``load_scores_loss_signed`` signs proponents negative (they reduce
     query loss), so a positive ``loss_change`` means the filter worsened query
     performance -- the opposite sign to the LDS ``diff`` column.
     """
@@ -560,7 +560,7 @@ def _validate_filter(
         )
         print(f"Saved tail-filter data to {csv_path}")
 
-    # The random arm ignores the scores, so one retrain serves every query.
+    # A random filter ignores the scores, so one retrain serves every query.
     dirs = [Path(d) for d in retrained_dir]
     if dirs:
         subsets = load_baseline_bank_subsets(run_cfg, dirs, k)
@@ -575,14 +575,16 @@ def _validate_filter(
             query_losses_per_doc=lambda m: eval_losses(m.eval()),
             write_cache=global_rank == 0,
         )
-        arm_baseline = bank_base_per_doc if multi_query else torch.tensor([bank_base])
+        random_baseline = (
+            bank_base_per_doc if multi_query else torch.tensor([bank_base])
+        )
         random_losses = per_subset.reshape(len(subsets), num_queries)
         source = "bank " + ", ".join(str(d) for d in dirs)
     elif run_cfg.num_subsets > 0:
         subsets = _baseline_subsets(run_cfg, valid_indices, k)
         if global_rank == 0:
             print(f"Retraining {len(subsets)} random baseline subsets of {k} docs")
-        arm_baseline = baseline_vec
+        random_baseline = baseline_vec
         random_losses = torch.stack(
             [
                 retrain_and_eval(x)
@@ -601,7 +603,7 @@ def _validate_filter(
     if global_rank != 0:
         return
 
-    random_changes = random_losses - arm_baseline
+    random_changes = random_losses - random_baseline
     random_csv = CSVWriter(
         os.path.join(run_cfg.run_path, "random_filter.csv"),
         columns=[
@@ -619,7 +621,7 @@ def _validate_filter(
                 i,
                 q,
                 len(subset),
-                arm_baseline[q].item(),
+                random_baseline[q].item(),
                 random_losses[i, q].item(),
                 random_changes[i, q].item(),
             )

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -210,6 +210,156 @@ def report_multi_query_validation(
     print(f"Mean Spearman across {num_queries} queries: {np.mean(rhos):.4f}")
 
 
+def _filter_slice_size(pool: int, fraction: float) -> int:
+    """Number of documents to remove per query for the tail-filter estimator.
+
+    A fraction rather than a count, so the perturbation stays proportional
+    across dataset sizes. Always at least one document.
+    """
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError(f"filter_fraction must be in (0, 1], got {fraction}")
+    return max(1, round(fraction * pool))
+
+
+def _select_filter_slice(
+    flat_scores: torch.Tensor,
+    valid_indices: torch.Tensor,
+    query_col: int,
+    k: int,
+    method: str,
+) -> torch.Tensor:
+    """Row indices of the slice to remove for one query.
+
+    ``load_scores_loss_signed`` signs scores so that **proponents are
+    negative** (they reduce query loss). Proponents are therefore the
+    *smallest* values and detractors the *largest* -- getting this backwards
+    silently inverts the estimator, so it is asserted by unit test.
+    """
+    if method == "filter-proponents":
+        largest = False
+    elif method == "filter-detractors":
+        largest = True
+    else:
+        raise ValueError(f"not a tail-filter method: {method}")
+
+    col = flat_scores[valid_indices, query_col]
+    chosen = torch.topk(col, min(k, len(col)), largest=largest).indices
+    return valid_indices[chosen]
+
+
+def _validate_filter(
+    run_cfg: ValidationConfig,
+    flat_scores: torch.Tensor,
+    multi_query: bool,
+    *,
+    global_rank: int,
+    rank: int,
+    world_size: int,
+    schedule: Callable,
+    stream: DataStream,
+    query_stream: DataStream,
+    baseline: float,
+    baseline_per_doc: torch.Tensor,
+    num_query_docs: int,
+    num_queries: int,
+    pad_count: int,
+    weight_pad_count: int,
+):
+    """Tail-filter estimator: retrain with one end of the score ranking removed.
+
+    For each query, the ``filter_fraction`` highest-ranked documents at the
+    selected end of that query's ranking are dropped, the model is retrained
+    once, and the query's loss change against the unablated baseline is
+    recorded. The mean over queries is the estimator's value.
+
+    Sign conventions, both easy to get backwards:
+
+    - ``load_scores_loss_signed`` signs scores so that **proponents are
+      negative** (they reduce query loss). Proponents are therefore the
+      *smallest* values and detractors the *largest*.
+    - The reported ``loss_change`` is ``filtered - baseline``, so a positive
+      value means removing the slice made the query harder. This is the
+      opposite sign to the ``diff`` column the LDS path writes.
+    """
+    if run_cfg.exclude_zero_scores:
+        valid_indices = torch.nonzero((flat_scores != 0).any(dim=1), as_tuple=True)[0]
+    else:
+        valid_indices = torch.arange(flat_scores.shape[0])
+
+    k = _filter_slice_size(len(valid_indices), run_cfg.filter_fraction)
+
+    csv_path = os.path.join(
+        run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv"
+    )
+    filter_csv = CSVWriter(
+        csv_path,
+        columns=["query", "n_removed", "baseline_loss", "filtered_loss", "loss_change"],
+        enabled=global_rank == 0,
+    )
+
+    hf_disable_pbar()
+    hf_set_verbosity_error()
+
+    changes = []
+    pbar = tqdm(range(num_queries), desc=run_cfg.method, disable=global_rank != 0)
+    for q in pbar:
+        removed = _select_filter_slice(flat_scores, valid_indices, q, k, run_cfg.method)
+
+        trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
+        fwd_state.detach_()
+
+        stream.weights.fill_(1.0)
+        if pad_count:
+            if stream.weights.ndim == 1:
+                stream.weights.data[-weight_pad_count:] = 0.0
+            else:
+                stream.weights.data[-pad_count:] = 0.0
+        stream.weights.view(-1)[removed] = run_cfg.subset_weight
+
+        for x in stream:
+            fwd_state = trainer.step(
+                fwd_state,
+                x,
+                inplace=True,
+                fsdp=run_cfg.fsdp,
+                max_grad_norm=run_cfg.max_grad_norm,
+                grad_accum_steps=run_cfg.grad_accum_steps,
+            )
+
+        if multi_query:
+            with fwd_state.activate(model):
+                per_doc = per_doc_query_losses(model, query_stream, num_query_docs)
+            filtered_loss = per_doc[q].item()
+            base_loss = baseline_per_doc[q].item()
+        else:
+            with fwd_state.activate(model), torch.no_grad():
+                loss = torch.tensor(0.0, device=stream.weights.device)
+                for batch in query_stream:
+                    del batch["example_weight"]
+                    loss += model(**batch).loss.detach() / len(query_stream)
+            if world_size > 1:
+                dist.all_reduce(loss, op=dist.ReduceOp.AVG)
+            filtered_loss = loss.item()
+            base_loss = baseline
+
+        change = filtered_loss - base_loss
+        filter_csv.writerow(q, len(removed), base_loss, filtered_loss, change)
+
+        if global_rank == 0:
+            changes.append(change)
+            pbar.set_postfix({"mean_loss_change": float(np.mean(changes))})
+
+    filter_csv.close()
+    if global_rank == 0:
+        print(
+            f"{run_cfg.method}: mean loss change {float(np.mean(changes)):.6f} "
+            f"over {len(changes)} quer{'y' if len(changes) == 1 else 'ies'} "
+            f"({k} of {len(valid_indices)} docs removed per query, "
+            f"{run_cfg.filter_fraction:.3%})"
+        )
+        print(f"Saved tail-filter data to {csv_path}")
+
+
 def validate_scores(
     run_cfg: ValidationConfig,
     scores: torch.Tensor,
@@ -262,6 +412,26 @@ def validate_scores(
     # doc * seq_len + token positions for per-token scores.
     num_queries = scores.shape[-1] if multi_query else 1
     flat_scores = scores.reshape(-1, num_queries)
+
+    if run_cfg.method != "lds":
+        _validate_filter(
+            run_cfg,
+            flat_scores,
+            multi_query,
+            global_rank=global_rank,
+            rank=rank,
+            world_size=world_size,
+            schedule=schedule,
+            stream=stream,
+            query_stream=query_stream,
+            baseline=baseline,
+            baseline_per_doc=baseline_per_doc,
+            num_query_docs=num_query_docs,
+            num_queries=num_queries,
+            pad_count=pad_count,
+            weight_pad_count=weight_pad_count,
+        )
+        return
 
     if run_cfg.weight_lrs:
         # Gradient step on the data weights: retrain with w = 1 - lr * score

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -288,9 +288,7 @@ def _validate_filter(
 
     k = _filter_slice_size(len(valid_indices), run_cfg.filter_fraction)
 
-    csv_path = os.path.join(
-        run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv"
-    )
+    csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
     filter_csv = CSVWriter(
         csv_path,
         columns=["query", "n_removed", "baseline_loss", "filtered_loss", "loss_change"],

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -210,20 +210,6 @@ def report_multi_query_validation(
     print(f"Mean Spearman across {num_queries} queries: {np.mean(rhos):.4f}")
 
 
-def _filter_slice_size(pool: int, fraction: float, num_subsets: int) -> int:
-    """Number of documents to remove per query for the tail-filter estimator.
-
-    A fraction rather than a count, so the perturbation stays proportional
-    across dataset sizes. Always at least one document. ``subset_fraction``
-    of 0.0 means the LDS path chunks the pool into ``num_subsets``
-    non-overlapping subsets, so the matching removal is ``1 / num_subsets``.
-    """
-    if fraction == 0.0:
-        fraction = 1 / num_subsets
-    if not 0.0 < fraction <= 1.0:
-        raise ValueError(f"subset_fraction must be in [0, 1], got {fraction}")
-    return max(1, round(fraction * pool))
-
 
 def _select_filter_slice(
     flat_scores: torch.Tensor,
@@ -232,7 +218,7 @@ def _select_filter_slice(
     k: int,
     method: str,
 ) -> torch.Tensor:
-    """Row indices of the slice to remove for one query.
+    """Get row indices of the documents to remove for one query.
 
     ``load_scores_loss_signed`` signs scores so that **proponents are
     negative** (they reduce query loss). Proponents are therefore the
@@ -244,7 +230,7 @@ def _select_filter_slice(
     elif method == "filter-detractors":
         largest = True
     else:
-        raise ValueError(f"not a tail-filter method: {method}")
+        raise ValueError(f"Not a tail-filter method: {method}")
 
     col = flat_scores[valid_indices, query_col]
     chosen = torch.topk(col, min(k, len(col)), largest=largest).indices
@@ -269,30 +255,23 @@ def _validate_filter(
     pad_count: int,
     weight_pad_count: int,
 ):
-    """Tail-filter estimator: retrain with one end of the score ranking removed.
+    """Retrain with documents corresponding to one end of the score ranking 
+    filtered.
 
-    For each query, the ``subset_fraction`` highest-ranked documents at the
-    selected end of that query's ranking are dropped, the model is retrained
-    once, and the query's loss change against the unablated baseline is
-    recorded. The mean over queries is the estimator's value.
-
-    Sign conventions, both easy to get backwards:
-
-    - ``load_scores_loss_signed`` signs scores so that **proponents are
-      negative** (they reduce query loss). Proponents are therefore the
-      *smallest* values and detractors the *largest*.
-    - The reported ``loss_change`` is ``filtered - baseline``, so a positive
-      value means removing the slice made the query harder. This is the
-      opposite sign to the ``diff`` column the LDS path writes.
+    Note that ``load_scores_loss_signed`` signs such that proponents are
+    negative (reduce query loss), and that a positive ``loss_change`` means
+    the filter worsened query performance. This is the opposite sign to the 
+    LDS ``diff`` column.
     """
     if run_cfg.exclude_zero_scores:
         valid_indices = torch.nonzero((flat_scores != 0).any(dim=1), as_tuple=True)[0]
     else:
         valid_indices = torch.arange(flat_scores.shape[0])
 
-    k = _filter_slice_size(
-        len(valid_indices), run_cfg.subset_fraction, run_cfg.num_subsets
-    )
+    # Get filtered subset size
+    if run_cfg.subset_fraction == 0.0:
+        run_cfg.subset_fraction = 1 / run_cfg.num_subsets
+    k = max(1, round(run_cfg.subset_fraction * len(valid_indices)))
 
     csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
     filter_csv = CSVWriter(

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -1,0 +1,72 @@
+import pytest
+import torch
+
+from bergson.validate import _filter_slice_size, _select_filter_slice
+
+# Scores follow the load_scores_loss_signed convention: negative reduces query
+# loss, so doc 0 is the strongest proponent and doc 4 the strongest detractor.
+SCORES = torch.tensor([[-5.0], [-2.0], [0.0], [1.0], [7.0]])
+ALL = torch.arange(5)
+
+
+def test_proponents_are_the_most_negative_scores():
+    """Proponents reduce query loss, so they are the smallest signed scores."""
+    got = _select_filter_slice(SCORES, ALL, 0, 2, "filter-proponents")
+    assert sorted(got.tolist()) == [0, 1]
+
+
+def test_detractors_are_the_most_positive_scores():
+    got = _select_filter_slice(SCORES, ALL, 0, 2, "filter-detractors")
+    assert sorted(got.tolist()) == [3, 4]
+
+
+def test_the_two_ends_are_disjoint():
+    """A sanity check that the two methods do not select the same slice."""
+    pro = set(_select_filter_slice(SCORES, ALL, 0, 2, "filter-proponents").tolist())
+    det = set(_select_filter_slice(SCORES, ALL, 0, 2, "filter-detractors").tolist())
+    assert pro.isdisjoint(det)
+
+
+def test_selection_respects_valid_indices():
+    """Excluded rows are never selected, and returned ids index the full pool."""
+    valid = torch.tensor([1, 2, 3, 4])  # doc 0, the top proponent, is excluded
+    got = _select_filter_slice(SCORES, valid, 0, 2, "filter-proponents")
+    assert sorted(got.tolist()) == [1, 2]
+
+
+def test_per_query_columns_are_ranked_independently():
+    scores = torch.tensor([[-1.0, 4.0], [4.0, -1.0]])
+    idx = torch.arange(2)
+    assert _select_filter_slice(scores, idx, 0, 1, "filter-proponents").tolist() == [0]
+    assert _select_filter_slice(scores, idx, 1, 1, "filter-proponents").tolist() == [1]
+
+
+def test_unknown_method_rejected():
+    with pytest.raises(ValueError, match="not a tail-filter method"):
+        _select_filter_slice(SCORES, ALL, 0, 1, "lds")
+
+
+@pytest.mark.parametrize(
+    "pool,fraction,expected",
+    [
+        (1000, 0.01, 10),
+        (16000, 0.01, 160),
+        (4000, 0.01, 40),
+        (50, 0.01, 1),  # rounds to 0, floored to 1
+        (100, 1.0, 100),
+    ],
+)
+def test_slice_size_is_a_fraction_of_the_pool(pool, fraction, expected):
+    assert _filter_slice_size(pool, fraction) == expected
+
+
+@pytest.mark.parametrize("fraction", [0.0, -0.1, 1.5])
+def test_slice_size_rejects_out_of_range_fractions(fraction):
+    with pytest.raises(ValueError, match="filter_fraction must be in"):
+        _filter_slice_size(100, fraction)
+
+
+def test_slice_size_clamped_to_pool():
+    """k larger than the pool must not error or over-select."""
+    got = _select_filter_slice(SCORES, ALL, 0, 99, "filter-proponents")
+    assert len(got) == 5

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -57,13 +57,20 @@ def test_unknown_method_rejected():
     ],
 )
 def test_slice_size_is_a_fraction_of_the_pool(pool, fraction, expected):
-    assert _filter_slice_size(pool, fraction) == expected
+    assert _filter_slice_size(pool, fraction, 100) == expected
 
 
-@pytest.mark.parametrize("fraction", [0.0, -0.1, 1.5])
+@pytest.mark.parametrize("num_subsets,expected", [(100, 10), (10, 100), (4, 250)])
+def test_zero_fraction_matches_a_leave_k_out_chunk(num_subsets, expected):
+    """subset_fraction 0.0 means the LDS path chunks the pool, so the matched
+    removal is one chunk."""
+    assert _filter_slice_size(1000, 0.0, num_subsets) == expected
+
+
+@pytest.mark.parametrize("fraction", [-0.1, 1.5])
 def test_slice_size_rejects_out_of_range_fractions(fraction):
-    with pytest.raises(ValueError, match="filter_fraction must be in"):
-        _filter_slice_size(100, fraction)
+    with pytest.raises(ValueError, match="subset_fraction must be in"):
+        _filter_slice_size(100, fraction, 100)
 
 
 def test_slice_size_clamped_to_pool():

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from bergson.validate import _filter_slice_size, _select_filter_slice
+from bergson.validate import _select_filter_slice
 
 # Scores follow the load_scores_loss_signed convention: negative reduces query
 # loss, so doc 0 is the strongest proponent and doc 4 the strongest detractor.
@@ -44,33 +44,6 @@ def test_per_query_columns_are_ranked_independently():
 def test_unknown_method_rejected():
     with pytest.raises(ValueError, match="not a tail-filter method"):
         _select_filter_slice(SCORES, ALL, 0, 1, "lds")
-
-
-@pytest.mark.parametrize(
-    "pool,fraction,expected",
-    [
-        (1000, 0.01, 10),
-        (16000, 0.01, 160),
-        (4000, 0.01, 40),
-        (50, 0.01, 1),  # rounds to 0, floored to 1
-        (100, 1.0, 100),
-    ],
-)
-def test_slice_size_is_a_fraction_of_the_pool(pool, fraction, expected):
-    assert _filter_slice_size(pool, fraction, 100) == expected
-
-
-@pytest.mark.parametrize("num_subsets,expected", [(100, 10), (10, 100), (4, 250)])
-def test_zero_fraction_matches_a_leave_k_out_chunk(num_subsets, expected):
-    """subset_fraction 0.0 means the LDS path chunks the pool, so the matched
-    removal is one chunk."""
-    assert _filter_slice_size(1000, 0.0, num_subsets) == expected
-
-
-@pytest.mark.parametrize("fraction", [-0.1, 1.5])
-def test_slice_size_rejects_out_of_range_fractions(fraction):
-    with pytest.raises(ValueError, match="subset_fraction must be in"):
-        _filter_slice_size(100, fraction, 100)
 
 
 def test_slice_size_clamped_to_pool():

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -1,7 +1,15 @@
+import csv
+import json
+
 import pytest
 import torch
 
-from bergson.validate import _select_filter_slice
+from bergson.validate import (
+    _baseline_subsets,
+    _report_filter_baseline,
+    _select_filter_slice,
+    load_baseline_bank_subsets,
+)
 
 # Scores follow the load_scores_loss_signed convention: negative reduces query
 # loss, so doc 0 is the strongest proponent and doc 4 the strongest detractor.
@@ -50,3 +58,181 @@ def test_slice_size_clamped_to_pool():
     """k larger than the pool must not error or over-select."""
     got = _select_filter_slice(SCORES, ALL, 0, 99, "filter-proponents")
     assert len(got) == 5
+
+
+def _cfg(tmp_path, **kwargs):
+    from bergson.magic.config import MagicConfig
+
+    return MagicConfig(run_path=str(tmp_path / "run"), model="gpt2", **kwargs)
+
+
+def _bank(tmp_path, subsets, name="bank", base=True, **cfg_overrides):
+    """A bank directory holding only what the baseline checks read."""
+    from bergson.config.config_io import save_run_config
+
+    root = tmp_path / name
+    if base:
+        (root / "retrained" / "base").mkdir(parents=True)
+    root.mkdir(parents=True, exist_ok=True)
+    with open(root / "subsets.json", "w") as f:
+        json.dump(subsets, f)
+    save_run_config(_cfg(tmp_path, **cfg_overrides), root)
+    return root
+
+
+def test_baseline_subsets_are_random_removals_of_the_filtered_size(tmp_path):
+    cfg = _cfg(tmp_path, num_subsets=4, seed=0)
+    subsets = _baseline_subsets(cfg, torch.arange(50), k=7)
+    assert [len(s) for s in subsets] == [7, 7, 7, 7]
+    assert all(len(set(s.tolist())) == 7 for s in subsets)  # no repeats within
+    assert len({tuple(sorted(s.tolist())) for s in subsets}) > 1  # not identical
+
+
+def test_baseline_subsets_reuse_a_saved_draw(tmp_path):
+    """An LDS run's subsets.json pairs the baseline with its draws."""
+    path = tmp_path / "subsets.json"
+    with open(path, "w") as f:
+        json.dump([[0, 1], [2, 3], [4, 5]], f)
+
+    cfg = _cfg(tmp_path, num_subsets=2, subsets=str(path))
+    subsets = _baseline_subsets(cfg, torch.arange(6), k=2)
+    assert [s.tolist() for s in subsets] == [[0, 1], [2, 3]]  # truncated to 2
+
+
+def test_baseline_subsets_reject_a_mismatched_saved_draw(tmp_path):
+    path = tmp_path / "subsets.json"
+    with open(path, "w") as f:
+        json.dump([[0, 1], [2, 3]], f)
+
+    cfg = _cfg(tmp_path, num_subsets=2, subsets=str(path))
+    with pytest.raises(ValueError, match="not a comparable baseline"):
+        _baseline_subsets(cfg, torch.arange(6), k=5)
+
+
+def test_bank_of_the_same_removal_size_is_accepted(tmp_path):
+    """The LDS default partitions the pool, so chunk sizes differ by one."""
+    root = _bank(tmp_path, [[0, 1, 2], [3, 4], [5, 6]])
+    subsets = load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+    assert [s.tolist() for s in subsets] == [[0, 1, 2], [3, 4], [5, 6]]
+
+
+def test_bank_of_a_different_removal_size_is_rejected(tmp_path):
+    root = _bank(tmp_path, [[0, 1], [2, 3]])
+    with pytest.raises(ValueError, match="not a comparable baseline"):
+        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=10)
+
+
+def test_bank_without_a_base_model_is_rejected(tmp_path):
+    """Loss changes are measured against the bank's own no-leave-out model."""
+    root = _bank(tmp_path, [[0, 1]], base=False)
+    with pytest.raises(FileNotFoundError, match="retrained/base"):
+        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+
+
+@pytest.mark.parametrize(
+    "field,value", [("subset_weight", 0.5), ("exclude_zero_scores", True)]
+)
+def test_bank_trained_with_different_settings_is_rejected(tmp_path, field, value):
+    root = _bank(tmp_path, [[0, 1]], **{field: value})
+    with pytest.raises(ValueError, match=field):
+        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+
+
+def test_averaged_banks_must_share_their_removal_sets(tmp_path):
+    a = _bank(tmp_path, [[0, 1]], name="a")
+    b = _bank(tmp_path, [[2, 3]], name="b")
+    with pytest.raises(ValueError, match="different removal sets"):
+        load_baseline_bank_subsets(_cfg(tmp_path), [a, b], k=2)
+
+
+def test_filter_is_ranked_against_the_random_draws(tmp_path):
+    """Rank 1 is the largest loss increase; the filter beats 2 of 3 draws."""
+    _report_filter_baseline(
+        str(tmp_path),
+        "filter-proponents",
+        torch.tensor([0.5]),
+        torch.tensor([[0.1], [0.2], [0.9]]),
+        k=2,
+        source="retrained here",
+    )
+    with open(tmp_path / "filter_summary.csv") as f:
+        row = list(csv.DictReader(f))[0]
+    assert int(row["rank"]) == 2
+    assert int(row["random_n"]) == 3
+    assert float(row["filter_change"]) == pytest.approx(0.5)
+    assert float(row["random_mean"]) == pytest.approx(0.4)
+
+
+def _e2e_shared(tmp_path) -> dict:
+    from datasets import Dataset
+
+    train = Dataset.from_dict({"text": [f"the cat sat on mat {i}" for i in range(8)]})
+    train.save_to_disk(tmp_path / "train")
+    query = Dataset.from_dict({"text": ["a dog ran", "birds fly high"]})
+    query.save_to_disk(tmp_path / "query")
+    return {
+        "model": "trl-internal-testing/tiny-Phi3ForCausalLM",
+        "batch_size": 2,
+        "num_epochs": 1,
+        "num_subsets": 2,
+        "subset_fraction": 0.25,
+        "data": {"dataset": str(tmp_path / "train")},
+        "query": {"dataset": str(tmp_path / "query")},
+        "distributed": {"nproc_per_node": 1},
+    }
+
+
+def test_a_filter_run_compares_against_random_filters(tmp_path):
+    from bergson.cli.commands import Magic, Validate
+
+    shared = _e2e_shared(tmp_path)
+    Magic.from_dict(shared | {"run_path": str(tmp_path / "magic")}).execute()
+    run = tmp_path / "filter"
+    Validate.from_dict(
+        shared
+        | {
+            "run_path": str(run),
+            "scores": str(tmp_path / "magic" / "scores"),
+            "method": "filter-proponents",
+        }
+    ).execute()
+
+    with open(run / "random_filter.csv") as f:
+        random_rows = list(csv.DictReader(f))
+    assert {r["subset"] for r in random_rows} == {"0", "1"}
+    with open(run / "filter_summary.csv") as f:
+        summary = list(csv.DictReader(f))
+    assert [r["query"] for r in summary] == ["0", "1"]
+    assert all(1 <= int(r["rank"]) <= 3 for r in summary)
+
+
+def test_a_bank_gives_the_same_random_arm_as_retraining_it(tmp_path):
+    """The bank's models are the retrains, so both arms must agree."""
+    from bergson.cli.commands import Magic, Validate
+
+    shared = _e2e_shared(tmp_path)
+    Magic.from_dict(shared | {"run_path": str(tmp_path / "magic")}).execute()
+    scores = str(tmp_path / "magic" / "scores")
+
+    bank = tmp_path / "bank"
+    Validate.from_dict(
+        shared | {"run_path": str(bank), "scores": scores, "save_models": True}
+    ).execute()
+
+    def random_changes(name, **overrides) -> list[str]:
+        Validate.from_dict(
+            shared
+            | {
+                "run_path": str(tmp_path / name),
+                "scores": scores,
+                "method": "filter-proponents",
+                "subsets": str(bank / "subsets.json"),
+            }
+            | overrides
+        ).execute()
+        with open(tmp_path / name / "random_filter.csv") as f:
+            return [r["loss_change"] for r in csv.DictReader(f)]
+
+    here = random_changes("here")
+    from_bank = random_changes("from_bank", retrained_dir=str(bank))
+    assert [round(float(x), 5) for x in from_bank] == [round(float(x), 5) for x in here]

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -206,8 +206,8 @@ def test_a_filter_run_compares_against_random_filters(tmp_path):
     assert all(1 <= int(r["rank"]) <= 3 for r in summary)
 
 
-def test_a_bank_gives_the_same_random_arm_as_retraining_it(tmp_path):
-    """The bank's models are the retrains, so both arms must agree."""
+def test_a_bank_gives_the_same_random_filters_as_retraining_them(tmp_path):
+    """The bank's models are those retrains, so the two must agree."""
     from bergson.cli.commands import Magic, Validate
 
     shared = _e2e_shared(tmp_path)

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -5,10 +5,9 @@ import pytest
 import torch
 
 from bergson.validate import (
-    _baseline_subsets,
     _report_filter_baseline,
     _select_filter_slice,
-    load_baseline_bank_subsets,
+    load_and_validate_subsets_match,
 )
 
 # Scores follow the load_scores_loss_signed convention: negative reduces query
@@ -80,53 +79,24 @@ def _bank(tmp_path, subsets, name="bank", base=True, **cfg_overrides):
     return root
 
 
-def test_baseline_subsets_are_random_removals_of_the_filtered_size(tmp_path):
-    cfg = _cfg(tmp_path, num_subsets=4, seed=0)
-    subsets = _baseline_subsets(cfg, torch.arange(50), k=7)
-    assert [len(s) for s in subsets] == [7, 7, 7, 7]
-    assert all(len(set(s.tolist())) == 7 for s in subsets)  # no repeats within
-    assert len({tuple(sorted(s.tolist())) for s in subsets}) > 1  # not identical
-
-
-def test_baseline_subsets_reuse_a_saved_draw(tmp_path):
-    """An LDS run's subsets.json pairs the baseline with its draws."""
-    path = tmp_path / "subsets.json"
-    with open(path, "w") as f:
-        json.dump([[0, 1], [2, 3], [4, 5]], f)
-
-    cfg = _cfg(tmp_path, num_subsets=2, subsets=str(path))
-    subsets = _baseline_subsets(cfg, torch.arange(6), k=2)
-    assert [s.tolist() for s in subsets] == [[0, 1], [2, 3]]  # truncated to 2
-
-
-def test_baseline_subsets_reject_a_mismatched_saved_draw(tmp_path):
-    path = tmp_path / "subsets.json"
-    with open(path, "w") as f:
-        json.dump([[0, 1], [2, 3]], f)
-
-    cfg = _cfg(tmp_path, num_subsets=2, subsets=str(path))
-    with pytest.raises(ValueError, match="not a comparable baseline"):
-        _baseline_subsets(cfg, torch.arange(6), k=5)
-
-
 def test_bank_of_the_same_removal_size_is_accepted(tmp_path):
     """The LDS default partitions the pool, so chunk sizes differ by one."""
     root = _bank(tmp_path, [[0, 1, 2], [3, 4], [5, 6]])
-    subsets = load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+    subsets = load_and_validate_subsets_match(_cfg(tmp_path), [root], num_filtered=2)
     assert [s.tolist() for s in subsets] == [[0, 1, 2], [3, 4], [5, 6]]
 
 
 def test_bank_of_a_different_removal_size_is_rejected(tmp_path):
     root = _bank(tmp_path, [[0, 1], [2, 3]])
-    with pytest.raises(ValueError, match="not a comparable baseline"):
-        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=10)
+    with pytest.raises(ValueError, match="set subset_fraction to match"):
+        load_and_validate_subsets_match(_cfg(tmp_path), [root], num_filtered=10)
 
 
 def test_bank_without_a_base_model_is_rejected(tmp_path):
     """Loss changes are measured against the bank's own no-leave-out model."""
     root = _bank(tmp_path, [[0, 1]], base=False)
-    with pytest.raises(FileNotFoundError, match="retrained/base"):
-        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+    with pytest.raises(AssertionError, match="not valid"):
+        load_and_validate_subsets_match(_cfg(tmp_path), [root], num_filtered=2)
 
 
 @pytest.mark.parametrize(
@@ -135,14 +105,14 @@ def test_bank_without_a_base_model_is_rejected(tmp_path):
 def test_bank_trained_with_different_settings_is_rejected(tmp_path, field, value):
     root = _bank(tmp_path, [[0, 1]], **{field: value})
     with pytest.raises(ValueError, match=field):
-        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+        load_and_validate_subsets_match(_cfg(tmp_path), [root], num_filtered=2)
 
 
 def test_averaged_banks_must_share_their_removal_sets(tmp_path):
     a = _bank(tmp_path, [[0, 1]], name="a")
     b = _bank(tmp_path, [[2, 3]], name="b")
-    with pytest.raises(ValueError, match="different removal sets"):
-        load_baseline_bank_subsets(_cfg(tmp_path), [a, b], k=2)
+    with pytest.raises(AssertionError, match="doesn't match others"):
+        load_and_validate_subsets_match(_cfg(tmp_path), [a, b], num_filtered=2)
 
 
 def test_filter_is_ranked_against_the_random_draws(tmp_path):

--- a/tests/test_validate_routing.py
+++ b/tests/test_validate_routing.py
@@ -1,44 +1,85 @@
 """Which phases of ``run_magic`` -- train, score, validate -- a command runs."""
 
+import csv
+
 import pytest
+from datasets import Dataset
 
 from bergson.cli.commands import Magic, Validate
+from bergson.config.config_io import read_config
 from bergson.magic.cli import run_magic
 
+MODEL = "trl-internal-testing/tiny-Phi3ForCausalLM"
 
-def _calls(monkeypatch) -> list[dict]:
-    calls = []
-    monkeypatch.setattr(
-        "bergson.cli.commands.run_magic", lambda cfg, **kw: calls.append(kw)
+
+def _datasets(tmp_path) -> dict:
+    train = Dataset.from_dict({"text": [f"the cat sat on mat {i}" for i in range(8)]})
+    train.save_to_disk(tmp_path / "train")
+    query = Dataset.from_dict({"text": ["a dog ran", "birds fly high"]})
+    query.save_to_disk(tmp_path / "query")
+    return {
+        "model": MODEL,
+        "batch_size": 2,
+        "num_epochs": 1,
+        "num_subsets": 2,
+        "data": {"dataset": str(tmp_path / "train")},
+        "query": {"dataset": str(tmp_path / "query")},
+        "distributed": {"nproc_per_node": 1},
+    }
+
+
+def test_magic_scores_and_stops(tmp_path):
+    run = tmp_path / "run"
+    Magic.from_dict(_datasets(tmp_path) | {"run_path": str(run)}).execute()
+
+    assert (run / "scores").exists()
+    assert not (run / "validation.csv").exists()
+    assert not (run / "subsets.json").exists()
+
+
+def test_magic_validates_the_scores_it_wrote(tmp_path):
+    run = tmp_path / "run"
+    Magic.from_dict(
+        _datasets(tmp_path)
+        | {"run_path": str(run), "skip_validation": False, "save_models": True}
+    ).execute()
+
+    with open(run / "validation.csv") as f:
+        subsets = {row["subset"] for row in csv.DictReader(f)}
+    assert subsets == {"0", "1"}
+    assert sorted(p.name for p in (run / "retrained").iterdir()) == [
+        "base",
+        "subset_0",
+        "subset_1",
+    ]
+
+    # The validation step saves its own config over the run's.
+    (step,) = read_config(run)["steps"]
+    assert set(step) == {"magic"}
+
+
+def test_a_baseline_model_gives_the_same_baseline_as_training_one(tmp_path):
+    shared = _datasets(tmp_path)
+    magic_run = tmp_path / "magic"
+    Magic.from_dict(
+        shared | {"run_path": str(magic_run), "save_models": True}
+    ).execute()
+
+    def baselines(name, **overrides) -> list[str]:
+        Validate.from_dict(
+            shared
+            | {"run_path": str(tmp_path / name), "scores": str(magic_run / "scores")}
+            | overrides
+        ).execute()
+        with open(tmp_path / name / "summary.csv") as f:
+            return [row["baseline_loss"] for row in csv.DictReader(f)]
+
+    trained_here = baselines("trained_here")
+    from_model = baselines(
+        "from_model", baseline_model=str(magic_run / "retrained" / "base")
     )
-    return calls
-
-
-def test_magic_scores_and_stops(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Magic.from_dict({"run_path": str(tmp_path), "model": "gpt2"}).execute()
-    assert calls == [{}]
-
-
-def test_validate_runs_the_validation_phase(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Validate.from_dict(
-        {"run_path": str(tmp_path), "model": "gpt2", "scores": "s"}
-    ).execute()
-    assert calls == [{"score_path": "s", "validate": True, "baseline_model": ""}]
-
-
-def test_validate_passes_the_trained_model_through(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Validate.from_dict(
-        {
-            "run_path": str(tmp_path),
-            "model": "gpt2",
-            "scores": "s",
-            "baseline_model": "runs/magic/model",
-        }
-    ).execute()
-    assert calls[0]["baseline_model"] == "runs/magic/model"
+    assert from_model == trained_here
+    assert not (tmp_path / "from_model" / "checkpoints").exists()
 
 
 def test_validate_reads_a_bank_without_training(tmp_path, monkeypatch):
@@ -53,74 +94,9 @@ def test_validate_reads_a_bank_without_training(tmp_path, monkeypatch):
     assert seen["dirs"] == ["a", "b"]
 
 
-def test_magic_dispatches_a_validation_of_its_own_scores(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Magic.from_dict(
-        {"run_path": str(tmp_path), "model": "gpt2", "skip_validation": False}
-    ).execute()
-    assert calls == [
-        {},
-        {
-            "score_path": str(tmp_path / "scores"),
-            "validate": True,
-            "baseline_model": "",
-        },
-    ]
-
-
-def test_a_chained_validation_reuses_the_trained_model(tmp_path, monkeypatch):
-    (tmp_path / "retrained" / "base").mkdir(parents=True)
-    calls = _calls(monkeypatch)
-    Magic.from_dict(
-        {"run_path": str(tmp_path), "model": "gpt2", "skip_validation": False}
-    ).execute()
-    assert calls[1]["baseline_model"] == str(tmp_path / "retrained" / "base")
-
-
-def test_a_chained_validation_keeps_the_training_config(tmp_path, monkeypatch):
-    """Both phases must train the same model for the baseline to transfer."""
-    seen = []
-    monkeypatch.setattr(
-        "bergson.cli.commands.run_magic", lambda cfg, **kw: seen.append(cfg)
-    )
-    Magic.from_dict(
-        {
-            "run_path": str(tmp_path),
-            "model": "gpt2",
-            "skip_validation": False,
-            "num_subsets": 7,
-            "num_epochs": 3,
-            "seed": 11,
-        }
-    ).execute()
-    magic_cfg, validate_cfg = seen
-    assert validate_cfg.num_subsets == 7
-    assert (validate_cfg.num_epochs, validate_cfg.seed) == (
-        magic_cfg.num_epochs,
-        magic_cfg.seed,
-    )
-
-
-def test_a_chained_validation_does_not_wipe_the_scores(tmp_path, monkeypatch):
-    """resume keeps run_magic's overwrite guard off the magic step's output."""
-    calls = []
-    monkeypatch.setattr(
-        "bergson.cli.commands.run_magic", lambda cfg, **kw: calls.append(cfg)
-    )
-    Magic.from_dict(
-        {
-            "run_path": str(tmp_path),
-            "model": "gpt2",
-            "skip_validation": False,
-            "overwrite": True,
-        }
-    ).execute()
-    assert calls[1].resume is True
-
-
 def test_validation_needs_a_validation_config(tmp_path):
     from bergson.config.config import TrainingConfig
 
-    cfg = TrainingConfig(run_path=str(tmp_path), model="gpt2")
+    cfg = TrainingConfig(run_path=str(tmp_path), model=MODEL)
     with pytest.raises(TypeError, match="ValidationConfig"):
         run_magic(cfg, validate=True)


### PR DESCRIPTION
`bergson validate --method filter-proponents` retrains with the top-scoring
`subset_fraction` of documents removed for each query, and measures the query
loss change; `filter-detractors` removes the other tail. Unlike LDS this asks
what the scores are usually *for* — drop the documents an attribution method
blames, and see whether the model gets worse.

`load_scores_loss_signed` signs proponents negative, so they are the smallest
values; getting that backwards silently inverts the estimator, and a unit test
pins it. A positive `loss_change` means the filter hurt, which is the opposite
sign to the LDS `diff` column.

### Compared against random filters of the same size

A filter loss change means nothing on its own: removing any 1% of the training
data moves the query loss. So the filter runs alongside `num_subsets` random
removals of the same size, and reports its rank among them per query:

```
filter-proponents: mean loss change 0.001111 over 3 queries (10 of 200 docs removed per query, 5.000%)
Random baseline (4 subsets of 10 docs, retrained here): mean loss change 0.003895
Query 0: filter-proponents -0.010040  random -0.000756 +/- 0.014530  rank 4/5
Query 1: filter-proponents +0.002502  random +0.004464 +/- 0.015796  rank 4/5
Query 2: filter-proponents +0.010871  random +0.007976 +/- 0.013704  rank 4/5
```

Rank 1 is the largest loss increase. With four or five draws a rank is what the
sample supports; the mean and sd are reported too, but no p-value is claimed.
`random_filter.csv` holds the per-draw losses, `filter_summary.csv` the
comparison, and `filter_proponents.csv` the filter itself.

### Reusing a bank instead of retraining them

A random filter ignores the scores, so one retrain serves every query — and an
LDS bank already holds exactly those retrains. `retrained_dir` therefore
supplies them for a `filter-*` run, where it previously shortcut `lds` alone.
No new flag: the same "read it from the bank" idiom, applied to the half of the
comparison a bank can serve. The score-based filter always retrains.
`num_subsets: 0` with no bank skips the comparison.

A bank drawn at a different removal size, `subset_weight` or
`exclude_zero_scores` pool is not a comparable baseline, so a mismatch raises
rather than reporting an apples-to-oranges number. With `subset_fraction: 0`
the filter removes `1/num_subsets` of the pool — the LDS chunk size — so a
default bank lines up as it is. `subsets:` reuses an LDS run's draws when its
models were not saved.

The bank's per-subset query losses come from the same cache
`evaluate_retrained` fills, lifted out as `load_bank_losses` so both callers
share it.

### Testing

Unit tests for the tail selection, the random draws, the bank rejections and
the ranking; two end-to-end runs on a tiny model, one asserting the outputs
and one asserting that reading the random filters from a bank reproduces
retraining the same subsets locally. On a 200-doc gpt2 run the two agree to
1e-6.

Rebased onto main after #435. Two things that fell out of that rebase are
included: the tests for a `_filter_slice_size` helper that had been inlined
(they failed to collect, taking the module with them), and the tail-filter
query loss, which still called `dist.all_reduce` with the `world_size` that
#429 removed from `validate_scores` — a `NameError` on any single-query filter
run, now routed through `mean_query_loss` like every other call site.
`tests/test_validate_routing.py` also picks up a behaviour-based rewrite that
missed the #435 merge: those tests asserted the kwargs `Validate` passes to
`run_magic`, which broke on the new argument and asserted nothing about what
the commands do.
