### PR TITLE
Reduce MAGIC mean query gradient over tokens, not batches

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -73,10 +73,15 @@ def compute_query_gradients(
 
     with fwd_state.activate(model) as params:
         for batch in tqdm(query_stream, desc="Query", disable=not main):
-            batch, live = mask_padded_rows(batch)
-            denom += int(live)
+            batch, n_tokens = mask_padded_rows(batch)
+            denom += n_tokens
             grads, loss = accumulate_grads(
-                model, params, batch, grad_accum_steps, create_graph=False
+                model,
+                params,
+                batch,
+                grad_accum_steps,
+                create_graph=False,
+                loss_scale=n_tokens,
             )
 
             if grad_accum is None:
@@ -85,7 +90,7 @@ def compute_query_gradients(
                 for k, g in grads.items():
                     grad_accum[k] += g.detach()
 
-            loss_accum += loss
+            loss_accum += loss * n_tokens
 
     assert grad_accum is not None, "Query stream was empty"
 
@@ -94,7 +99,7 @@ def compute_query_gradients(
         dist.all_reduce(denom_t)
         denom = int(denom_t.item())
 
-    if method == "mean":
+    if method != "sum":
         for k in grad_accum:
             grad_accum[k] /= denom
 

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -188,8 +188,8 @@ def compute_per_query_magic_scores(
         fwd_state.copy_(restored)
         del restored
 
-        # A one-document stream indexes its weights by row, not by doc id, and
-        # one row per rank is its full width: wider is zero-weight padding.
+        # A one-document stream indexes its weights by row, not by doc id.
+        # One row per rank; more rows are zero-weight padding.
         one = query_dataset.select([qi])
         if "doc_ids" in one.column_names:
             one = one.remove_columns("doc_ids")

--- a/bergson/magic/data_stream.py
+++ b/bergson/magic/data_stream.py
@@ -5,18 +5,17 @@ from datasets import Dataset
 from ..data import pad_and_tensor
 
 
-def mask_padded_rows(batch: dict) -> tuple[dict, bool]:
+def mask_padded_rows(batch: dict) -> tuple[dict, int]:
     """Remove ``example_weight`` and mask out the rows it zeroes, so all ranks
-    keep the same batch width. Returns the batch and whether any row is left.
+    keep the same batch width. Returns the batch and its supervised token count.
     """
     weight = batch.pop("example_weight", None)
-    if weight is None:
-        return batch, True
-    live = (weight != 0).reshape(len(weight), -1).any(dim=1)
-    batch["labels"] = batch["labels"].masked_fill(~live[:, None], -100)
-    if "shift_loss_mask" in batch:
-        batch["shift_loss_mask"] = batch["shift_loss_mask"] & live[:, None]
-    return batch, bool(live.any())
+    if weight is not None:
+        live = (weight != 0).reshape(len(weight), -1).any(dim=1)
+        batch["labels"] = batch["labels"].masked_fill(~live[:, None], -100)
+        if "shift_loss_mask" in batch:
+            batch["shift_loss_mask"] = batch["shift_loss_mask"] & live[:, None]
+    return batch, int((batch["labels"][:, 1:] != -100).sum())
 
 
 def pad_dataset_to_batch_size(

--- a/bergson/magic/data_stream.py
+++ b/bergson/magic/data_stream.py
@@ -7,7 +7,7 @@ from ..data import pad_and_tensor
 
 def mask_padded_rows(batch: dict) -> tuple[dict, int]:
     """Remove ``example_weight`` and mask out the rows it zeroes, so all ranks
-    keep the same batch width. Returns the batch and its supervised token count.
+    keep the same batch size. Returns the batch and its supervised token count.
     """
     weight = batch.pop("example_weight", None)
     if weight is not None:

--- a/bergson/magic/grad_accum.py
+++ b/bergson/magic/grad_accum.py
@@ -110,6 +110,7 @@ def accumulate_grads(
     *,
     create_graph: bool,
     rng_snapshots: list | None = None,
+    loss_scale: float = 1.0,
 ) -> tuple[dict, float]:
     """Sum normalized per-micro-batch gradients into the full-batch gradient.
 
@@ -135,7 +136,9 @@ def accumulate_grads(
         assert isinstance(micro_loss, torch.Tensor), "Loss must be a Tensor"
         coef = loss_denom(micro_batch) / total_denom
         last_loss += float(micro_loss.detach()) * coef
-        micro_grads = grad_tree(micro_loss * coef, params, create_graph=create_graph)
+        micro_grads = grad_tree(
+            micro_loss * coef * loss_scale, params, create_graph=create_graph
+        )
         if grads is None:
             grads = dict(micro_grads)
         else:

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -148,19 +148,19 @@ def per_doc_query_losses(
 def mean_query_loss(
     model: torch.nn.Module, query_stream: DataStream, grad_accum_steps: int = 1
 ) -> torch.Tensor:
-    """Mean loss over the query stream's batches, reduced across ranks."""
+    """Mean loss over the query stream, reduced across ranks."""
     total = torch.zeros((), device=query_stream.device)
-    live_batches = torch.zeros((), device=query_stream.device)
+    tokens = torch.zeros((), device=query_stream.device)
     with torch.no_grad():
         for batch in query_stream:
-            batch, live = mask_padded_rows(batch)
-            live_batches += float(live)
+            batch, n_tokens = mask_padded_rows(batch)
+            tokens += n_tokens
             for micro in split_batch(batch, grad_accum_steps):
-                total += model(**micro).loss * loss_denom(micro) / loss_denom(batch)
+                total += model(**micro).loss * loss_denom(micro)
     if dist.is_initialized():
         dist.all_reduce(total)
-        dist.all_reduce(live_batches)
-    return total / live_batches
+        dist.all_reduce(tokens)
+    return total / tokens
 
 
 def report_multi_query_validation(

--- a/tests/test_ddp.py
+++ b/tests/test_ddp.py
@@ -14,7 +14,10 @@ from transformers import AutoConfig, AutoModelForCausalLM
 
 from bergson.distributed import grad_tree
 from bergson.magic import BackwardState, DataStream, Trainer
+from bergson.magic.cli import compute_query_gradients
+from bergson.magic.data_stream import pad_dataset_to_batch_size
 from bergson.utils.math import weighted_causal_lm_ce
+from bergson.validate import mean_query_loss, per_doc_query_losses
 
 
 def _make_model():
@@ -267,3 +270,59 @@ def test_ddp_matches_single_process():
         rtol=1e-3,
         msg="DDP attribution scores diverged from single-process",
     )
+
+
+def _padded_query_eval(device):
+    """Query loss, per-document losses and mean query gradient of a 3-document
+    query set padded to 4 rows, so on two ranks one rank's shard is half pad."""
+    model = _make_model().to(device)
+    _, fwd_state = Trainer.initialize(model, torchopt.adamw(1e-4))
+    model.eval()
+    docs = _make_dataset().select(range(3))
+    padded, n_docs, _, weight_pad = pad_dataset_to_batch_size(docs, 4, 3, "Q", 0)
+    stream = DataStream(padded, 4, device=device, weight_shape=(n_docs,))
+    stream.weights.data[-weight_pad:] = 0.0
+    grads, loss = compute_query_gradients(fwd_state, model, stream)
+    with fwd_state.activate(model):
+        per_doc = per_doc_query_losses(model, stream, n_docs)[:3]
+        mean = mean_query_loss(model, stream)
+    return {k: g.cpu() for k, g in grads.items()}, loss, per_doc.cpu(), mean.cpu()
+
+
+def _padded_query_worker(rank, world_size, port, result_dict):
+    try:
+        torch.cuda.set_device(rank)
+        dist.init_process_group(
+            "cpu:gloo,cuda:nccl",
+            init_method=f"tcp://localhost:{port}",
+            rank=rank,
+            world_size=world_size,
+            device_id=torch.device(f"cuda:{rank}"),
+        )
+        result_dict[rank] = _padded_query_eval(f"cuda:{rank}")
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="Need >= 2 GPUs for DDP test",
+)
+def test_padded_query_eval_matches_single_process():
+    """Every rank returns the single-process query loss, per-document losses and
+    mean query gradient, even when part of its shard is zero-weight padding."""
+    expected = _padded_query_eval("cuda:0")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        port = s.getsockname()[1]
+    result_dict = mp.Manager().dict()
+    mp.spawn(_padded_query_worker, args=(2, port, result_dict), nprocs=2, join=True)
+
+    for rank in range(2):
+        grads, loss, per_doc, mean = result_dict[rank]
+        assert loss == pytest.approx(expected[1], rel=1e-5)
+        torch.testing.assert_close(per_doc, expected[2])
+        torch.testing.assert_close(mean, expected[3])
+        for name, g in expected[0].items():
+            torch.testing.assert_close(grads[name], g, atol=1e-6, rtol=1e-4)


### PR DESCRIPTION
## Why

#429 masks padded query rows, which leaves ranks with unequal supervised token counts. Both aggregate query reductions were means of per-rank batch means, so the result depended on how rows shard: on a 3-document query set padded to 4 rows, two ranks gave a query loss of 10.3287 against 10.3344 single-process. Nothing ran query evaluation on more than one GPU, which is how it got through.

## What

- `compute_query_gradients` and `mean_query_loss` reduce over supervised tokens: each batch's mean is weighted by its token count and the total is all-reduced, so the result is the same on any number of ranks. `query_method: sum` is the matching token sum; `mean` and `none` divide.
- The weight is applied to the loss through a new `loss_scale` argument of `accumulate_grads`, not to the gradient afterwards: FSDP sums gradients across ranks inside autograd, so scaling after the fact multiplies a cross-rank sum by one rank's count. Scaling the gradient made four of the five `test_distributed_magic.py` cases fail.
- `mask_padded_rows` returns the batch's supervised token count instead of a live flag.

## Tests

- `test_padded_query_eval_matches_single_process` (`test_ddp.py`, 2 GPUs): every rank returns the single-process query loss, per-document losses and mean query gradient for a 3-document query set padded to 4 rows, where one rank's shard is half padding. Fails on `main`.
- `test_distributed_magic.py` (4 GPUs) passes; it ran per-query MAGIC under DDP and FSDP with the one-row-per-rank query stream and validation's all-reduced query loss.
