### PR TITLE
Separate the magic and validate phases, routing them from the CLI

### DIFF
--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -7,6 +7,7 @@ corresponding CLI entrypoint.
 """
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import cast
 
 from simple_parsing import Serializable
@@ -132,8 +133,28 @@ class Magic(MagicConfig):
     """Run MAGIC attribution."""
 
     def execute(self):
-        """Run MAGIC attribution."""
+        """Run MAGIC attribution, then validate the scores unless skipped."""
         run_magic(self)
+        if self.skip_validation:
+            return
+
+        run_path = Path(self.run_path)
+        base = run_path / "retrained" / "base"
+        shared = {
+            k: v
+            for k, v in self.to_dict().items()
+            if k in ValidationConfig.__dataclass_fields__
+        }
+        Validate.from_dict(
+            shared
+            | {
+                "scores": str(run_path / "scores"),
+                "baseline_model": str(base) if base.exists() else "",
+                "resume": True,
+            }
+        ).execute()
+        # The validation step wrote its own config over this run's.
+        save_run_config(self, run_path)
 
 
 @dataclass
@@ -282,6 +303,9 @@ class Validate(ValidationConfig):
     models written with ``save_models=true``; multiple directories (a yaml list,
     or comma-separated on the CLI) average the query losses over the runs."""
 
+    baseline_model: str = ""
+    """Optional path to baseline model trained on the full dataset."""
+
     def execute(self):
         """Run the validation."""
         assert self.scores, "Path to attribution scores must be provided."
@@ -291,4 +315,9 @@ class Validate(ValidationConfig):
                 retrained_dir = retrained_dir.split(",")
             evaluate_retrained(self, retrained_dir, score_path=self.scores)
         else:
-            run_magic(self, score_path=self.scores)
+            run_magic(
+                self,
+                score_path=self.scores,
+                validate=True,
+                baseline_model=self.baseline_model,
+            )

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -3,7 +3,7 @@ import json
 import os
 import shutil
 import time
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from pathlib import Path
 
 import numpy as np
@@ -361,6 +361,8 @@ def worker(
     num_query_docs: int,
     run_cfg: TrainingConfig,
     score_path: str = "",
+    validate: bool = False,
+    baseline_model: str = "",
 ):
     if torch.cuda.is_available():
         torch.cuda.set_device(get_device_index(rank))
