### PR TITLE
Compare a tail filter against random filters of the same size

### DIFF
--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -306,18 +306,26 @@ class Validate(ValidationConfig):
     baseline_model: str = ""
     """Optional path to baseline model trained on the full dataset."""
 
+    @property
+    def retrained_dirs(self) -> list[str]:
+        """``retrained_dir`` normalized to a list of paths."""
+        if isinstance(self.retrained_dir, str):
+            return [d for d in self.retrained_dir.split(",") if d]
+        return list(self.retrained_dir)
+
     def execute(self):
         """Run the validation."""
         assert self.scores, "Path to attribution scores must be provided."
-        if self.retrained_dir:
-            retrained_dir = self.retrained_dir
-            if isinstance(retrained_dir, str) and "," in retrained_dir:
-                retrained_dir = retrained_dir.split(",")
-            evaluate_retrained(self, retrained_dir, score_path=self.scores)
+        dirs = self.retrained_dirs
+        # A filter-* run still retrains its score-dependent arm, so a bank
+        # replaces the whole run only for lds.
+        if dirs and self.method == "lds":
+            evaluate_retrained(self, dirs, score_path=self.scores)
         else:
             run_magic(
                 self,
                 score_path=self.scores,
                 validate=True,
                 baseline_model=self.baseline_model,
+                retrained_dir=dirs,
             )

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -458,7 +458,9 @@ class ValidationConfig(TrainingConfig, ABC):
     ``none`` will perform one backward per query."""
 
     num_subsets: int = 100
-    """Number of leave-k-out subsets for Spearman correlation."""
+    """Number of leave-k-out subsets for Spearman correlation, or for a
+    filter-* method the number of random filters it is compared against;
+    ``0`` skips them, as does a bank of retrained models."""
 
     subset_weight: float = 0.0
     """Training weight assigned to each subset's documents during the retrain
@@ -486,10 +488,10 @@ class ValidationConfig(TrainingConfig, ABC):
     """One past the last subset index to retrain; ``None`` means ``num_subsets``."""
 
     subset_fraction: float = 0.0
-    """Fraction of data filtered during a retrain. When > 0 subsets are sampled 
-    independently without replacement within a subset, but with replacement 
+    """Fraction of data filtered during a retrain. When > 0 subsets are sampled
+    independently without replacement within a subset, but with replacement
     across subsets, and contain ``round(subset_fraction * pool)`` documents
