### PR TITLE
EK-FAC: average query gradients over model checkpoints

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -906,17 +906,11 @@ class HessianPipelineConfig:
     """Config for the Hessian-preconditioned influence pipeline."""
 
     query_model_paths: list[str] = field(default_factory=list)
-    """Average the query gradient over these model checkpoints.
+    """Average the query gradient over these model checkpoints; empty uses
+    ``index_cfg.model``.
 
-    Empty (default) builds the query gradient once from ``index_cfg.model``,
-    which is the previous behaviour exactly. With two or more paths the query
-    gradient is built once per checkpoint and averaged elementwise, giving the
-    EK-FAC counterpart of ``ValidationConfig.ckpt_avg_k``.
-
-    Paths must be loadable the same way ``index_cfg.model`` is (a HF model
-    directory or hub name). The MAGIC trainer writes its trajectory as
-    ``TrainerState`` dcp checkpoints, which are NOT that format -- export them
-    first rather than pointing this at ``checkpoints/step_*.ckpt``.
+    Entries load like ``index_cfg.model`` (HF directory or hub name), not the
+    ``TrainerState`` dcp checkpoints the MAGIC trainer writes.
     """
 
     query: DataConfig = field(default_factory=DataConfig)

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -905,6 +905,20 @@ class HessianConfig(Serializable):
 class HessianPipelineConfig:
     """Config for the Hessian-preconditioned influence pipeline."""
 
+    query_model_paths: list[str] = field(default_factory=list)
+    """Average the query gradient over these model checkpoints.
+
+    Empty (default) builds the query gradient once from ``index_cfg.model``,
+    which is the previous behaviour exactly. With two or more paths the query
+    gradient is built once per checkpoint and averaged elementwise, giving the
+    EK-FAC counterpart of ``ValidationConfig.ckpt_avg_k``.
+
+    Paths must be loadable the same way ``index_cfg.model`` is (a HF model
+    directory or hub name). The MAGIC trainer writes its trajectory as
+    ``TrainerState`` dcp checkpoints, which are NOT that format -- export them
+    first rather than pointing this at ``checkpoints/step_*.ckpt``.
+    """
+
     query: DataConfig = field(default_factory=DataConfig)
     """Query dataset specification."""
 

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -906,12 +906,8 @@ class HessianPipelineConfig:
     """Config for the Hessian-preconditioned influence pipeline."""
 
     query_model_paths: list[str] = field(default_factory=list)
-    """Average the query gradient over these model checkpoints; empty uses
-    ``index_cfg.model``.
-
-    Entries load like ``index_cfg.model`` (HF directory or hub name), not the
-    ``TrainerState`` dcp checkpoints the MAGIC trainer writes.
-    """
+    """Average the query gradient over these model checkpoints instead of the
+    index_cfg.model default."""
 
     query: DataConfig = field(default_factory=DataConfig)
     """Query dataset specification."""

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -503,18 +503,18 @@ def average_gradient_indices(sources: list[Path | str], dest: Path | str) -> Non
     a low-precision store dtype would discard exactly the differences being
     averaged.
     """
-    sources = [Path(s) for s in sources]
-    if not sources:
+    srcs = [Path(s) for s in sources]
+    if not srcs:
         raise ValueError("average_gradient_indices needs at least one source")
-    dest = Path(dest)
+    dst = Path(dest)
 
     infos = []
-    for src in sources:
+    for src in srcs:
         with (src / "info.json").open() as f:
             infos.append(json.load(f))
 
     first = infos[0]
