### PR TITLE
Reduce aggregate query evaluation over tokens, not over batches

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -48,7 +48,7 @@ from ..utils.worker_utils import setup_data_pipeline
 from ..validate import validate_scores
 from .config import MagicConfig
 from .data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
-from .grad_accum import accumulate_grads
+from .grad_accum import accumulate_grads, loss_denom
 from .trainer import BackwardState, TrainerState, prepare_trainer, write_lr_history
 
 
@@ -67,32 +67,39 @@ def compute_query_gradients(
     """
     grad_accum: dict[str, torch.Tensor] | None = None
     loss_accum = 0.0
-    denom = 0
+    denom = 0.0
 
     main = not dist.is_initialized() or dist.get_rank() == 0
 
     with fwd_state.activate(model) as params:
         for batch in tqdm(query_stream, desc="Query", disable=not main):
             batch, live = mask_padded_rows(batch)
-            denom += int(live)
             grads, loss = accumulate_grads(
                 model, params, batch, grad_accum_steps, create_graph=False
             )
 
+            # A batch reports the mean over its own label tokens, so weighting
+            # by that count turns the accumulation into a sum over the query
+            # set. Averaging the batch means instead would let a partial last
+            # batch count as much as a full one, putting the batch width into
+            # the query gradient. A dead batch contributes an exact zero.
+            weight = loss_denom(batch) if live else 0.0
+            denom += weight
+
             if grad_accum is None:
-                grad_accum = {k: g.detach().clone() for k, g in grads.items()}
+                grad_accum = {k: g.detach() * weight for k, g in grads.items()}
             else:
                 for k, g in grads.items():
-                    grad_accum[k] += g.detach()
+                    grad_accum[k] += g.detach() * weight
 
-            loss_accum += loss
+            loss_accum += loss * weight
 
     assert grad_accum is not None, "Query stream was empty"
 
     if dist.is_initialized():
         denom_t = torch.tensor(denom, device=current_device())
         dist.all_reduce(denom_t)
-        denom = int(denom_t.item())
+        denom = float(denom_t.item())
 
     if method == "mean":
         for k in grad_accum:

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -148,19 +148,26 @@ def per_doc_query_losses(
 def mean_query_loss(
     model: torch.nn.Module, query_stream: DataStream, grad_accum_steps: int = 1
 ) -> torch.Tensor:
-    """Mean loss over the query stream's batches, reduced across ranks."""
+    """Mean loss per query label token, reduced across ranks.
+
+    Each forward reports the mean over its own label tokens, so multiplying by
+    that count and dividing once at the end weights every token equally.
+    Averaging the batch means instead would let a partial last batch count as
+    much as a full one, which puts the batch width into a recorded loss. Dead
+    batches -- all rows padding -- contribute an exact zero to both sums.
+    """
     total = torch.zeros((), device=query_stream.device)
-    live_batches = torch.zeros((), device=query_stream.device)
+    tokens = torch.zeros((), device=query_stream.device)
     with torch.no_grad():
         for batch in query_stream:
             batch, live = mask_padded_rows(batch)
-            live_batches += float(live)
             for micro in split_batch(batch, grad_accum_steps):
-                total += model(**micro).loss * loss_denom(micro) / loss_denom(batch)
+                total += model(**micro).loss * loss_denom(micro)
+            tokens += loss_denom(batch) if live else 0.0
     if dist.is_initialized():
         dist.all_reduce(total)
-        dist.all_reduce(live_batches)
-    return total / live_batches
+        dist.all_reduce(tokens)
+    return total / tokens
 
 
 def report_multi_query_validation(

--- a/tests/test_per_query_magic.py
+++ b/tests/test_per_query_magic.py
@@ -311,6 +311,49 @@ def test_query_eval_ignores_padding_and_grad_accum(grad_accum_steps):
     torch.testing.assert_close(loss, (per_doc * counts).sum() / counts.sum())
 
 
+@pytest.mark.parametrize("grad_accum_steps", [1, 3])
+def test_aggregate_query_reduction_ignores_batch_width(grad_accum_steps):
+    """The aggregate query loss and gradient reduce over the query set, not
+    over the batching. Splitting the same documents across several batches --
+    the last of them partial -- must not move either, which averaging the
+    per-batch means would: a batch holding one document would count as much as
+    a batch holding four."""
+    model = _model()
+    _, fwd_state = Trainer.initialize(model, torchopt.adamw(1e-4))
+    model.eval()
+
+    # Unequal lengths, so a per-batch mean is not the per-token mean.
+    ids = [list(range(10, 10 + n)) for n in (4, 9, 5, 8, 6)]
+    query_ds = Dataset.from_dict({"input_ids": ids, "labels": ids})
+
+    # One batch holding everything: the reduction has nothing to get wrong.
+    whole = DataStream(query_ds, batch_size=len(ids), device="cpu")
+
+    # The same documents over three batches, the last one 1 real + 1 padding.
+    split_ds, n_docs, _, weight_pad = pad_dataset_to_batch_size(
+        query_ds, 2, len(ids), "Query", 0
+    )
+    split = DataStream(split_ds, 2, device="cpu", weight_shape=(n_docs,))
+    split.weights.data[-weight_pad:] = 0.0
+    assert len(split) == 3
+
+    with fwd_state.activate(model):
+        want_loss = mean_query_loss(model, whole)
+        got_loss = mean_query_loss(model, split, grad_accum_steps)
+        per_doc = per_doc_query_losses(model, whole, len(ids))
+
+    counts = torch.tensor([len(x) - 1 for x in ids], dtype=torch.float32)
+    torch.testing.assert_close(want_loss, (per_doc * counts).sum() / counts.sum())
+    torch.testing.assert_close(got_loss, want_loss)
+
+    want_grads, _ = compute_query_gradients(fwd_state, model, whole)
+    got_grads, _ = compute_query_gradients(
+        fwd_state, model, split, grad_accum_steps=grad_accum_steps
+    )
+    for name in want_grads:
+        torch.testing.assert_close(got_grads[name], want_grads[name], msg=name)
+
+
 def test_unsupervised_batch_loss_is_zero():
     """A batch with no supervised token scores 0 rather than 0/0."""
     logits, labels = torch.randn(2, 8, 32), torch.full((2, 8), -100)


### PR DESCRIPTION
Stacked on #429 (`fix/eval-batch-size`), which is where `mean_query_loss` and `mask_padded_rows` live. Retarget to `main` once that merges.

## Why

#429 stopped padding rows from entering aggregate query evaluation. What is left is the reduction over the batches themselves: both `mean_query_loss` and `compute_query_gradients` average the *per-batch* means. Each batch reports the mean over its own label tokens, and those means are then averaged with equal weight, so a batch holding one live document counts as much as a batch holding eight. The batch width, a memory and throughput knob, lands in a recorded loss and in the query gradient the MAGIC scores are built from.

Ten GPT-2 query documents, padded to a batch width of 4:

| eval batch | pad rows | aggregate query loss | mean over the real documents |
|---|---|---|---|
| 4 | 2 | 4.716831 | 4.779631 |
| 8 | 6 | 4.638320 | 4.779621 |
| 32 | 22 | 4.779619 | 4.779618 |
| 256 | 246 | 4.779622 | 4.779621 |

The aggregate only agrees with the query set's own mean once every document fits in one batch.

## What

Weight each batch by the label tokens it actually carries and divide once at the end, in both `mean_query_loss` and `compute_query_gradients`. That is exactly what a single batch spanning the whole query set already produced, so the reduction now runs over the query set rather than over the batching. Dead batches (every row padding) contribute an exact zero to both sums, which the `weighted_causal_lm_ce` guard from #429 already provides.

After the change the same table is flat: 4.779631 / 4.779620 / 4.779619 / 4.779619 / 4.779622 across batch widths 4 through 256, matching the mean over the real documents at every width.

## This moves recorded numbers

End-to-end GPT-2 run, 10 query documents at batch 8 (so the second batch is 2 real documents against the first batch's 8), `query_method: mean`, leave-k-out over 3 subsets:

- baseline query loss 3.6654106974601746 -> 3.5614548206329344
- aggregate MAGIC scores: Pearson 0.9907, Spearman 0.9270 against the old run, largest change 41% of the largest score

That case is deliberately lopsided. The standard 50-query configs feel a milder version of the same effect rather than none: 50 documents sharded over 4 ranks live 13/13/12/12, and the old reduction weighted those four rank means equally.

`query_method="sum"` changes scale: it is now the gradient of the summed query loss rather than of the summed per-batch means. No config in the repository sets it.

## Testing

- `test_aggregate_query_reduction_ignores_batch_width`, new: the same 5 unequal-length documents as one batch, and as three batches whose last is 1 real + 1 padding, must give the same aggregate loss and the same query gradient; the loss must equal the token-weighted mean of `per_doc_query_losses`. Fails on `fix/eval-batch-size` (both parametrisations), passes here.
- `tests/test_per_query_magic.py tests/test_magic.py tests/test_bank_loss_cache.py tests/test_banked_model_loading.py tests/test_multi_query_validate.py tests/test_per_token_lds.py tests/test_batch_size_invariance.py`: 75 passed.
- `pre-commit run --all-files` and `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpLMt4jYaPpjUUz4PoBbja