-    — e.g. 0.05 filters 5 percent of documents per subset. When 0.0, the 
+    — e.g. 0.05 filters 5 percent of documents per subset. When 0.0, the
     dataset is randomly partitioned into ``num_subsets`` disjoint subsets
     for ```lds```, or for a filter-* method the size is 1 / num_subsets."""
 
@@ -498,7 +500,7 @@ class ValidationConfig(TrainingConfig, ABC):
     correlates the query loss change with the summed attribution scores.
     ``filter`` methods filter either the top- or bottom-scoring
     ``subset_fraction`` of data, then retrain and measure the query loss
-    change, suitable for comparison with a random subset filter re-train."""
+    change against ``num_subsets`` random filters of the same size."""
 
 
 @dataclass

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import time
+from collections.abc import Sequence
 from dataclasses import asdict, replace
 from pathlib import Path
 
@@ -363,6 +364,7 @@ def worker(
     score_path: str = "",
     validate: bool = False,
     baseline_model: str = "",
+    retrained_dir: Sequence[str] = (),
 ):
     if torch.cuda.is_available():
         torch.cuda.set_device(get_device_index(rank))
@@ -631,6 +633,7 @@ def worker(
         run_cfg,
         scores,
         multi_query,
+        retrained_dir=retrained_dir,
         global_rank=global_rank,
         rank=rank,
         schedule=schedule,
@@ -652,6 +655,7 @@ def run_magic(
     score_path: str = "",
     validate: bool = False,
     baseline_model: str = "",
+    retrained_dir: Sequence[str] = (),
 ):
     """Train ``run_cfg``, score the query set, and validate those scores."""
     if validate and not isinstance(run_cfg, ValidationConfig):
@@ -707,6 +711,7 @@ def run_magic(
             score_path,
             validate,
             baseline_model,
+            retrained_dir,
         ],
         run_cfg.distributed,
     )

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import os
 import random
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Callable
 
@@ -30,7 +31,7 @@ from transformers.utils.logging import (
 )
 
 from .config.config import ValidationConfig
-from .config.config_io import save_run_config
+from .config.config_io import read_config, save_run_config
 from .data import load_scores_loss_signed, pad_and_tensor
 from .magic.data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
 from .magic.grad_accum import loss_denom, split_batch
@@ -210,6 +211,217 @@ def report_multi_query_validation(
     print(f"Mean Spearman across {num_queries} queries: {np.mean(rhos):.4f}")
 
 
+def _bank_config_field(bank_dir: Path, field: str):
+    """Value of ``field`` in a bank's saved run config, or ``None`` if absent."""
+    try:
+        doc = read_config(bank_dir)
+    except (OSError, ValueError):
+        return None
+    for step in doc.get("steps", []):
+        for cmd in step.values():
+            if cmd and field in cmd:
+                return cmd[field]
+    return None
+
+
+def load_baseline_bank_subsets(
+    run_cfg: ValidationConfig, dirs: list[Path], k: int
+) -> list[torch.Tensor]:
+    """Removal sets of a bank reused as a filter run's random baseline.
+
+    A mismatched bank raises rather than reporting an incomparable number.
+    """
+    subsets: list[list[int]] | None = None
+    for d in dirs:
+        if not (d / "retrained" / "base").exists():
+            raise FileNotFoundError(
+                f"{d / 'retrained' / 'base'} not found; the random arm's loss "
+                "change is measured against the bank's own no-leave-out model"
+            )
+        path = d / "subsets.json"
+        if not path.exists():
+            raise FileNotFoundError(
+                f"{path} not found; retrained_dir must point at a run directory "
+                "written with save_models=true"
+            )
+        with open(path) as f:
+            found = json.load(f)
+        if subsets is None:
+            subsets = found
+        elif found != subsets:
+            raise ValueError(
+                f"{path} lists different removal sets to {dirs[0] / 'subsets.json'}; "
+                "averaging query losses over banks requires the same subsets"
+            )
+        sizes = sorted({len(x) for x in found})
+        if max(abs(n - k) for n in sizes) > 1:
+            raise ValueError(
+                f"{path} removes {sizes} docs per subset but the filter removes "
+                f"{k}; a different removal size is not a comparable baseline. Set "
+                "subset_fraction (or num_subsets, when it is 0) to match the bank."
+            )
+        for field, ours in [
+            ("model", run_cfg.model),
+            ("subset_weight", run_cfg.subset_weight),
+            ("exclude_zero_scores", run_cfg.exclude_zero_scores),
+        ]:
+            theirs = _bank_config_field(d, field)
+            if theirs is not None and theirs != ours:
+                raise ValueError(
+                    f"{d} was written with {field}={theirs!r} but this run uses "
+                    f"{ours!r}; the bank is not a comparable baseline"
+                )
+
+    assert subsets is not None
+    return [torch.tensor(x, dtype=torch.long) for x in subsets]
+
+
+def load_bank_losses(
+    run_cfg: ValidationConfig,
+    dirs: list[Path],
+    num_subsets: int,
+    *,
+    multi_query: bool,
+    num_real_query_docs: int,
+    device: torch.device | str,
+    query_loss: Callable[[torch.nn.Module], float],
+    query_losses_per_doc: Callable[[torch.nn.Module], torch.Tensor],
+    write_cache: bool = True,
+) -> tuple[float, torch.Tensor, torch.Tensor]:
+    """Query losses of every banked model, averaged over ``dirs``.
+
+    ``per_subset`` is ``[num_subsets, num_real_query_docs]`` for multi-query,
+    else ``[num_subsets]``. ``retrained/base`` gives the baseline; absent it
+    the baseline stays 0 (correlation-safe). The losses do not depend on the
+    scores, so each dir caches them for later methods on the same bank.
+    """
+
+    def compute(models_root: Path) -> tuple[float, torch.Tensor, torch.Tensor]:
+        base_dir = models_root / "base"
+        base_scalar = 0.0
+        base_per_doc = torch.zeros(num_real_query_docs)
+        if base_dir.exists():
+            base = _load_banked_model(run_cfg, str(base_dir), device)
+            if multi_query:
+                base_per_doc = query_losses_per_doc(base)
+            else:
+                base_scalar = query_loss(base)
+            del base
+
+        if multi_query:
+            per_subset = torch.zeros(num_subsets, num_real_query_docs)
+        else:
+            per_subset = torch.zeros(num_subsets)
+        for i in tqdm(range(num_subsets), desc="Evaluating bank"):
+            model = _load_banked_model(
+                run_cfg, str(models_root / f"subset_{i}"), device
+            )
+            if multi_query:
+                per_subset[i] = query_losses_per_doc(model)
+            else:
+                per_subset[i] = query_loss(model)
+            del model
+        return base_scalar, base_per_doc, per_subset
+
+    per_dir = []
+    for d in dirs:
+        cache_path = (
+            d
+            / "query_loss_cache"
+            / bank_loss_cache_key(run_cfg, multi_query, num_subsets)
+        )
+        if cache_path.exists():
+            print(f"Reusing cached bank losses from {cache_path}")
+            blob = torch.load(cache_path, map_location="cpu")
+        else:
+            base_scalar, base_per_doc, per_subset = compute(d / "retrained")
+            blob = {
+                "baseline": base_scalar,
+                "baseline_per_doc": base_per_doc,
+                "per_subset": per_subset,
+            }
+            if write_cache:
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                torch.save(blob, cache_path)
+                print(f"Saved bank losses to {cache_path}")
+        per_dir.append(blob)
+
+    baseline = float(np.mean([b["baseline"] for b in per_dir]))
+    baseline_per_doc = torch.stack([b["baseline_per_doc"] for b in per_dir]).mean(0)
+    per_subset_losses = torch.stack([b["per_subset"] for b in per_dir]).mean(0)
+    return baseline, baseline_per_doc, per_subset_losses
+
+
+def _baseline_subsets(
+    run_cfg: ValidationConfig, valid_indices: torch.Tensor, k: int
+) -> list[torch.Tensor]:
+    """Random removal sets of ``k`` documents for the filter baseline arm.
+
+    A ``subsets`` path pairs the baseline with an existing LDS run's draws.
+    """
+    path = run_cfg.subsets
+    if path and os.path.exists(path):
+        with open(path) as f:
+            subsets = [torch.tensor(x, dtype=torch.long) for x in json.load(f)]
+        sizes = sorted({len(x) for x in subsets})
+        if max(abs(n - k) for n in sizes) > 1:
+            raise ValueError(
+                f"{path} removes {sizes} docs per subset but the filter removes "
+                f"{k}; a different removal size is not a comparable baseline"
+            )
+        return subsets[: run_cfg.num_subsets]
+
+    rng = torch.Generator().manual_seed(run_cfg.seed)
+    return [
+        valid_indices[torch.randperm(len(valid_indices), generator=rng)[:k]]
+        for _ in range(run_cfg.num_subsets)
+    ]
+
+
+def _report_filter_baseline(
+    run_path: str,
+    method: str,
+    filter_changes: torch.Tensor,
+    random_changes: torch.Tensor,
+    k: int,
+    source: str,
+):
+    """Print and save the filter arm's loss change against the random arm.
+
+    A handful of draws supports a rank, not a p-value, so both are reported.
+    """
+    n, num_queries = random_changes.shape
+    print(
+        f"Random baseline ({n} subsets of {k} docs, {source}): "
+        f"mean loss change {random_changes.mean():.6f}"
+    )
+    summary_path = os.path.join(run_path, "filter_summary.csv")
+    summary = CSVWriter(
+        summary_path,
+        columns=[
+            "query",
+            "n_removed",
+            "filter_change",
+            "random_mean",
+            "random_sd",
+            "random_n",
+            "rank",
+        ],
+    )
+    for q in range(num_queries):
+        col = random_changes[:, q].numpy()
+        # Rank 1 is the largest loss increase, i.e. the most damaging removal.
+        rank = 1 + int((col > filter_changes[q].item()).sum())
+        sd = float(np.std(col, ddof=1)) if n > 1 else float("nan")
+        print(
+            f"Query {q}: {method} {filter_changes[q]:+.6f}  "
+            f"random {col.mean():+.6f} +/- {sd:.6f}  rank {rank}/{n + 1}"
+        )
+        summary.writerow(q, k, filter_changes[q].item(), float(col.mean()), sd, n, rank)
+    summary.close()
+    print(f"Saved filter/baseline comparison to {summary_path}")
+
+
 def _select_filter_slice(
     flat_scores: torch.Tensor,
     valid_indices: torch.Tensor,
@@ -252,11 +464,14 @@ def _validate_filter(
     num_queries: int,
     pad_count: int,
     weight_pad_count: int,
+    retrained_dir: Sequence[str],
 ):
     """Retrain with documents corresponding to one end of the score ranking
     filtered.
 
-    Note that ``load_scores_loss_signed`` signs such that proponents are
+    A random arm removing the same number of documents runs alongside it,
+    retrained here or read from a bank; ``num_subsets = 0`` and no bank skips
+    it. Note that ``load_scores_loss_signed`` signs such that proponents are
     negative (reduce query loss), and that a positive ``loss_change`` means
     the filter worsened query performance. This is the opposite sign to the
     LDS ``diff`` column.
@@ -267,25 +482,33 @@ def _validate_filter(
         valid_indices = torch.arange(flat_scores.shape[0])
 
     # Get filtered subset size
+    pool = len(valid_indices)
     if run_cfg.subset_fraction == 0.0:
+        if run_cfg.num_subsets <= 0:
+            raise ValueError(
+                "subset_fraction must be positive when num_subsets is 0: there is "
+                "no leave-k-out chunk size for the filter to match"
+            )
         run_cfg.subset_fraction = 1 / run_cfg.num_subsets
-    k = max(1, round(run_cfg.subset_fraction * len(valid_indices)))
+    k = max(1, round(run_cfg.subset_fraction * pool))
 
-    csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
-    filter_csv = CSVWriter(
-        csv_path,
-        columns=["query", "n_removed", "baseline_loss", "filtered_loss", "loss_change"],
-        enabled=global_rank == 0,
+    baseline_vec = (
+        baseline_per_doc[:num_queries] if multi_query else torch.tensor([baseline])
     )
 
-    hf_disable_pbar()
-    hf_set_verbosity_error()
+    def eval_losses(model: torch.nn.Module) -> torch.Tensor:
+        """Query losses of an activated model, ``[num_queries]`` on the CPU."""
+        if multi_query:
+            per_doc = per_doc_query_losses(
+                model, query_stream, num_query_docs, run_cfg.grad_accum_steps
+            )
+            return per_doc[:num_queries].cpu()
 
-    changes = []
-    pbar = tqdm(range(num_queries), desc=run_cfg.method, disable=global_rank != 0)
-    for q in pbar:
-        removed = _select_filter_slice(flat_scores, valid_indices, q, k, run_cfg.method)
+        loss = mean_query_loss(model, query_stream, run_cfg.grad_accum_steps)
+        return loss.reshape(1).cpu()
 
+    def retrain_and_eval(removed: torch.Tensor) -> torch.Tensor:
+        """Query losses after retraining with ``removed`` down-weighted."""
         trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
         fwd_state.detach_()
 
@@ -307,33 +530,113 @@ def _validate_filter(
                 grad_accum_steps=run_cfg.grad_accum_steps,
             )
 
-        if multi_query:
-            with fwd_state.activate(model):
-                per_doc = per_doc_query_losses(model, query_stream, num_query_docs)
-            filtered_loss = per_doc[q].item()
-            base_loss = baseline_per_doc[q].item()
-        else:
-            with fwd_state.activate(model):
-                loss = mean_query_loss(model, query_stream, run_cfg.grad_accum_steps)
-            filtered_loss = loss.item()
-            base_loss = baseline
+        with fwd_state.activate(model):
+            return eval_losses(model)
 
-        change = filtered_loss - base_loss
-        filter_csv.writerow(q, len(removed), base_loss, filtered_loss, change)
+    hf_disable_pbar()
+    hf_set_verbosity_error()
 
+    csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
+    filter_csv = CSVWriter(
+        csv_path,
+        columns=["query", "n_removed", "baseline_loss", "filtered_loss", "loss_change"],
+        enabled=global_rank == 0,
+    )
+
+    filter_changes = torch.zeros(num_queries)
+    pbar = tqdm(range(num_queries), desc=run_cfg.method, disable=global_rank != 0)
+    for q in pbar:
+        removed = _select_filter_slice(flat_scores, valid_indices, q, k, run_cfg.method)
+        losses = retrain_and_eval(removed)
+
+        base_loss = baseline_vec[q].item()
+        filtered_loss = losses[q].item()
+        filter_changes[q] = filtered_loss - base_loss
+        filter_csv.writerow(
+            q, len(removed), base_loss, filtered_loss, filter_changes[q].item()
+        )
         if global_rank == 0:
-            changes.append(change)
-            pbar.set_postfix({"mean_loss_change": float(np.mean(changes))})
+            pbar.set_postfix(
+                {"mean_loss_change": filter_changes[: q + 1].mean().item()}
+            )
 
     filter_csv.close()
     if global_rank == 0:
         print(
-            f"{run_cfg.method}: mean loss change {float(np.mean(changes)):.6f} "
-            f"over {len(changes)} quer{'y' if len(changes) == 1 else 'ies'} "
-            f"({k} of {len(valid_indices)} docs removed per query, "
-            f"{k / len(valid_indices):.3%})"
+            f"{run_cfg.method}: mean loss change {filter_changes.mean():.6f} "
+            f"over {num_queries} quer{'y' if num_queries == 1 else 'ies'} "
+            f"({k} of {pool} docs removed per query, {k / pool:.3%})"
         )
         print(f"Saved tail-filter data to {csv_path}")
+
+    # The random arm ignores the scores, so one retrain serves every query.
+    dirs = [Path(d) for d in retrained_dir]
+    if dirs:
+        subsets = load_baseline_bank_subsets(run_cfg, dirs, k)
+        bank_base, bank_base_per_doc, per_subset = load_bank_losses(
+            run_cfg,
+            dirs,
+            len(subsets),
+            multi_query=multi_query,
+            num_real_query_docs=num_queries,
+            device=stream.weights.device,
+            query_loss=lambda m: float(eval_losses(m.eval())[0]),
+            query_losses_per_doc=lambda m: eval_losses(m.eval()),
+            write_cache=global_rank == 0,
+        )
+        arm_baseline = bank_base_per_doc if multi_query else torch.tensor([bank_base])
+        random_losses = per_subset.reshape(len(subsets), num_queries)
+        source = "bank " + ", ".join(str(d) for d in dirs)
+    elif run_cfg.num_subsets > 0:
+        subsets = _baseline_subsets(run_cfg, valid_indices, k)
+        if global_rank == 0:
+            print(f"Retraining {len(subsets)} random baseline subsets of {k} docs")
+        arm_baseline = baseline_vec
+        random_losses = torch.stack(
+            [
+                retrain_and_eval(x)
+                for x in tqdm(subsets, desc="random", disable=global_rank != 0)
+            ]
+        )
+        source = "retrained here"
+    else:
+        if global_rank == 0:
+            print(
+                "No random baseline: set num_subsets > 0, or retrained_dir to a "
+                "bank of random-subset retrains"
+            )
+        return
+
+    if global_rank != 0:
+        return
+
+    random_changes = random_losses - arm_baseline
+    random_csv = CSVWriter(
+        os.path.join(run_cfg.run_path, "random_filter.csv"),
+        columns=[
+            "subset",
+            "query",
+            "n_removed",
+            "baseline_loss",
+            "filtered_loss",
+            "loss_change",
+        ],
+    )
+    for i, subset in enumerate(subsets):
+        for q in range(num_queries):
+            random_csv.writerow(
+                i,
+                q,
+                len(subset),
+                arm_baseline[q].item(),
+                random_losses[i, q].item(),
+                random_changes[i, q].item(),
+            )
+    random_csv.close()
+
+    _report_filter_baseline(
+        run_cfg.run_path, run_cfg.method, filter_changes, random_changes, k, source
+    )
 
 
 def validate_scores(
@@ -353,6 +656,7 @@ def validate_scores(
     query_weight_pad_count: int,
     pad_count: int,
     weight_pad_count: int,
+    retrained_dir: Sequence[str] = (),
 ):
     """Validate attribution scores via leave-subset-out retraining.
 
@@ -405,6 +709,7 @@ def validate_scores(
             num_queries=num_queries,
             pad_count=pad_count,
             weight_pad_count=weight_pad_count,
+            retrained_dir=retrained_dir,
         )
         return
 
@@ -765,69 +1070,16 @@ def evaluate_retrained(
             model, query_stream, query_n, run_cfg.grad_accum_steps
         )[:num_real_query_docs].cpu()
 
-    def compute_bank_losses(
-        models_root: Path,
-    ) -> tuple[float, torch.Tensor, torch.Tensor]:
-        """Evaluate every banked model, returning baseline + per-subset losses.
-
-        ``per_subset`` is ``[num_subsets, num_real_query_docs]`` for multi-query
-        or ``[num_subsets]`` for single-query. The bank's no-leave-out model
-        (``retrained/base``) gives the baseline; absent it the baseline stays 0
-        (correlation-safe).
-        """
-        base_dir = models_root / "base"
-        base_scalar = 0.0
-        base_per_doc = torch.zeros(num_real_query_docs)
-        if base_dir.exists():
-            base = _load_banked_model(run_cfg, str(base_dir), device)
-            if multi_query:
-                base_per_doc = query_losses_per_doc(base)
-            else:
-                base_scalar = query_loss(base)
-            del base
-
-        if multi_query:
-            per_subset = torch.zeros(len(subsets), num_real_query_docs)
-        else:
-            per_subset = torch.zeros(len(subsets))
-        for i in tqdm(range(len(subsets)), desc="Evaluating bank"):
-            model = _load_banked_model(
-                run_cfg, str(models_root / f"subset_{i}"), device
-            )
-            if multi_query:
-                per_subset[i] = query_losses_per_doc(model)
-            else:
-                per_subset[i] = query_loss(model)
-            del model
-        return base_scalar, base_per_doc, per_subset
-
-    # Cache per-subset query losses for re-use with different attribution methods.
-    per_dir = []
-    for d in dirs:
-        cache_path = (
-            d
-            / "query_loss_cache"
-            / bank_loss_cache_key(run_cfg, multi_query, len(subsets))
-        )
-        if cache_path.exists():
-            print(f"Reusing cached bank losses from {cache_path}")
-            blob = torch.load(cache_path, map_location="cpu")
-        else:
-            base_scalar, base_per_doc, per_subset = compute_bank_losses(d / "retrained")
-            blob = {
-                "baseline": base_scalar,
-                "baseline_per_doc": base_per_doc,
-                "per_subset": per_subset,
-            }
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            torch.save(blob, cache_path)
-            print(f"Saved bank losses to {cache_path}")
-        per_dir.append(blob)
-
-    baseline = float(np.mean([b["baseline"] for b in per_dir]))
-    baseline_per_doc = torch.stack([b["baseline_per_doc"] for b in per_dir]).mean(0)
-    per_subset_losses = torch.stack([b["per_subset"] for b in per_dir]).mean(0)
-
+    baseline, baseline_per_doc, per_subset_losses = load_bank_losses(
+        run_cfg,
+        dirs,
+        len(subsets),
+        multi_query=multi_query,
+        num_real_query_docs=num_real_query_docs,
+        device=device,
+        query_loss=query_loss,
+        query_losses_per_doc=query_losses_per_doc,
+    )
     if multi_query:
         print(f"Baseline per-query losses (no leave-out): {baseline_per_doc.tolist()}")
     else:

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -1,7 +1,15 @@
+import csv
+import json
+
 import pytest
 import torch
 
-from bergson.validate import _select_filter_slice
+from bergson.validate import (
+    _baseline_subsets,
+    _report_filter_baseline,
+    _select_filter_slice,
+    load_baseline_bank_subsets,
+)
 
 # Scores follow the load_scores_loss_signed convention: negative reduces query
 # loss, so doc 0 is the strongest proponent and doc 4 the strongest detractor.
@@ -50,3 +58,181 @@ def test_slice_size_clamped_to_pool():
     """k larger than the pool must not error or over-select."""
     got = _select_filter_slice(SCORES, ALL, 0, 99, "filter-proponents")
     assert len(got) == 5
+
+
+def _cfg(tmp_path, **kwargs):
+    from bergson.magic.config import MagicConfig
+
+    return MagicConfig(run_path=str(tmp_path / "run"), model="gpt2", **kwargs)
+
+
+def _bank(tmp_path, subsets, name="bank", base=True, **cfg_overrides):
+    """A bank directory holding only what the baseline checks read."""
+    from bergson.config.config_io import save_run_config
+
+    root = tmp_path / name
+    if base:
+        (root / "retrained" / "base").mkdir(parents=True)
+    root.mkdir(parents=True, exist_ok=True)
+    with open(root / "subsets.json", "w") as f:
+        json.dump(subsets, f)
+    save_run_config(_cfg(tmp_path, **cfg_overrides), root)
+    return root
+
+
+def test_baseline_subsets_are_random_removals_of_the_filtered_size(tmp_path):
+    cfg = _cfg(tmp_path, num_subsets=4, seed=0)
+    subsets = _baseline_subsets(cfg, torch.arange(50), k=7)
+    assert [len(s) for s in subsets] == [7, 7, 7, 7]
+    assert all(len(set(s.tolist())) == 7 for s in subsets)  # no repeats within
+    assert len({tuple(sorted(s.tolist())) for s in subsets}) > 1  # not identical
+
+
+def test_baseline_subsets_reuse_a_saved_draw(tmp_path):
+    """An LDS run's subsets.json pairs the baseline with its draws."""
+    path = tmp_path / "subsets.json"
+    with open(path, "w") as f:
+        json.dump([[0, 1], [2, 3], [4, 5]], f)
+
+    cfg = _cfg(tmp_path, num_subsets=2, subsets=str(path))
+    subsets = _baseline_subsets(cfg, torch.arange(6), k=2)
+    assert [s.tolist() for s in subsets] == [[0, 1], [2, 3]]  # truncated to 2
+
+
+def test_baseline_subsets_reject_a_mismatched_saved_draw(tmp_path):
+    path = tmp_path / "subsets.json"
+    with open(path, "w") as f:
+        json.dump([[0, 1], [2, 3]], f)
+
+    cfg = _cfg(tmp_path, num_subsets=2, subsets=str(path))
+    with pytest.raises(ValueError, match="not a comparable baseline"):
+        _baseline_subsets(cfg, torch.arange(6), k=5)
+
+
+def test_bank_of_the_same_removal_size_is_accepted(tmp_path):
+    """The LDS default partitions the pool, so chunk sizes differ by one."""
+    root = _bank(tmp_path, [[0, 1, 2], [3, 4], [5, 6]])
+    subsets = load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+    assert [s.tolist() for s in subsets] == [[0, 1, 2], [3, 4], [5, 6]]
+
+
+def test_bank_of_a_different_removal_size_is_rejected(tmp_path):
+    root = _bank(tmp_path, [[0, 1], [2, 3]])
+    with pytest.raises(ValueError, match="not a comparable baseline"):
+        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=10)
+
+
+def test_bank_without_a_base_model_is_rejected(tmp_path):
+    """Loss changes are measured against the bank's own no-leave-out model."""
+    root = _bank(tmp_path, [[0, 1]], base=False)
+    with pytest.raises(FileNotFoundError, match="retrained/base"):
+        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+
+
+@pytest.mark.parametrize(
+    "field,value", [("subset_weight", 0.5), ("exclude_zero_scores", True)]
+)
+def test_bank_trained_with_different_settings_is_rejected(tmp_path, field, value):
+    root = _bank(tmp_path, [[0, 1]], **{field: value})
+    with pytest.raises(ValueError, match=field):
+        load_baseline_bank_subsets(_cfg(tmp_path), [root], k=2)
+
+
+def test_averaged_banks_must_share_their_removal_sets(tmp_path):
+    a = _bank(tmp_path, [[0, 1]], name="a")
+    b = _bank(tmp_path, [[2, 3]], name="b")
+    with pytest.raises(ValueError, match="different removal sets"):
+        load_baseline_bank_subsets(_cfg(tmp_path), [a, b], k=2)
+
+
+def test_filter_is_ranked_against_the_random_draws(tmp_path):
+    """Rank 1 is the largest loss increase; the filter beats 2 of 3 draws."""
+    _report_filter_baseline(
+        str(tmp_path),
+        "filter-proponents",
+        torch.tensor([0.5]),
+        torch.tensor([[0.1], [0.2], [0.9]]),
+        k=2,
+        source="retrained here",
+    )
+    with open(tmp_path / "filter_summary.csv") as f:
+        row = list(csv.DictReader(f))[0]
+    assert int(row["rank"]) == 2
+    assert int(row["random_n"]) == 3
+    assert float(row["filter_change"]) == pytest.approx(0.5)
+    assert float(row["random_mean"]) == pytest.approx(0.4)
+
+
+def _e2e_shared(tmp_path) -> dict:
+    from datasets import Dataset
+
+    train = Dataset.from_dict({"text": [f"the cat sat on mat {i}" for i in range(8)]})
+    train.save_to_disk(tmp_path / "train")
+    query = Dataset.from_dict({"text": ["a dog ran", "birds fly high"]})
+    query.save_to_disk(tmp_path / "query")
+    return {
+        "model": "trl-internal-testing/tiny-Phi3ForCausalLM",
+        "batch_size": 2,
+        "num_epochs": 1,
+        "num_subsets": 2,
+        "subset_fraction": 0.25,
+        "data": {"dataset": str(tmp_path / "train")},
+        "query": {"dataset": str(tmp_path / "query")},
+        "distributed": {"nproc_per_node": 1},
+    }
+
+
+def test_a_filter_run_compares_against_random_filters(tmp_path):
+    from bergson.cli.commands import Magic, Validate
+
+    shared = _e2e_shared(tmp_path)
+    Magic.from_dict(shared | {"run_path": str(tmp_path / "magic")}).execute()
+    run = tmp_path / "filter"
+    Validate.from_dict(
+        shared
+        | {
+            "run_path": str(run),
+            "scores": str(tmp_path / "magic" / "scores"),
+            "method": "filter-proponents",
+        }
+    ).execute()
+
+    with open(run / "random_filter.csv") as f:
+        random_rows = list(csv.DictReader(f))
+    assert {r["subset"] for r in random_rows} == {"0", "1"}
+    with open(run / "filter_summary.csv") as f:
+        summary = list(csv.DictReader(f))
+    assert [r["query"] for r in summary] == ["0", "1"]
+    assert all(1 <= int(r["rank"]) <= 3 for r in summary)
+
+
+def test_a_bank_gives_the_same_random_arm_as_retraining_it(tmp_path):
+    """The bank's models are the retrains, so both arms must agree."""
+    from bergson.cli.commands import Magic, Validate
+
+    shared = _e2e_shared(tmp_path)
+    Magic.from_dict(shared | {"run_path": str(tmp_path / "magic")}).execute()
+    scores = str(tmp_path / "magic" / "scores")
+
+    bank = tmp_path / "bank"
+    Validate.from_dict(
+        shared | {"run_path": str(bank), "scores": scores, "save_models": True}
+    ).execute()
+
+    def random_changes(name, **overrides) -> list[str]:
+        Validate.from_dict(
+            shared
+            | {
+                "run_path": str(tmp_path / name),
+                "scores": scores,
+                "method": "filter-proponents",
+                "subsets": str(bank / "subsets.json"),
+            }
+            | overrides
+        ).execute()
+        with open(tmp_path / name / "random_filter.csv") as f:
+            return [r["loss_change"] for r in csv.DictReader(f)]
+
+    here = random_changes("here")
+    from_bank = random_changes("from_bank", retrained_dir=str(bank))
+    assert [round(float(x), 5) for x in from_bank] == [round(float(x), 5) for x in here]