-    for src, info in zip(sources[1:], infos[1:]):
+    for src, info in zip(srcs[1:], infos[1:]):
         if info["num_grads"] != first["num_grads"]:
             raise ValueError(
                 f"{src} has {info['num_grads']} rows, expected {first['num_grads']}"
@@ -523,21 +523,21 @@ def average_gradient_indices(sources: list[Path | str], dest: Path | str) -> Non
             raise ValueError(f"{src} has a different module layout")
 
     acc = None
-    for src in sources:
+    for src in srcs:
         arr = np.asarray(load_gradients(src), dtype=np.float64)
         acc = arr.copy() if acc is None else acc + arr
     assert acc is not None
-    acc /= len(sources)
+    acc /= len(srcs)
 
-    dest.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(sources[0] / "info.json", dest / "info.json")
+    dst.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(srcs[0] / "info.json", dst / "info.json")
     for extra in ("preprocess_cfg.json", "offsets.npy"):
-        if (sources[0] / extra).exists():
-            shutil.copy2(sources[0] / extra, dest / extra)
+        if (srcs[0] / extra).exists():
+            shutil.copy2(srcs[0] / extra, dst / extra)
 
     out = np.memmap(
-        dest / "gradients.bin",
-        dtype=load_gradients(sources[0]).dtype,
+        dst / "gradients.bin",
+        dtype=load_gradients(srcs[0]).dtype,
         mode="w+",
         shape=acc.shape,
     )

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -489,6 +489,64 @@ def load_data_string(
     return ds
 
 
+def average_gradient_indices(sources: list[Path | str], dest: Path | str) -> None:
+    """Average several gradient indices elementwise into a new index at ``dest``.
+
+    Every source must agree on row count, module layout and dtype -- they are
+    the same query set evaluated at different model checkpoints, so a mismatch
+    means the indices are not comparable and averaging them would be silently
+    wrong.
+
+    The accumulation is done in float64 regardless of the stored dtype: these
+    are sums of k values that may differ in the last bits, and accumulating in
+    a low-precision store dtype would discard exactly the differences being
+    averaged.
+    """
+    import json
+    import shutil
+
+    sources = [Path(s) for s in sources]
+    if not sources:
+        raise ValueError("average_gradient_indices needs at least one source")
+    dest = Path(dest)
+
+    infos = []
+    for src in sources:
+        with (src / "info.json").open() as f:
+            infos.append(json.load(f))
+
+    first = infos[0]
+    for src, info in zip(sources[1:], infos[1:]):
+        if info["num_grads"] != first["num_grads"]:
+            raise ValueError(
+                f"{src} has {info['num_grads']} rows, expected {first['num_grads']}"
+            )
+        if info["grad_sizes"] != first["grad_sizes"]:
+            raise ValueError(f"{src} has a different module layout")
+
+    acc = None
+    for src in sources:
+        arr = np.asarray(load_gradients(src), dtype=np.float64)
+        acc = arr.copy() if acc is None else acc + arr
+    assert acc is not None
+    acc /= len(sources)
+
+    dest.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(sources[0] / "info.json", dest / "info.json")
+    for extra in ("preprocess_cfg.json", "offsets.npy"):
+        if (sources[0] / extra).exists():
+            shutil.copy2(sources[0] / extra, dest / extra)
+
+    out = np.memmap(
+        dest / "gradients.bin",
+        dtype=load_gradients(sources[0]).dtype,
+        mode="w+",
+        shape=acc.shape,
+    )
+    out[:] = acc.astype(out.dtype)
+    out.flush()
+
+
 def load_gradients(root_dir: Path | str) -> np.memmap:
     """Map the gradients stored in `root_dir` into memory as a flat
     ``(num_grads, total_grad_dim)`` array, with modules laid out in

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -4,6 +4,7 @@ import math
 import os
 import random
 import re
+import shutil
 from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Any, Iterator, Sequence
@@ -502,9 +503,6 @@ def average_gradient_indices(sources: list[Path | str], dest: Path | str) -> Non
     a low-precision store dtype would discard exactly the differences being
     averaged.
     """
-    import json
-    import shutil
-
     sources = [Path(s) for s in sources]
     if not sources:
         raise ValueError("average_gradient_indices needs at least one source")

--- a/bergson/data.py
+++ b/bergson/data.py
@@ -493,15 +493,8 @@ def load_data_string(
 def average_gradient_indices(sources: list[Path | str], dest: Path | str) -> None:
     """Average several gradient indices elementwise into a new index at ``dest``.
 
-    Every source must agree on row count, module layout and dtype -- they are
-    the same query set evaluated at different model checkpoints, so a mismatch
-    means the indices are not comparable and averaging them would be silently
-    wrong.
-
-    The accumulation is done in float64 regardless of the stored dtype: these
-    are sums of k values that may differ in the last bits, and accumulating in
-    a low-precision store dtype would discard exactly the differences being
-    averaged.
+    Accumulates in float64 whatever the store dtype: the sources differ only in
+    their last bits, which a low-precision accumulator would discard.
     """
     srcs = [Path(s) for s in sources]
     if not srcs:

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -101,7 +101,6 @@ def hessian_pipeline(
 
             ckpt_models = list(hessian_pipeline_cfg.query_model_paths)
             if len(ckpt_models) > 1:
-                # Build the query gradient at each checkpoint, then average.
                 parts = []
                 for i, model_path in enumerate(ckpt_models):
                     part_cfg = deepcopy(query_cfg)

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -13,6 +13,7 @@ from ..config.config import (
     ScoreConfig,
 )
 from ..config.config_io import save_run_config
+from ..data import average_gradient_indices
 from ..distributed import launch_distributed_run
 from ..score.score import score_dataset
 from ..utils.step_state import prepare_step
@@ -101,8 +102,6 @@ def hessian_pipeline(
             ckpt_models = list(hessian_pipeline_cfg.query_model_paths)
             if len(ckpt_models) > 1:
                 # Build the query gradient at each checkpoint, then average.
-                from ..data import average_gradient_indices
-
                 parts = []
                 for i, model_path in enumerate(ckpt_models):
                     part_cfg = deepcopy(query_cfg)
@@ -111,9 +110,7 @@ def hessian_pipeline(
                     _validate(part_cfg)
                     build(part_cfg, query_preprocess_cfg)
                     parts.append(Path(part_cfg.run_path))
-                print(
-                    f"  averaging query gradients over {len(parts)} checkpoints"
-                )
+                print(f"  averaging query gradients over {len(parts)} checkpoints")
                 average_gradient_indices(parts, Path(query_path))
             else:
                 if ckpt_models:

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -1,6 +1,7 @@
 import time
 from contextlib import contextmanager
 from copy import deepcopy
+from pathlib import Path
 
 from ..build import build
 from ..cli.commands import Build, Score
@@ -96,7 +97,28 @@ def hessian_pipeline(
                 Build(query_cfg, query_preprocess_cfg),
                 query_cfg.partial_run_path,
             )
-            build(query_cfg, query_preprocess_cfg)
+
+            ckpt_models = list(hessian_pipeline_cfg.query_model_paths)
+            if len(ckpt_models) > 1:
+                # Build the query gradient at each checkpoint, then average.
+                from ..data import average_gradient_indices
+
+                parts = []
+                for i, model_path in enumerate(ckpt_models):
+                    part_cfg = deepcopy(query_cfg)
+                    part_cfg.model = model_path
+                    part_cfg.run_path = f"{query_path}__ckpt{i}"
+                    _validate(part_cfg)
+                    build(part_cfg, query_preprocess_cfg)
+                    parts.append(Path(part_cfg.run_path))
+                print(
+                    f"  averaging query gradients over {len(parts)} checkpoints"
+                )
+                average_gradient_indices(parts, Path(query_path))
+            else:
+                if ckpt_models:
+                    query_cfg.model = ckpt_models[0]
+                build(query_cfg, query_preprocess_cfg)
 
     # ── Step 2: Fit Hessian factors on training data ──────────────────────
     print(f"Step 2/4: Fitting {method} factors on training data...")

--- a/tests/test_ekfac_query_ckpt_avg.py
+++ b/tests/test_ekfac_query_ckpt_avg.py
@@ -1,0 +1,86 @@
+"""Tests for averaging query-gradient indices across model checkpoints."""
+
+import json
+
+import numpy as np
+import pytest
+
+from bergson.data import average_gradient_indices, load_gradients
+
+
+def _write_index(root, rows, dtype=np.float32, grad_sizes=None):
+    root.mkdir(parents=True, exist_ok=True)
+    arr = np.asarray(rows, dtype=dtype)
+    sizes = grad_sizes or {"mlp": arr.shape[1]}
+    info = {
+        "num_grads": arr.shape[0],
+        "grad_sizes": sizes,
+        "base_dtype": np.dtype(dtype).name,
+    }
+    (root / "info.json").write_text(json.dumps(info))
+    mm = np.memmap(root / "gradients.bin", dtype=dtype, mode="w+", shape=arr.shape)
+    mm[:] = arr
+    mm.flush()
+    return root
+
+
+def test_averages_elementwise(tmp_path):
+    a = _write_index(tmp_path / "a", [[0.0, 2.0], [4.0, 6.0]])
+    b = _write_index(tmp_path / "b", [[2.0, 4.0], [8.0, 10.0]])
+    average_gradient_indices([a, b], tmp_path / "out")
+    got = np.asarray(load_gradients(tmp_path / "out"))
+    assert np.allclose(got, [[1.0, 3.0], [6.0, 8.0]])
+
+
+def test_single_source_is_a_copy(tmp_path):
+    a = _write_index(tmp_path / "a", [[1.5, -2.5]])
+    average_gradient_indices([a], tmp_path / "out")
+    assert np.allclose(np.asarray(load_gradients(tmp_path / "out")), [[1.5, -2.5]])
+
+
+def test_preserves_shape_and_info(tmp_path):
+    a = _write_index(tmp_path / "a", [[1.0, 1.0], [1.0, 1.0]])
+    b = _write_index(tmp_path / "b", [[3.0, 3.0], [3.0, 3.0]])
+    average_gradient_indices([a, b], tmp_path / "out")
+    info = json.loads((tmp_path / "out" / "info.json").read_text())
+    assert info["num_grads"] == 2
+    assert info["grad_sizes"] == {"mlp": 2}
+
+
+def test_row_count_mismatch_raises(tmp_path):
+    a = _write_index(tmp_path / "a", [[1.0, 1.0]])
+    b = _write_index(tmp_path / "b", [[1.0, 1.0], [2.0, 2.0]])
+    with pytest.raises(ValueError, match="rows"):
+        average_gradient_indices([a, b], tmp_path / "out")
+
+
+def test_module_layout_mismatch_raises(tmp_path):
+    a = _write_index(tmp_path / "a", [[1.0, 1.0]], grad_sizes={"mlp": 2})
+    b = _write_index(tmp_path / "b", [[1.0, 1.0]], grad_sizes={"attn": 2})
+    with pytest.raises(ValueError, match="module layout"):
+        average_gradient_indices([a, b], tmp_path / "out")
+
+
+def test_empty_sources_raises(tmp_path):
+    with pytest.raises(ValueError):
+        average_gradient_indices([], tmp_path / "out")
+
+
+def test_many_sources_average_is_accurate(tmp_path):
+    """Averaging many indices must not drift.
+
+    The stored dtype is float32, so a sub-ULP difference between two sources can
+    never survive the write no matter how the sum is accumulated -- that is a
+    property of the store, not of this function. What the float64 accumulator
+    buys is that a long running sum does not drift before the divide, which is
+    what this checks: 64 sources whose exact mean is representable.
+    """
+    n = 64
+    srcs = []
+    for i in range(n):
+        # Values straddling a large offset, so a naive low-precision running sum
+        # loses the small terms; the exact mean is 1e6 + 31.5.
+        srcs.append(_write_index(tmp_path / f"s{i}", [[1e6 + i]]))
+    average_gradient_indices(srcs, tmp_path / "out")
+    got = float(np.asarray(load_gradients(tmp_path / "out"))[0, 0])
+    assert got == pytest.approx(1e6 + (n - 1) / 2, abs=0.05)

--- a/tests/test_ekfac_query_ckpt_avg.py
+++ b/tests/test_ekfac_query_ckpt_avg.py
@@ -11,10 +11,9 @@ from bergson.data import average_gradient_indices, load_gradients
 def _write_index(root, rows, dtype=np.float32, grad_sizes=None):
     root.mkdir(parents=True, exist_ok=True)
     arr = np.asarray(rows, dtype=dtype)
-    sizes = grad_sizes or {"mlp": arr.shape[1]}
     info = {
         "num_grads": arr.shape[0],
-        "grad_sizes": sizes,
+        "grad_sizes": grad_sizes or {"mlp": arr.shape[1]},
         "base_dtype": np.dtype(dtype).name,
     }
     (root / "info.json").write_text(json.dumps(info))
@@ -24,63 +23,44 @@ def _write_index(root, rows, dtype=np.float32, grad_sizes=None):
     return root
 
 
-def test_averages_elementwise(tmp_path):
+def test_average_gradient_indices(tmp_path):
     a = _write_index(tmp_path / "a", [[0.0, 2.0], [4.0, 6.0]])
     b = _write_index(tmp_path / "b", [[2.0, 4.0], [8.0, 10.0]])
     average_gradient_indices([a, b], tmp_path / "out")
-    got = np.asarray(load_gradients(tmp_path / "out"))
-    assert np.allclose(got, [[1.0, 3.0], [6.0, 8.0]])
-
-
-def test_single_source_is_a_copy(tmp_path):
-    a = _write_index(tmp_path / "a", [[1.5, -2.5]])
-    average_gradient_indices([a], tmp_path / "out")
-    assert np.allclose(np.asarray(load_gradients(tmp_path / "out")), [[1.5, -2.5]])
-
-
-def test_preserves_shape_and_info(tmp_path):
-    a = _write_index(tmp_path / "a", [[1.0, 1.0], [1.0, 1.0]])
-    b = _write_index(tmp_path / "b", [[3.0, 3.0], [3.0, 3.0]])
-    average_gradient_indices([a, b], tmp_path / "out")
+    assert np.allclose(
+        np.asarray(load_gradients(tmp_path / "out")), [[1.0, 3.0], [6.0, 8.0]]
+    )
     info = json.loads((tmp_path / "out" / "info.json").read_text())
-    assert info["num_grads"] == 2
-    assert info["grad_sizes"] == {"mlp": 2}
+    assert info["num_grads"] == 2 and info["grad_sizes"] == {"mlp": 2}
 
+    average_gradient_indices([a], tmp_path / "one")
+    assert np.allclose(
+        np.asarray(load_gradients(tmp_path / "one")), [[0.0, 2.0], [4.0, 6.0]]
+    )
 
-def test_row_count_mismatch_raises(tmp_path):
-    a = _write_index(tmp_path / "a", [[1.0, 1.0]])
-    b = _write_index(tmp_path / "b", [[1.0, 1.0], [2.0, 2.0]])
-    with pytest.raises(ValueError, match="rows"):
-        average_gradient_indices([a, b], tmp_path / "out")
-
-
-def test_module_layout_mismatch_raises(tmp_path):
-    a = _write_index(tmp_path / "a", [[1.0, 1.0]], grad_sizes={"mlp": 2})
-    b = _write_index(tmp_path / "b", [[1.0, 1.0]], grad_sizes={"attn": 2})
-    with pytest.raises(ValueError, match="module layout"):
-        average_gradient_indices([a, b], tmp_path / "out")
-
-
-def test_empty_sources_raises(tmp_path):
-    with pytest.raises(ValueError):
-        average_gradient_indices([], tmp_path / "out")
-
-
-def test_many_sources_average_is_accurate(tmp_path):
-    """Averaging many indices must not drift.
-
-    The stored dtype is float32, so a sub-ULP difference between two sources can
-    never survive the write no matter how the sum is accumulated -- that is a
-    property of the store, not of this function. What the float64 accumulator
-    buys is that a long running sum does not drift before the divide, which is
-    what this checks: 64 sources whose exact mean is representable.
-    """
+    # The float64 accumulator keeps a long running sum from drifting before the
+    # divide; the exact mean here is 1e6 + 31.5.
     n = 64
-    srcs = []
-    for i in range(n):
-        # Values straddling a large offset, so a naive low-precision running sum
-        # loses the small terms; the exact mean is 1e6 + 31.5.
-        srcs.append(_write_index(tmp_path / f"s{i}", [[1e6 + i]]))
-    average_gradient_indices(srcs, tmp_path / "out")
-    got = float(np.asarray(load_gradients(tmp_path / "out"))[0, 0])
+    srcs = [_write_index(tmp_path / f"s{i}", [[1e6 + i]]) for i in range(n)]
+    average_gradient_indices(srcs, tmp_path / "many")
+    got = float(np.asarray(load_gradients(tmp_path / "many"))[0, 0])
     assert got == pytest.approx(1e6 + (n - 1) / 2, abs=0.05)
+
+    with pytest.raises(ValueError, match="rows"):
+        average_gradient_indices(
+            [a, _write_index(tmp_path / "short", [[1.0, 1.0]])], tmp_path / "bad"
+        )
+    with pytest.raises(ValueError, match="module layout"):
+        average_gradient_indices(
+            [
+                a,
+                _write_index(
+                    tmp_path / "attn",
+                    [[1.0, 1.0], [1.0, 1.0]],
+                    grad_sizes={"attn": 2},
+                ),
+            ],
+            tmp_path / "bad",
+        )
+    with pytest.raises(ValueError):
+        average_gradient_indices([], tmp_path / "bad")


### PR DESCRIPTION
- Add `HessianPipelineConfig.query_model_paths` for averaging a query's gradients for multiple checkpoints.
- With two or more paths, the query gradient is built once per checkpoint and averaged before the Hessian is applied.

### Implementation

- `average_gradient_indices` in `bergson/data.py` averages several gradient indices into a new one. Accumulates in float64 for safety.
- `hessian_pipeline` builds each checkpoint's query index into `<query_path>__ckpt<i>`, then averages them into `query_path`.