### PR TITLE
Add ckpt_avg_k: average MAGIC query gradients over the last k checkpoints

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -449,6 +449,7 @@ class MetasmoothnessConfig(TrainingConfig):
 @dataclass
 class ValidationConfig(TrainingConfig, ABC):
     """Config for leave-k-out validation of attribution scores."""
+
     ckpt_avg_k: int = 1
     """Average the query gradient over the last ``k`` trajectory checkpoints.
 
@@ -462,7 +463,6 @@ class ValidationConfig(TrainingConfig, ABC):
     steps. Use ``save_mode="interval"`` with a small ``save_interval`` if
     closely-spaced states are wanted.
     """
-
 
     query: DataConfig = field(
         default_factory=lambda: DataConfig(split="train"),

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -449,6 +449,20 @@ class MetasmoothnessConfig(TrainingConfig):
 @dataclass
 class ValidationConfig(TrainingConfig, ABC):
     """Config for leave-k-out validation of attribution scores."""
+    ckpt_avg_k: int = 1
+    """Average the query gradient over the last ``k`` trajectory checkpoints.
+
+    ``1`` (default) uses the final state only and is bit-identical to the
+    previous behaviour. Larger ``k`` averages the query gradient computed at
+    each of the last ``k`` saved checkpoints.
+
+    NOTE the checkpoints averaged over are the ones the trainer actually
+    SAVED, which under ``save_mode="log"`` are exponentially spaced -- the
+    "last 4" may span a wide stretch of training rather than four adjacent
+    steps. Use ``save_mode="interval"`` with a small ``save_interval`` if
+    closely-spaced states are wanted.
+    """
+
 
     query: DataConfig = field(
         default_factory=lambda: DataConfig(split="train"),

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -451,18 +451,7 @@ class ValidationConfig(TrainingConfig, ABC):
     """Config for leave-k-out validation of attribution scores."""
 
     ckpt_avg_k: int = 1
-    """Average the query gradient over the last ``k`` trajectory checkpoints.
-
-    ``1`` (default) uses the final state only and is bit-identical to the
-    previous behaviour. Larger ``k`` averages the query gradient computed at
-    each of the last ``k`` saved checkpoints.
-
-    NOTE the checkpoints averaged over are the ones the trainer actually
-    SAVED, which under ``save_mode="log"`` are exponentially spaced -- the
-    "last 4" may span a wide stretch of training rather than four adjacent
-    steps. Use ``save_mode="interval"`` with a small ``save_interval`` if
-    closely-spaced states are wanted.
-    """
+    """Average the query gradient over the last ``k`` saved trajectory checkpoints."""
 
     query: DataConfig = field(
         default_factory=lambda: DataConfig(split="train"),

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -70,9 +70,9 @@ def compute_query_gradients(
     """Compute reduced query gradients over the query dataset.
 
     Iterates over the query stream, computing per-batch parameter gradients
-    and reducing them (mean or sum) into a single gradient dict. If
-    ``ckpt_avg_k > 1``, the result is averaged over the last ``ckpt_avg_k``
-    checkpoints in ``ckpts_path`` and ``fwd_state`` is left unchanged.
+    and reducing them into a single gradient dict. If ``ckpt_avg_k > 1``, the
+    result is averaged over the last ``ckpt_avg_k`` checkpoints in
+    ``ckpts_path``.
     """
     if ckpt_avg_k > 1:
         assert ckpts_path is not None

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -1,7 +1,6 @@
 import gc
 import json
 import os
-import re
 import shutil
 import time
 from collections.abc import Sequence
@@ -32,7 +31,11 @@ from transformers.utils.logging import (
 
 from ..config.config import TrainingConfig, ValidationConfig
 from ..config.config_io import save_run_config
-from ..data import compute_num_token_grads, load_scores_loss_signed
+from ..data import (
+    compute_num_token_grads,
+    load_scores_loss_signed,
+    sorted_checkpoints,
+)
 from ..distributed import launch_distributed_run
 from ..score.score_writer import save_sequence_scores, save_token_scores
 from ..utils.load_from_optimizer import (
@@ -54,74 +57,6 @@ from .grad_accum import accumulate_grads
 from .trainer import BackwardState, TrainerState, prepare_trainer, write_lr_history
 
 
-def _last_k_checkpoint_paths(ckpts_path: str, k: int) -> list[str]:
-    """Return up to ``k`` highest-step ``step_<N>.ckpt`` paths, oldest first."""
-    if not os.path.isdir(ckpts_path):
-        return []
-    found: list[tuple[int, str]] = []
-    for name in os.listdir(ckpts_path):
-        m = re.match(r"step_(\d+)\.ckpt$", name)
-        if m:
-            found.append((int(m.group(1)), os.path.join(ckpts_path, name)))
-    found.sort()
-    return [path for _, path in found[-k:]]
-
-
-def compute_query_gradients_averaged(
-    fwd_state: TrainerState,
-    model: torch.nn.Module,
-    query_stream: DataStream,
-    ckpts_path: str,
-    ckpt_avg_k: int = 1,
-    method: str = "mean",
-    fsdp: bool = False,
-    grad_accum_steps: int = 1,
-) -> tuple[dict[str, torch.Tensor], float]:
-    """Query gradients averaged over the last ``ckpt_avg_k`` saved checkpoints.
-
-    ``ckpt_avg_k <= 1`` delegates to :func:`compute_query_gradients` unchanged,
-    so the default path is bit-identical to the previous behaviour.
-    """
-    if ckpt_avg_k <= 1:
-        return compute_query_gradients(
-            fwd_state, model, query_stream, method, fsdp, grad_accum_steps
-        )
-
-    paths = _last_k_checkpoint_paths(ckpts_path, ckpt_avg_k)
-    if len(paths) < ckpt_avg_k:
-        raise RuntimeError(
-            f"ckpt_avg_k={ckpt_avg_k} needs {ckpt_avg_k} saved checkpoints under "
-            f"{ckpts_path!r}, found {len(paths)}. Note save_mode='log' keeps only "
-            "O(log steps) checkpoints; use save_mode='interval' with a small "
-            "save_interval to keep enough."
-        )
-
-    # Snapshot the final state: the reverse pass downstream needs it, not
-    # whichever checkpoint we happen to load last.
-    saved = fwd_state.to("cpu")
-    accum: dict[str, torch.Tensor] | None = None
-    loss_accum = 0.0
-    try:
-        for path in paths:
-            fwd_state.load(path)
-            grads, loss = compute_query_gradients(
-                fwd_state, model, query_stream, method, fsdp, grad_accum_steps
-            )
-            if accum is None:
-                accum = {k: g.clone() for k, g in grads.items()}
-            else:
-                for k, g in grads.items():
-                    accum[k] += g
-            loss_accum += loss
-    finally:
-        fwd_state.copy_(saved)
-
-    assert accum is not None
-    for k in accum:
-        accum[k] /= len(paths)
-    return accum, loss_accum / len(paths)
-
-
 def compute_query_gradients(
     fwd_state: TrainerState,
     model: torch.nn.Module,
@@ -129,12 +64,40 @@ def compute_query_gradients(
     method: str = "mean",
     fsdp: bool = False,
     grad_accum_steps: int = 1,
+    ckpts_path: str | None = None,
+    ckpt_avg_k: int = 1,
 ) -> tuple[dict[str, torch.Tensor], float]:
     """Compute reduced query gradients over the query dataset.
 
     Iterates over the query stream, computing per-batch parameter gradients
-    and reducing them (mean or sum) into a single gradient dict.
+    and reducing them (mean or sum) into a single gradient dict. If
+    ``ckpt_avg_k > 1``, the result is averaged over the last ``ckpt_avg_k``
+    checkpoints in ``ckpts_path`` and ``fwd_state`` is left unchanged.
     """
+    if ckpt_avg_k > 1:
+        assert ckpts_path is not None
+        paths = [p for _, p in sorted_checkpoints(ckpts_path)[-ckpt_avg_k:]]
+        if len(paths) < ckpt_avg_k:
+            raise ValueError(
+                f"ckpt_avg_k={ckpt_avg_k} but only {len(paths)} checkpoints "
+                f"saved under {ckpts_path}"
+            )
+
+        final = fwd_state.to("cpu")
+        grads, loss = {}, 0.0
+        try:
+            for path in paths:
+                fwd_state.load(path)
+                g, l = compute_query_gradients(
+                    fwd_state, model, query_stream, method, fsdp, grad_accum_steps
+                )
+                grads = {k: grads[k] + v for k, v in g.items()} if grads else g
+                loss += l
+        finally:
+            fwd_state.copy_(final)
+
+        return {k: v / len(paths) for k, v in grads.items()}, loss / len(paths)
+
     grad_accum: dict[str, torch.Tensor] | None = None
     loss_accum = 0.0
     denom = 0
@@ -598,15 +561,15 @@ def worker(
         # query_stream.weights is always 1D (weight_shape=(num_query_docs,))
         query_stream.weights.data[-query_weight_pad_count:] = 0.0
 
-    query_grads, baseline = compute_query_gradients_averaged(
+    query_grads, baseline = compute_query_gradients(
         fwd_state,
         model,
         query_stream,
-        ckpts_path,
-        getattr(run_cfg, "ckpt_avg_k", 1),
         run_cfg.query_method,
         run_cfg.fsdp,
         run_cfg.grad_accum_steps,
+        ckpts_path,
+        run_cfg.ckpt_avg_k,
     )
 
     multi_query = False

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -1,6 +1,7 @@
 import gc
 import json
 import os
+import re
 import shutil
 import time
 from collections.abc import Sequence
@@ -51,6 +52,74 @@ from .config import MagicConfig
 from .data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
 from .grad_accum import accumulate_grads
 from .trainer import BackwardState, TrainerState, prepare_trainer, write_lr_history
+
+
+def _last_k_checkpoint_paths(ckpts_path: str, k: int) -> list[str]:
+    """Return up to ``k`` highest-step ``step_<N>.ckpt`` paths, oldest first."""
+    if not os.path.isdir(ckpts_path):
+        return []
+    found: list[tuple[int, str]] = []
+    for name in os.listdir(ckpts_path):
+        m = re.match(r"step_(\d+)\.ckpt$", name)
+        if m:
+            found.append((int(m.group(1)), os.path.join(ckpts_path, name)))
+    found.sort()
+    return [path for _, path in found[-k:]]
+
+
+def compute_query_gradients_averaged(
+    fwd_state: TrainerState,
+    model: torch.nn.Module,
+    query_stream: DataStream,
+    ckpts_path: str,
+    ckpt_avg_k: int = 1,
+    method: str = "mean",
+    fsdp: bool = False,
+    grad_accum_steps: int = 1,
+) -> tuple[dict[str, torch.Tensor], float]:
+    """Query gradients averaged over the last ``ckpt_avg_k`` saved checkpoints.
+
+    ``ckpt_avg_k <= 1`` delegates to :func:`compute_query_gradients` unchanged,
+    so the default path is bit-identical to the previous behaviour.
+    """
+    if ckpt_avg_k <= 1:
+        return compute_query_gradients(
+            fwd_state, model, query_stream, method, fsdp, grad_accum_steps
+        )
+
+    paths = _last_k_checkpoint_paths(ckpts_path, ckpt_avg_k)
+    if len(paths) < ckpt_avg_k:
+        raise RuntimeError(
+            f"ckpt_avg_k={ckpt_avg_k} needs {ckpt_avg_k} saved checkpoints under "
+            f"{ckpts_path!r}, found {len(paths)}. Note save_mode='log' keeps only "
+            "O(log steps) checkpoints; use save_mode='interval' with a small "
+            "save_interval to keep enough."
+        )
+
+    # Snapshot the final state: the reverse pass downstream needs it, not
+    # whichever checkpoint we happen to load last.
+    saved = fwd_state.to("cpu")
+    accum: dict[str, torch.Tensor] | None = None
+    loss_accum = 0.0
+    try:
+        for path in paths:
+            fwd_state.load(path)
+            grads, loss = compute_query_gradients(
+                fwd_state, model, query_stream, method, fsdp, grad_accum_steps
+            )
+            if accum is None:
+                accum = {k: g.clone() for k, g in grads.items()}
+            else:
+                for k, g in grads.items():
+                    accum[k] += g
+            loss_accum += loss
+    finally:
+        fwd_state.copy_(saved)
+
+    assert accum is not None
+    for k in accum:
+        accum[k] /= len(paths)
+    return accum, loss_accum / len(paths)
 
 
 def compute_query_gradients(
@@ -529,10 +598,12 @@ def worker(
         # query_stream.weights is always 1D (weight_shape=(num_query_docs,))
         query_stream.weights.data[-query_weight_pad_count:] = 0.0
 
-    query_grads, baseline = compute_query_gradients(
+    query_grads, baseline = compute_query_gradients_averaged(
         fwd_state,
         model,
         query_stream,
+        ckpts_path,
+        getattr(run_cfg, "ckpt_avg_k", 1),
         run_cfg.query_method,
         run_cfg.fsdp,
         run_cfg.grad_accum_steps,

--- a/tests/test_ckpt_avg_query_grads.py
+++ b/tests/test_ckpt_avg_query_grads.py
@@ -1,67 +1,48 @@
-"""Tests for query-gradient averaging over the last k trajectory checkpoints."""
-
 import os
 
 import pytest
 
-from bergson.magic.cli import _last_k_checkpoint_paths, compute_query_gradients_averaged
+import bergson.magic.cli as cli
 
 
-def _make_ckpts(root, steps):
-    for n in steps:
-        os.makedirs(os.path.join(root, f"step_{n}.ckpt"))
-    # Non-checkpoint entries in the same directory must be ignored.
-    open(os.path.join(root, "log_history.json"), "w").close()
-    os.makedirs(os.path.join(root, "not_a_step"))
+class FakeState:
+    def __init__(self):
+        self.step = "final"
+        self.log = []
+
+    def load(self, path):
+        self.step = os.path.basename(path)
+
+    def to(self, device):
+        return "snapshot"
+
+    def copy_(self, other):
+        self.log.append(other)
+        self.step = "final"
 
 
-def test_orders_numerically_not_lexically(tmp_path):
-    _make_ckpts(tmp_path, [2, 10, 40, 125])
-    got = [os.path.basename(p) for p in _last_k_checkpoint_paths(str(tmp_path), 3)]
-    # Lexical ordering would put step_40 last and drop step_125.
-    assert got == ["step_10.ckpt", "step_40.ckpt", "step_125.ckpt"]
+def test_averages_last_k_and_restores_state(tmp_path, monkeypatch):
+    for n in (2, 10, 40, 125):
+        os.makedirs(tmp_path / f"step_{n}.ckpt")
+    state = FakeState()
+    compute = cli.compute_query_gradients
+    steps = []
+
+    def fake(fwd_state, *args):
+        steps.append(fwd_state.step)
+        return {"w": len(steps)}, float(len(steps))
+
+    monkeypatch.setattr(cli, "compute_query_gradients", fake)
+    grads, loss = compute(state, None, None, ckpts_path=str(tmp_path), ckpt_avg_k=2)
+
+    assert steps == ["step_40.ckpt", "step_125.ckpt"]
+    assert grads == {"w": 1.5} and loss == 1.5
+    assert state.step == "final" and state.log == ["snapshot"]
 
 
-def test_returns_oldest_first(tmp_path):
-    _make_ckpts(tmp_path, [1, 2, 3])
-    got = [os.path.basename(p) for p in _last_k_checkpoint_paths(str(tmp_path), 3)]
-    assert got == ["step_1.ckpt", "step_2.ckpt", "step_3.ckpt"]
-
-
-def test_missing_directory_is_empty(tmp_path):
-    assert _last_k_checkpoint_paths(str(tmp_path / "nope"), 4) == []
-
-
-def test_k_greater_than_available_returns_all(tmp_path):
-    _make_ckpts(tmp_path, [5, 6])
-    assert len(_last_k_checkpoint_paths(str(tmp_path), 99)) == 2
-
-
-def test_k_of_one_delegates_without_touching_checkpoints():
-    """k<=1 must not read the checkpoint dir at all, so the default path is unchanged."""
-    sentinel_grads = {"w": object()}
-    calls = []
-
-    def fake_compute(fwd_state, model, query_stream, method, fsdp, grad_accum_steps):
-        calls.append((method, fsdp, grad_accum_steps))
-        return sentinel_grads, 1.25
-
-    import bergson.magic.cli as cli
-
-    orig = cli.compute_query_gradients
-    cli.compute_query_gradients = fake_compute
-    try:
-        grads, loss = compute_query_gradients_averaged(
-            None, None, None, "/definitely/does/not/exist", 1, "mean", False, 3
+def test_too_few_checkpoints_raises(tmp_path):
+    os.makedirs(tmp_path / "step_1.ckpt")
+    with pytest.raises(ValueError, match="only 1 checkpoints"):
+        cli.compute_query_gradients(
+            FakeState(), None, None, ckpts_path=str(tmp_path), ckpt_avg_k=2
         )
-    finally:
-        cli.compute_query_gradients = orig
-
-    assert grads is sentinel_grads and loss == 1.25
-    assert calls == [("mean", False, 3)]
-
-
-def test_too_few_checkpoints_raises_with_actionable_message(tmp_path):
-    _make_ckpts(tmp_path, [1, 2])
-    with pytest.raises(RuntimeError, match="needs 4 saved checkpoints"):
-        compute_query_gradients_averaged(None, None, None, str(tmp_path), 4)

--- a/tests/test_ckpt_avg_query_grads.py
+++ b/tests/test_ckpt_avg_query_grads.py
@@ -1,0 +1,67 @@
+"""Tests for query-gradient averaging over the last k trajectory checkpoints."""
+
+import os
+
+import pytest
+
+from bergson.magic.cli import _last_k_checkpoint_paths, compute_query_gradients_averaged
+
+
+def _make_ckpts(root, steps):
+    for n in steps:
+        os.makedirs(os.path.join(root, f"step_{n}.ckpt"))
+    # Non-checkpoint entries in the same directory must be ignored.
+    open(os.path.join(root, "log_history.json"), "w").close()
+    os.makedirs(os.path.join(root, "not_a_step"))
+
+
+def test_orders_numerically_not_lexically(tmp_path):
+    _make_ckpts(tmp_path, [2, 10, 40, 125])
+    got = [os.path.basename(p) for p in _last_k_checkpoint_paths(str(tmp_path), 3)]
+    # Lexical ordering would put step_40 last and drop step_125.
+    assert got == ["step_10.ckpt", "step_40.ckpt", "step_125.ckpt"]
+
+
+def test_returns_oldest_first(tmp_path):
+    _make_ckpts(tmp_path, [1, 2, 3])
+    got = [os.path.basename(p) for p in _last_k_checkpoint_paths(str(tmp_path), 3)]
+    assert got == ["step_1.ckpt", "step_2.ckpt", "step_3.ckpt"]
+
+
+def test_missing_directory_is_empty(tmp_path):
+    assert _last_k_checkpoint_paths(str(tmp_path / "nope"), 4) == []
+
+
+def test_k_greater_than_available_returns_all(tmp_path):
+    _make_ckpts(tmp_path, [5, 6])
+    assert len(_last_k_checkpoint_paths(str(tmp_path), 99)) == 2
+
+
+def test_k_of_one_delegates_without_touching_checkpoints():
+    """k<=1 must not read the checkpoint dir at all, so the default path is unchanged."""
+    sentinel_grads = {"w": object()}
+    calls = []
+
+    def fake_compute(fwd_state, model, query_stream, method, fsdp, grad_accum_steps):
+        calls.append((method, fsdp, grad_accum_steps))
+        return sentinel_grads, 1.25
+
+    import bergson.magic.cli as cli
+
+    orig = cli.compute_query_gradients
+    cli.compute_query_gradients = fake_compute
+    try:
+        grads, loss = compute_query_gradients_averaged(
+            None, None, None, "/definitely/does/not/exist", 1, "mean", False, 3
+        )
+    finally:
+        cli.compute_query_gradients = orig
+
+    assert grads is sentinel_grads and loss == 1.25
+    assert calls == [("mean", False, 3)]
+
+
+def test_too_few_checkpoints_raises_with_actionable_message(tmp_path):
+    _make_ckpts(tmp_path, [1, 2])
+    with pytest.raises(RuntimeError, match="needs 4 saved checkpoints"):
+        compute_query_gradients_averaged(None, None, None, str(tmp_path), 4)


### PR DESCRIPTION
Implements the query gradient eval averaging over final checkpoints

ckpt_avg_k defaults to 1 and delegates to compute_query_gradients unchanged, so the default path is unchanged.

For k>1 the final state is snapshotted with TrainerState.to('cpu') and restored via copy_() in a finally block, since the reverse pass downstream needs the final state rather than whichever checkpoint loaded last. 

Under save_mode='log' the last 4 checkpoints can span a wide stretch of training. save_mode='interval' can give more adjacent states.