--- a/tests/test_validate_routing.py
+++ b/tests/test_validate_routing.py
@@ -1,44 +1,85 @@
 """Which phases of ``run_magic`` -- train, score, validate -- a command runs."""
 
+import csv
+
 import pytest
+from datasets import Dataset
 
 from bergson.cli.commands import Magic, Validate
+from bergson.config.config_io import read_config
 from bergson.magic.cli import run_magic
 
+MODEL = "trl-internal-testing/tiny-Phi3ForCausalLM"
 
-def _calls(monkeypatch) -> list[dict]:
-    calls = []
-    monkeypatch.setattr(
-        "bergson.cli.commands.run_magic", lambda cfg, **kw: calls.append(kw)
+
+def _datasets(tmp_path) -> dict:
+    train = Dataset.from_dict({"text": [f"the cat sat on mat {i}" for i in range(8)]})
+    train.save_to_disk(tmp_path / "train")
+    query = Dataset.from_dict({"text": ["a dog ran", "birds fly high"]})
+    query.save_to_disk(tmp_path / "query")
+    return {
+        "model": MODEL,
+        "batch_size": 2,
+        "num_epochs": 1,
+        "num_subsets": 2,
+        "data": {"dataset": str(tmp_path / "train")},
+        "query": {"dataset": str(tmp_path / "query")},
+        "distributed": {"nproc_per_node": 1},
+    }
+
+
+def test_magic_scores_and_stops(tmp_path):
+    run = tmp_path / "run"
+    Magic.from_dict(_datasets(tmp_path) | {"run_path": str(run)}).execute()
+
+    assert (run / "scores").exists()
+    assert not (run / "validation.csv").exists()
+    assert not (run / "subsets.json").exists()
+
+
+def test_magic_validates_the_scores_it_wrote(tmp_path):
+    run = tmp_path / "run"
+    Magic.from_dict(
+        _datasets(tmp_path)
+        | {"run_path": str(run), "skip_validation": False, "save_models": True}
+    ).execute()
+
+    with open(run / "validation.csv") as f:
+        subsets = {row["subset"] for row in csv.DictReader(f)}
+    assert subsets == {"0", "1"}
+    assert sorted(p.name for p in (run / "retrained").iterdir()) == [
+        "base",
+        "subset_0",
+        "subset_1",
+    ]
+
+    # The validation step saves its own config over the run's.
+    (step,) = read_config(run)["steps"]
+    assert set(step) == {"magic"}
+
+
+def test_a_baseline_model_gives_the_same_baseline_as_training_one(tmp_path):
+    shared = _datasets(tmp_path)
+    magic_run = tmp_path / "magic"
+    Magic.from_dict(
+        shared | {"run_path": str(magic_run), "save_models": True}
+    ).execute()
+
+    def baselines(name, **overrides) -> list[str]:
+        Validate.from_dict(
+            shared
+            | {"run_path": str(tmp_path / name), "scores": str(magic_run / "scores")}
+            | overrides
+        ).execute()
+        with open(tmp_path / name / "summary.csv") as f:
+            return [row["baseline_loss"] for row in csv.DictReader(f)]
+
+    trained_here = baselines("trained_here")
+    from_model = baselines(
+        "from_model", baseline_model=str(magic_run / "retrained" / "base")
     )
-    return calls
-
-
-def test_magic_scores_and_stops(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Magic.from_dict({"run_path": str(tmp_path), "model": "gpt2"}).execute()
-    assert calls == [{}]
-
-
-def test_validate_runs_the_validation_phase(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Validate.from_dict(
-        {"run_path": str(tmp_path), "model": "gpt2", "scores": "s"}
-    ).execute()
-    assert calls == [{"score_path": "s", "validate": True, "baseline_model": ""}]
-
-
-def test_validate_passes_the_trained_model_through(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Validate.from_dict(
-        {
-            "run_path": str(tmp_path),
-            "model": "gpt2",
-            "scores": "s",
-            "baseline_model": "runs/magic/model",
-        }
-    ).execute()
-    assert calls[0]["baseline_model"] == "runs/magic/model"
+    assert from_model == trained_here
+    assert not (tmp_path / "from_model" / "checkpoints").exists()
 
 
 def test_validate_reads_a_bank_without_training(tmp_path, monkeypatch):
@@ -53,74 +94,9 @@ def test_validate_reads_a_bank_without_training(tmp_path, monkeypatch):
     assert seen["dirs"] == ["a", "b"]
 
 
-def test_magic_dispatches_a_validation_of_its_own_scores(tmp_path, monkeypatch):
-    calls = _calls(monkeypatch)
-    Magic.from_dict(
-        {"run_path": str(tmp_path), "model": "gpt2", "skip_validation": False}
-    ).execute()
-    assert calls == [
-        {},
-        {
-            "score_path": str(tmp_path / "scores"),
-            "validate": True,
-            "baseline_model": "",
-        },
-    ]
-
-
-def test_a_chained_validation_reuses_the_trained_model(tmp_path, monkeypatch):
-    (tmp_path / "retrained" / "base").mkdir(parents=True)
-    calls = _calls(monkeypatch)
-    Magic.from_dict(
-        {"run_path": str(tmp_path), "model": "gpt2", "skip_validation": False}
-    ).execute()
-    assert calls[1]["baseline_model"] == str(tmp_path / "retrained" / "base")
-
-
-def test_a_chained_validation_keeps_the_training_config(tmp_path, monkeypatch):
-    """Both phases must train the same model for the baseline to transfer."""
-    seen = []
-    monkeypatch.setattr(
-        "bergson.cli.commands.run_magic", lambda cfg, **kw: seen.append(cfg)
-    )
-    Magic.from_dict(
-        {
-            "run_path": str(tmp_path),
-            "model": "gpt2",
-            "skip_validation": False,
-            "num_subsets": 7,
-            "num_epochs": 3,
-            "seed": 11,
-        }
-    ).execute()
-    magic_cfg, validate_cfg = seen
-    assert validate_cfg.num_subsets == 7
-    assert (validate_cfg.num_epochs, validate_cfg.seed) == (
-        magic_cfg.num_epochs,
-        magic_cfg.seed,
-    )
-
-
-def test_a_chained_validation_does_not_wipe_the_scores(tmp_path, monkeypatch):
-    """resume keeps run_magic's overwrite guard off the magic step's output."""
-    calls = []
-    monkeypatch.setattr(
-        "bergson.cli.commands.run_magic", lambda cfg, **kw: calls.append(cfg)
-    )
-    Magic.from_dict(
-        {
-            "run_path": str(tmp_path),
-            "model": "gpt2",
-            "skip_validation": False,
-            "overwrite": True,
-        }
-    ).execute()
-    assert calls[1].resume is True
-
-
 def test_validation_needs_a_validation_config(tmp_path):
     from bergson.config.config import TrainingConfig
 
-    cfg = TrainingConfig(run_path=str(tmp_path), model="gpt2")
+    cfg = TrainingConfig(run_path=str(tmp_path), model=MODEL)
     with pytest.raises(TypeError, match="ValidationConfig"):
         run_magic(cfg, validate=True)


### PR DESCRIPTION
Stacked on #430 — review that first; this branch contains its commits.

A `filter-proponents` loss change means nothing on its own: removing any 1% of
the training data moves the query loss. Without a reference the number is
unreadable, and every use of it so far has compared it against a random filter
run by hand.

The filter arm now runs alongside `num_subsets` random removals of the same
size, and reports the filter's rank among them per query:

```
filter-proponents: mean loss change 0.001111 over 3 queries (10 of 200 docs removed per query, 5.000%)
Random baseline (4 subsets of 10 docs, retrained here): mean loss change 0.003895
Query 0: filter-proponents -0.010040  random -0.000756 +/- 0.014530  rank 4/5
Query 1: filter-proponents +0.002502  random +0.004464 +/- 0.015796  rank 4/5
Query 2: filter-proponents +0.010871  random +0.007976 +/- 0.013704  rank 4/5
```

Rank 1 is the largest loss increase. With four or five draws a rank is what the
sample supports; the mean and sd are there too, but no p-value is claimed.
`random_filter.csv` holds the per-draw losses and `filter_summary.csv` the
comparison.

### Reusing a bank instead of retraining the arm

The random arm ignores the scores, so one retrain serves every query — and an
LDS bank already holds exactly those retrains. `retrained_dir` therefore
supplies the random arm for a `filter-*` run, where it previously shortcut
`lds` alone. No new flag: the same "read it from the bank" idiom, applied to
the one arm a bank can serve. The filter arm is score-dependent and always
retrains.

`num_subsets: 0` with no bank skips the arm.

A bank drawn at a different removal size, `subset_weight`, or
`exclude_zero_scores` pool is not a comparable baseline, so a mismatch raises
rather than reporting an apples-to-oranges number. With `subset_fraction: 0`
the filter's size is `1/num_subsets` of the pool — the LDS chunk size — so a
default bank lines up as it is. `subsets:` reuses an LDS run's draws when the
models were not saved.

The bank's per-subset query losses come from the same cache
`evaluate_retrained` fills, lifted out as `load_bank_losses` so both callers
share it.

### Testing

Unit tests for the draws, the bank rejections and the ranking; two end-to-end
runs on a tiny model, one asserting the arm's outputs and one asserting that
reading the arm from a bank reproduces retraining the same subsets locally. On
a 200-doc gpt2 run the two agree to 1e-6.

`tests/test_validate_routing.py` also picks up the behaviour-based rewrite that
missed the #435 merge — the previous tests asserted the kwargs `Validate`
passes to `run_magic`, which broke on the new argument and asserted nothing
about what the commands do.