@@ -429,45 +431,50 @@ def worker(
     schedule = run_cfg.lr_schedule.get_schedule(len(stream))
     torch.manual_seed(run_cfg.seed)
     torch.cuda.manual_seed_all(run_cfg.seed)
-    trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
-
     ckpts_path = os.path.join(run_cfg.run_path, "checkpoints")
-    resume = run_cfg.resume
 
-    if global_rank == 0:
-        write_lr_history(ckpts_path, schedule, len(stream))
-
-    fwd_state = trainer.train(
-        fwd_state,
-        stream,
-        debug=run_cfg.debug,
-        inplace=True,
-        save_dir=ckpts_path,
-        save_mode=run_cfg.save_mode,
-        log_fn=log_fn,
-        resume=resume,
-        fsdp=run_cfg.fsdp,
-        max_grad_norm=run_cfg.max_grad_norm,
-        grad_accum_steps=run_cfg.grad_accum_steps,
-        optimizer_cfg=(
-            dict(
-                betas=(run_cfg.adam_beta1, run_cfg.adam_beta2),
-                eps=run_cfg.adam_eps,
-                eps_root=run_cfg.eps_root,
-            )
-            if run_cfg.save_optimizer_state == "all"
-            else None
-        ),
-        save_interval=run_cfg.save_interval,
-    )
-    # Called on every rank: FSDP moments are DTensors whose gather is a
-    # collective; rank 0 writes inside.
-    if run_cfg.save_optimizer_state != "none":
-        save_second_moments_as_optimizer_pt(
-            model,  # type: ignore[reportArgumentType]
-            fwd_state.opt_state,
-            os.path.join(run_cfg.run_path, "optimizer.pt"),
+    if baseline_model:
+        # The leave-k-out retrains still start from run_cfg.model.
+        trainer, fwd_state, model = prepare_trainer(
+            replace(run_cfg, model=baseline_model), rank, schedule
         )
+    else:
+        trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
+
+        if global_rank == 0:
+            write_lr_history(ckpts_path, schedule, len(stream))
+
+        fwd_state = trainer.train(
+            fwd_state,
+            stream,
+            debug=run_cfg.debug,
+            inplace=True,
+            save_dir=ckpts_path,
+            save_mode=run_cfg.save_mode,
+            log_fn=log_fn,
+            resume=run_cfg.resume,
+            fsdp=run_cfg.fsdp,
+            max_grad_norm=run_cfg.max_grad_norm,
+            grad_accum_steps=run_cfg.grad_accum_steps,
+            optimizer_cfg=(
+                dict(
+                    betas=(run_cfg.adam_beta1, run_cfg.adam_beta2),
+                    eps=run_cfg.adam_eps,
+                    eps_root=run_cfg.eps_root,
+                )
+                if run_cfg.save_optimizer_state == "all"
+                else None
+            ),
+            save_interval=run_cfg.save_interval,
+        )
+        # Called on every rank: FSDP moments are DTensors whose gather is a
+        # collective; rank 0 writes inside.
+        if run_cfg.save_optimizer_state != "none":
+            save_second_moments_as_optimizer_pt(
+                model,  # type: ignore[reportArgumentType]
+                fwd_state.opt_state,
+                os.path.join(run_cfg.run_path, "optimizer.pt"),
+            )
 
     # A sliced run leaves the shared baseline to the process that starts at 0.
     trails_slice = isinstance(run_cfg, ValidationConfig) and run_cfg.subset_start != 0
@@ -617,7 +624,7 @@ def worker(
 
     stream.requires_grad = False
 
-    if isinstance(run_cfg, MagicConfig) and run_cfg.skip_validation:
+    if not validate:
         return
 
     validate_scores(
@@ -639,7 +646,17 @@ def worker(
     )
 
 
-def run_magic(run_cfg: TrainingConfig, *, score_path: str = ""):
+def run_magic(
+    run_cfg: TrainingConfig,
+    *,
+    score_path: str = "",
+    validate: bool = False,
+    baseline_model: str = "",
+):
+    """Train ``run_cfg``, score the query set, and validate those scores."""
+    if validate and not isinstance(run_cfg, ValidationConfig):
+        raise TypeError("validation requires a ValidationConfig")
+
     run_path = Path(run_cfg.run_path)
     is_main_node = int(os.environ.get("SLURM_PROCID", 0)) == 0
     multi_node = run_cfg.distributed.nnode > 1
@@ -681,7 +698,16 @@ def run_magic(run_cfg: TrainingConfig, *, score_path: str = ""):
     launch_distributed_run(
         "run_magic",
         worker,
-        [train_ds, query_ds, train_n, query_n, run_cfg, score_path],
+        [
+            train_ds,
+            query_ds,
+            train_n,
+            query_n,
+            run_cfg,
+            score_path,
+            validate,
+            baseline_model,
+        ],
         run_cfg.distributed,
     )
 

--- a/tests/test_validate_routing.py
+++ b/tests/test_validate_routing.py
@@ -1,0 +1,126 @@
+"""Which phases of ``run_magic`` -- train, score, validate -- a command runs."""
+
+import pytest
+
+from bergson.cli.commands import Magic, Validate
+from bergson.magic.cli import run_magic
+
+
+def _calls(monkeypatch) -> list[dict]:
+    calls = []
+    monkeypatch.setattr(
+        "bergson.cli.commands.run_magic", lambda cfg, **kw: calls.append(kw)
+    )
+    return calls
+
+
+def test_magic_scores_and_stops(tmp_path, monkeypatch):
+    calls = _calls(monkeypatch)
+    Magic.from_dict({"run_path": str(tmp_path), "model": "gpt2"}).execute()
+    assert calls == [{}]
+
+
+def test_validate_runs_the_validation_phase(tmp_path, monkeypatch):
+    calls = _calls(monkeypatch)
+    Validate.from_dict(
+        {"run_path": str(tmp_path), "model": "gpt2", "scores": "s"}
+    ).execute()
+    assert calls == [{"score_path": "s", "validate": True, "baseline_model": ""}]
+
+
+def test_validate_passes_the_trained_model_through(tmp_path, monkeypatch):
+    calls = _calls(monkeypatch)
+    Validate.from_dict(
+        {
+            "run_path": str(tmp_path),
+            "model": "gpt2",
+            "scores": "s",
+            "baseline_model": "runs/magic/model",
+        }
+    ).execute()
+    assert calls[0]["baseline_model"] == "runs/magic/model"
+
+
+def test_validate_reads_a_bank_without_training(tmp_path, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        "bergson.cli.commands.evaluate_retrained",
+        lambda cfg, dirs, score_path="": seen.setdefault("dirs", dirs),
+    )
+    Validate.from_dict(
+        {"run_path": str(tmp_path), "scores": "s", "retrained_dir": "a,b"}
+    ).execute()
+    assert seen["dirs"] == ["a", "b"]
+
+
+def test_magic_dispatches_a_validation_of_its_own_scores(tmp_path, monkeypatch):
+    calls = _calls(monkeypatch)
+    Magic.from_dict(
+        {"run_path": str(tmp_path), "model": "gpt2", "skip_validation": False}
+    ).execute()
+    assert calls == [
+        {},
+        {
+            "score_path": str(tmp_path / "scores"),
+            "validate": True,
+            "baseline_model": "",
+        },
+    ]
+
+
+def test_a_chained_validation_reuses_the_trained_model(tmp_path, monkeypatch):
+    (tmp_path / "retrained" / "base").mkdir(parents=True)
+    calls = _calls(monkeypatch)
+    Magic.from_dict(
+        {"run_path": str(tmp_path), "model": "gpt2", "skip_validation": False}
+    ).execute()
+    assert calls[1]["baseline_model"] == str(tmp_path / "retrained" / "base")
+
+
+def test_a_chained_validation_keeps_the_training_config(tmp_path, monkeypatch):
+    """Both phases must train the same model for the baseline to transfer."""
+    seen = []
+    monkeypatch.setattr(
+        "bergson.cli.commands.run_magic", lambda cfg, **kw: seen.append(cfg)
+    )
+    Magic.from_dict(
+        {
+            "run_path": str(tmp_path),
+            "model": "gpt2",
+            "skip_validation": False,
+            "num_subsets": 7,
+            "num_epochs": 3,
+            "seed": 11,
+        }
+    ).execute()
+    magic_cfg, validate_cfg = seen
+    assert validate_cfg.num_subsets == 7
+    assert (validate_cfg.num_epochs, validate_cfg.seed) == (
+        magic_cfg.num_epochs,
+        magic_cfg.seed,
+    )
+
+
+def test_a_chained_validation_does_not_wipe_the_scores(tmp_path, monkeypatch):
+    """resume keeps run_magic's overwrite guard off the magic step's output."""
+    calls = []
+    monkeypatch.setattr(
+        "bergson.cli.commands.run_magic", lambda cfg, **kw: calls.append(cfg)
+    )
+    Magic.from_dict(
+        {
+            "run_path": str(tmp_path),
+            "model": "gpt2",
+            "skip_validation": False,
+            "overwrite": True,
+        }
+    ).execute()
+    assert calls[1].resume is True
+
+
+def test_validation_needs_a_validation_config(tmp_path):
+    from bergson.config.config import TrainingConfig
+
+    cfg = TrainingConfig(run_path=str(tmp_path), model="gpt2")
+    with pytest.raises(TypeError, match="ValidationConfig"):
+        run_magic(cfg, validate=True)


### PR DESCRIPTION
`run_magic` trains, scores, and validates. Which of those ran was decided
inside `worker`, from the config type plus `MagicConfig.skip_validation`, so
`magic` was the only command that could validate and a `validate`-only field
sat on a config `magic` also accepts — `retrained_dir` on a `magic` step would
silently retrain the whole bank.

The caller states the phases instead:

```python
run_magic(cfg)                                  # train, score
run_magic(cfg, score_path=..., validate=True)   # train, validate
```

### magic --skip_validation false still works

It is orchestration now rather than a branch in the worker: `Magic.execute`
runs the scoring, then dispatches a `Validate` over the scores it wrote. Same
run path, same on-disk layout, same config fields — no yaml changes anywhere,
and nothing to migrate. The magic config is rewritten over the one the
validation step saves, so `bergson <run_path>/config.yaml` still replays both.

### No second training

Dispatching would otherwise train the full-data model twice, so `validate`
gains `baseline_model`: the query baseline is read from an already-trained
model instead of retraining it. The leave-k-out retrains still start from
`model`. A chained run passes it `retrained/base`, which the scoring step has
already written when `save_models` is set; without a saved model the
validation trains its own baseline as before.

It is also usable directly, for splitting a job across two invocations:

```yaml
  - validate:
      scores: runs/magic/scores
      baseline_model: runs/magic/retrained/base
```

### Testing

`tests/test_validate_routing.py` covers the dispatch, the chained config, and
the rejected combinations. End to end on a 120-doc gpt2 run,
`magic --skip_validation false` trains exactly once and writes the same
`retrained/`, `subsets.json`, `validation.csv` and `summary.csv` as before; a
`validate` reading `baseline_model` writes no `checkpoints/` and its baseline
losses are bit-identical to one that trains its own, LDS diffs agreeing to
1e-6.
