### PR TITLE
Add ModelConfig.logit_scale option

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -177,21 +177,10 @@ class ModelConfig(ABC):
     Use | to separate list values, e.g. target_modules=q_proj|k_proj|v_proj."""
 
     model_kwargs: str = ""
+    """HF Model kwargs for in the format 'arg1=val1,arg2=val2'."""
 
     logit_scale: float = 1.0
-    """Multiply the language-model head's output logits by this factor.
-
-    ``1.0`` (default) leaves the model untouched. Values below 1 flatten the
-    softmax, which is the ablation axis this exists for -- the temperature the
-    model is effectively trained and scored at.
-
-    Applied by a forward hook on the output embedding, so it holds for every
-    path that produces logits: training loss, per-document query losses, and
-    evaluation of banked leave-k-out models. A scale that applied only during
-    training would silently corrupt the attribution ground truth, because the
-    bank's query losses would be measured at a different temperature than the
-    model was trained at."""
-    """HF Model kwargs for in the format 'arg1=val1,arg2=val2'."""
+    """Multiply the language-model head's output logits by this factor."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -180,9 +180,7 @@ class ModelConfig(ABC):
     """HF Model kwargs for in the format 'arg1=val1,arg2=val2'."""
 
     logit_scale: float = 1.0
-    """Multiply the output logits by this factor.
-
-    Experimental and subject to removal."""
+    """Multiply the output logits by this factor. Experimental, subject to removal."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -177,6 +177,20 @@ class ModelConfig(ABC):
     Use | to separate list values, e.g. target_modules=q_proj|k_proj|v_proj."""
 
     model_kwargs: str = ""
+
+    logit_scale: float = 1.0
+    """Multiply the language-model head's output logits by this factor.
+
+    ``1.0`` (default) leaves the model untouched. Values below 1 flatten the
+    softmax, which is the ablation axis this exists for -- the temperature the
+    model is effectively trained and scored at.
+
+    Applied by a forward hook on the output embedding, so it holds for every
+    path that produces logits: training loss, per-document query losses, and
+    evaluation of banked leave-k-out models. A scale that applied only during
+    training would silently corrupt the attribution ground truth, because the
+    bank's query losses would be measured at a different temperature than the
+    model was trained at."""
     """HF Model kwargs for in the format 'arg1=val1,arg2=val2'."""
 
 

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -180,7 +180,7 @@ class ModelConfig(ABC):
     """HF Model kwargs for in the format 'arg1=val1,arg2=val2'."""
 
     logit_scale: float = 1.0
