### PR TITLE
Fix incompatible query aggregation for token attribution in hessian_pipeline (mirroring trackstar)

### DIFF
--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -88,6 +88,19 @@ def hessian_pipeline(
             query_cfg.run_path = query_path
             query_cfg.data = hessian_pipeline_cfg.query
             query_cfg.projection_dim = 0
+
+            # Query aggregation is not compatible with query-side token
+            # attribution: aggregating collapses per-token query gradients
+            # into a single target gradient, so a per-token query index is
+            # invalid. Build a per-example query instead. Mirrors the same
+            # guard in cli/trackstar.py's query build step.
+            if aggregation != "none" and query_cfg.attribute_tokens:
+                print(
+                    "Query aggregation is not compatible with query-side "
+                    "token attribution; building a per-example query instead."
+                )
+                query_cfg.attribute_tokens = False
+
             _validate(query_cfg)
 
             query_preprocess_cfg = PreprocessConfig(aggregation=aggregation)


### PR DESCRIPTION
## Problem

`attribute_tokens` lives on `IndexConfig` and is inherited via
`deepcopy(index_cfg)` by both the query build (step 1) and the score/training
build (step 4) in `hessian_pipeline`. This makes it easy to hit an invalid
combination: setting `index_cfg.attribute_tokens = True` for token-level
attribution on the training/score side, while using
`hessian_pipeline_cfg.query_aggregation != "none"` (e.g. `"mean"`) to collapse
the query into a single target gradient — a separate, independent aggregation
setting from the score side's `preprocess_cfg.aggregation`.

Aggregating the query collapses per-token query gradients into one target
gradient, so a per-token query index is invalid in that case, even though
per-token attribution on the score side is still valid and desired.

## Fix

In step 1 (query build), if `query_aggregation != "none"` and
`query_cfg.attribute_tokens` is set, force `attribute_tokens = False` on the
query build only (with a warning). This only mutates the `deepcopy`d
`query_cfg`, so the score-side `index_cfg`/`score_index_cfg` used in step 4
is untouched and keeps token-level attribution. Mirrors the existing guard in
`cli/trackstar.py`'s query build step.

## Testing

Manual review — this mirrors the existing, already-tested guard in
`cli/trackstar.py`.