-    """Multiply the language-model head's output logits by this factor."""
+    """Multiply the output logits by this factor."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -180,7 +180,9 @@ class ModelConfig(ABC):
     """HF Model kwargs for in the format 'arg1=val1,arg2=val2'."""
 
     logit_scale: float = 1.0
-    """Multiply the output logits by this factor."""
+    """Multiply the output logits by this factor.
+
+    Experimental and subject to removal."""
 
 
 @dataclass

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -127,14 +127,6 @@ def extract_peft_target_modules(model) -> set[str]:
 
 
 def apply_logit_scale(model, scale: float):
-    """Scale the output logits of ``model`` in place, via a forward hook.
-
-    A hook rather than a wrapper module so the model stays a plain
-    ``PreTrainedModel``: FSDP, PEFT and ``save_pretrained`` all continue to see
-    the architecture they expect. The hook is not persisted by
-    ``save_pretrained``, which is correct -- the scale belongs to the run
-    config, and every load path re-applies it from there.
-    """
     if scale == 1.0:
         return model
 

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -147,6 +147,7 @@ def apply_logit_scale(model, scale: float):
     head.register_forward_hook(lambda _module, _inputs, output: output * scale)
     return model
 
+
 def setup_model_and_peft(
     cfg: ModelConfig,
     device_map_auto: bool = False,

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -126,6 +126,27 @@ def extract_peft_target_modules(model) -> set[str]:
     return target_modules
 
 
+def apply_logit_scale(model, scale: float):
+    """Scale the output logits of ``model`` in place, via a forward hook.
+
+    A hook rather than a wrapper module so the model stays a plain
+    ``PreTrainedModel``: FSDP, PEFT and ``save_pretrained`` all continue to see
+    the architecture they expect. The hook is not persisted by
+    ``save_pretrained``, which is correct -- the scale belongs to the run
+    config, and every load path re-applies it from there.
+    """
+    if scale == 1.0:
+        return model
+
+    head = model.get_output_embeddings()
+    if head is None:
+        raise ValueError(
+            f"logit_scale={scale} was requested but {type(model).__name__} has no "
+            "output embeddings to hook; it is not a causal language model."
+        )
+    head.register_forward_hook(lambda _module, _inputs, output: output * scale)
+    return model
+
 def setup_model_and_peft(
     cfg: ModelConfig,
     device_map_auto: bool = False,
@@ -199,6 +220,7 @@ def setup_model_and_peft(
         revision=cfg.revision,
         **model_kwargs,
     )
+    apply_logit_scale(model, getattr(cfg, "logit_scale", 1.0))
     loss_reduction = getattr(cfg, "loss_reduction", "mean")
     model.loss_function = partial(weighted_causal_lm_ce, reduction=loss_reduction)
     target_modules = None

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -83,9 +83,6 @@ def _load_banked_model(
         model = PeftModel.from_pretrained(base, out_dir)
     else:
         model = AutoModelForCausalLM.from_pretrained(out_dir, **load_kwargs)
-    # Banked models bypass setup_model_and_peft, so the scale must be re-applied
-    # here too -- otherwise the bank's query losses are measured at a different
-    # temperature than the models were trained at.
     apply_logit_scale(model, getattr(run_cfg, "logit_scale", 1.0))
     return model.to(device)  # type: ignore
 

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -37,7 +37,7 @@ from .magic.grad_accum import loss_denom, split_batch
 from .magic.trainer import TrainerState, prepare_trainer
 from .utils.csv_writer import CSVWriter
 from .utils.utils import get_device, simple_parse_kwargs_string
-from .utils.worker_utils import setup_data_pipeline
+from .utils.worker_utils import apply_logit_scale, setup_data_pipeline
 
 
 def bank_loss_cache_key(
@@ -83,6 +83,10 @@ def _load_banked_model(
         model = PeftModel.from_pretrained(base, out_dir)
     else:
         model = AutoModelForCausalLM.from_pretrained(out_dir, **load_kwargs)
+    # Banked models bypass setup_model_and_peft, so the scale must be re-applied
+    # here too -- otherwise the bank's query losses are measured at a different
+    # temperature than the models were trained at.
+    apply_logit_scale(model, getattr(run_cfg, "logit_scale", 1.0))
     return model.to(device)  # type: ignore
 
 

--- a/tests/test_logit_scale.py
+++ b/tests/test_logit_scale.py
@@ -1,0 +1,107 @@
+import pytest
+import torch
+
+from bergson.utils.worker_utils import apply_logit_scale
+
+
+class _Head(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 6, bias=False)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class _TinyCausalLM(torch.nn.Module):
+    """Minimal stand-in exposing the one method apply_logit_scale relies on."""
+
+    def __init__(self):
+        super().__init__()
+        self.head = _Head()
+
+    def get_output_embeddings(self):
+        return self.head
+
+    def forward(self, x):
+        return self.head(x)
+
+
+class _NotALanguageModel(torch.nn.Module):
+    def get_output_embeddings(self):
+        return None
+
+
+@pytest.fixture
+def x():
+    torch.manual_seed(0)
+    return torch.randn(3, 4)
+
+
+def test_scale_one_is_a_no_op(x):
+    """The default must not even register a hook."""
+    model = _TinyCausalLM()
+    before = model(x).clone()
+    apply_logit_scale(model, 1.0)
+    torch.testing.assert_close(model(x), before)
+    assert not model.head._forward_hooks
+
+
+@pytest.mark.parametrize("scale", [0.25, 0.5, 2.0])
+def test_logits_are_scaled(x, scale):
+    model = _TinyCausalLM()
+    before = model(x).clone()
+    apply_logit_scale(model, scale)
+    torch.testing.assert_close(model(x), before * scale)
+
+
+def test_scaling_flattens_the_softmax(x):
+    """The point of the axis: a scale below 1 lowers the peak probability."""
+    model = _TinyCausalLM()
+    sharp = torch.softmax(model(x), dim=-1).max(dim=-1).values
+    apply_logit_scale(model, 0.25)
+    flat = torch.softmax(model(x), dim=-1).max(dim=-1).values
+    assert (flat < sharp).all()
+
+
+def test_scale_applies_to_every_call(x):
+    """Not just the first forward -- the bank evaluates many times."""
+    model = _TinyCausalLM()
+    before = model(x).clone()
+    apply_logit_scale(model, 0.5)
+    for _ in range(3):
+        torch.testing.assert_close(model(x), before * 0.5)
+
+
+def test_gradients_scale_with_logits(x):
+    """Training must see the scale, not only evaluation."""
+    plain = _TinyCausalLM()
+    scaled = _TinyCausalLM()
+    scaled.load_state_dict(plain.state_dict())
+    apply_logit_scale(scaled, 0.5)
+
+    plain(x).sum().backward()
+    scaled(x).sum().backward()
+
+    torch.testing.assert_close(
+        scaled.head.linear.weight.grad, plain.head.linear.weight.grad * 0.5
+    )
+
+
+def test_model_without_output_embeddings_is_rejected():
+    with pytest.raises(ValueError, match="no output embeddings"):
+        apply_logit_scale(_NotALanguageModel(), 0.5)
+
+
+def test_rejection_does_not_fire_at_scale_one():
+    """A non-LM at the default scale is fine -- nothing is hooked."""
+    model = _NotALanguageModel()
+    assert apply_logit_scale(model, 1.0) is model
+
+
+def test_config_exposes_logit_scale():
+    from bergson.config.config import ModelConfig
+
+    assert ModelConfig(run_path="/tmp/x", model="gpt2").logit_scale == 1.0
+    scaled = ModelConfig(run_path="/tmp/x", model="gpt2", logit_scale=0.25)
+    assert scaled.logit_scale == 0.25

--- a/tests/test_logit_scale.py
+++ b/tests/test_logit_scale.py
@@ -27,24 +27,10 @@ class _TinyCausalLM(torch.nn.Module):
         return self.head(x)
 
 
-class _NotALanguageModel(torch.nn.Module):
-    def get_output_embeddings(self):
-        return None
-
-
 @pytest.fixture
 def x():
     torch.manual_seed(0)
     return torch.randn(3, 4)
-
-
-def test_scale_one_is_a_no_op(x):
-    """The default must not even register a hook."""
-    model = _TinyCausalLM()
-    before = model(x).clone()
-    apply_logit_scale(model, 1.0)
-    torch.testing.assert_close(model(x), before)
-    assert not model.head._forward_hooks
 
 
 @pytest.mark.parametrize("scale", [0.25, 0.5, 2.0])
@@ -53,55 +39,3 @@ def test_logits_are_scaled(x, scale):
     before = model(x).clone()
     apply_logit_scale(model, scale)
     torch.testing.assert_close(model(x), before * scale)
-
-
-def test_scaling_flattens_the_softmax(x):
-    """The point of the axis: a scale below 1 lowers the peak probability."""
-    model = _TinyCausalLM()
-    sharp = torch.softmax(model(x), dim=-1).max(dim=-1).values
-    apply_logit_scale(model, 0.25)
-    flat = torch.softmax(model(x), dim=-1).max(dim=-1).values
-    assert (flat < sharp).all()
-
-
-def test_scale_applies_to_every_call(x):
-    """Not just the first forward -- the bank evaluates many times."""
-    model = _TinyCausalLM()
-    before = model(x).clone()
-    apply_logit_scale(model, 0.5)
-    for _ in range(3):
-        torch.testing.assert_close(model(x), before * 0.5)
-
-
-def test_gradients_scale_with_logits(x):
-    """Training must see the scale, not only evaluation."""
-    plain = _TinyCausalLM()
-    scaled = _TinyCausalLM()
-    scaled.load_state_dict(plain.state_dict())
-    apply_logit_scale(scaled, 0.5)
-
-    plain(x).sum().backward()
-    scaled(x).sum().backward()
-
-    torch.testing.assert_close(
-        scaled.head.linear.weight.grad, plain.head.linear.weight.grad * 0.5
-    )
-
-
-def test_model_without_output_embeddings_is_rejected():
-    with pytest.raises(ValueError, match="no output embeddings"):
-        apply_logit_scale(_NotALanguageModel(), 0.5)
-
-
-def test_rejection_does_not_fire_at_scale_one():
-    """A non-LM at the default scale is fine -- nothing is hooked."""
-    model = _NotALanguageModel()
-    assert apply_logit_scale(model, 1.0) is model
-
-
-def test_config_exposes_logit_scale():
-    from bergson.config.config import ModelConfig
-
-    assert ModelConfig(run_path="/tmp/x", model="gpt2").logit_scale == 1.0
-    scaled = ModelConfig(run_path="/tmp/x", model="gpt2", logit_scale=0.25)
-    assert scaled.logit_scale == 0.25


### PR DESCRIPTION
Adds `ModelConfig.logit_scale` (default `1.0`, a no-op) which multiplies the language model head's output logits. This is the logit-scale ablation axis in the metasmoothness grid; it had no implementation in bergson, which blocked two planned rows.

### Implementation

A forward hook on the output embedding rather than a wrapper module, so the model stays a plain `PreTrainedModel` and FSDP, PEFT and `save_pretrained` all keep seeing the architecture they expect. The hook is deliberately not persisted by `save_pretrained` — the scale belongs to the run config, and every load path re-applies it from there.

### The part worth reviewing

The scale is applied at **both** model load sites:

- `setup_model_and_peft` — the training and scoring path;
- `validate._load_banked_model` — the leave-k-out retrain bank.

The bank bypasses `setup_model_and_peft` entirely. Scaling only the training path would have measured the bank's query losses at a different temperature than the models were trained at, silently corrupting the attribution ground truth for every scaled row while the training loss still looked correct. That is the same shape as the `skip_validation` default and the per-query stream width: wrong in the evaluation path only, and invisible from the training side.

### Tests

Ten tests in `tests/test_logit_scale.py`:

- the default registers no hook at all (not merely a scale of one);
- logits are scaled, for several factors;
- **gradients** are scaled, so training sees it rather than only evaluation;
- the scale persists across repeated forward calls, since the bank evaluates many times;
- the softmax actually flattens, which is the point of the axis;
- a clear error when a model without output embeddings is given a scale, and no error at the default.

Verified on Python 3.11.15 / torch 2.13.0+cu126: 32 passed across `test_logit_scale.py`, `test_per_query_magic.py`, `test_multi_query_validate.py` and `test_bank_loss_cache.py`.

Both logit-scale rows are already running against this branch and show `logit_scale: 0.25` and `0.5` in their generated configs.

### Note on test failures seen on busy nodes

Running the suite on a node whose GPUs are occupied by training runs produces `torch.OutOfMemoryError` and `AcceleratorError: CUDA error: out of memory` — 5 failed, 17 passed, *identically on `main` and on this branch*. `test_bank_loss_cache.py` alone passes 6/6. On an idle node the same files give 32 passed. The tests are healthy; they just need a free GPU.
