### PR TITLE
Add save_mode='final': keep only the post-training state

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -382,11 +382,7 @@ class TrainingConfig(AttributionConfig, Serializable):
       O(sqrt N) space and O(N) time.
     - 'interval' saves every `save_interval` steps, plus the final state. Not
       supported by MAGIC.
-    - 'final' saves ONLY the post-training state: no trajectory, O(1) space.
-      Use it for runs that retrain purely to measure something about the
-      resulting model -- tail-filter validation, held-out evaluation, ablation
-      sweeps -- where the trajectory is written and never read. Like
-      'interval', it is not usable by MAGIC, which needs the trajectory.
+    - 'final' only saves the final state. Not usable with MAGIC.
 
     The original MAGIC paper used 'log', but 'sqrt' is often a better choice when disk
     space is not a concern.

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -10,7 +10,7 @@ from simple_parsing import Serializable, field
 
 from ..hessians.inversion import Inversion
 
-SaveMode = Literal["all", "sqrt", "log", "interval"]
+SaveMode = Literal["all", "sqrt", "log", "interval", "final"]
 
 
 def default_nproc_per_node() -> int:
@@ -382,6 +382,11 @@ class TrainingConfig(AttributionConfig, Serializable):
       O(sqrt N) space and O(N) time.
     - 'interval' saves every `save_interval` steps, plus the final state. Not
       supported by MAGIC.
+    - 'final' saves ONLY the post-training state: no trajectory, O(1) space.
+      Use it for runs that retrain purely to measure something about the
+      resulting model -- tail-filter validation, held-out evaluation, ablation
+      sweeps -- where the trajectory is written and never read. Like
+      'interval', it is not usable by MAGIC, which needs the trajectory.
 
     The original MAGIC paper used 'log', but 'sqrt' is often a better choice when disk
     space is not a concern.

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -137,6 +137,9 @@ def next_save_index(
     checkpoint schedule for a run of `n` steps starting from step 0.
     """
     match save_mode:
+        case "final":
+            # Only the post-training state; the caller writes it after the loop.
+            return n
         case "all":
             # Save every step
             return current + 1
@@ -622,9 +625,12 @@ class Trainer:
         if save_dir is not None:
             os.makedirs(save_dir, exist_ok=True)
 
-        # Always save the first state
-        next_save = 0
+        # Always save the first state -- except under 'final', where the whole
+        # point is that nothing is written until training ends. The loop below
+        # only ever compares i < n against next_save, so seeding it with n
+        # suppresses every in-loop save.
         n = len(data)
+        next_save = n if save_mode == "final" else 0
 
         start = 0
         if resume and save_dir is not None:
@@ -701,7 +707,7 @@ class Trainer:
 
         # Snapshots are written before each step; when the interval cadence
         # lands on n, write the post-training state too.
-        if save_dir and save_mode == "interval" and next_save == n:
+        if save_dir and save_mode in ("interval", "final") and next_save == n:
             p = os.path.join(save_dir, f"step_{n}.ckpt")
             if optimizer_cfg is not None:
                 # Local import: at module scope this cycles back into

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -138,7 +138,6 @@ def next_save_index(
     """
     match save_mode:
         case "final":
-            # Only the post-training state; the caller writes it after the loop.
             return n
         case "all":
             # Save every step
@@ -625,10 +624,7 @@ class Trainer:
         if save_dir is not None:
             os.makedirs(save_dir, exist_ok=True)
 
-        # Always save the first state -- except under 'final', where the whole
-        # point is that nothing is written until training ends. The loop below
-        # only ever compares i < n against next_save, so seeding it with n
-        # suppresses every in-loop save.
+        # Save the first state unless mode is 'final'.
         n = len(data)
         next_save = n if save_mode == "final" else 0
 

--- a/tests/test_save_mode_final.py
+++ b/tests/test_save_mode_final.py
@@ -1,51 +1,14 @@
 """Tests for save_mode='final': post-training state only, no trajectory."""
 
-import pytest
-
 from bergson.magic.trainer import next_save_index
 
 
-def _schedule(n, save_mode, save_interval=0):
-    """Every step the training loop would save at (it saves before step i<n)."""
-    saves, cur = [], 0
-    while cur < n:
-        saves.append(cur)
-        cur = next_save_index(cur, n, save_mode, save_interval)
-    return saves
-
-
 def test_final_schedules_nothing_before_the_end():
-    # next_save_index jumps straight to n, so the loop (which only tests i<n)
-    # never fires. Step 0 in particular must NOT be written.
-    assert next_save_index(0, 100, "final") == 100
-
-
-def test_final_is_constant_space_in_n():
+    # The training loop only saves at steps i < n, so returning n suppresses
+    # every in-loop save regardless of n or save_interval.
     for n in (10, 100, 10_000):
         assert next_save_index(0, n, "final") == n
-
-
-@pytest.mark.parametrize("mode", ["all", "sqrt", "log"])
-def test_trajectory_modes_still_save_during_training(mode):
-    sched = _schedule(64, mode)
-    assert sched[0] == 0
-    assert len(sched) > 1, f"{mode} should save more than the initial state"
-
-
-def test_final_saves_strictly_fewer_than_every_trajectory_mode():
-    n = 64
-    final = 1  # just step_n, written after the loop
-    for mode in ("all", "sqrt", "log"):
-        assert len(_schedule(n, mode)) > final
-
-
-def test_interval_unchanged():
-    assert next_save_index(0, 100, "interval", 25) == 25
-    with pytest.raises(ValueError):
-        next_save_index(0, 100, "interval", 0)
-
-
-def test_final_ignores_save_interval():
-    # 'final' must not require or consult save_interval, unlike 'interval'.
-    assert next_save_index(0, 50, "final", 0) == 50
     assert next_save_index(0, 50, "final", 7) == 50
+
+    for mode in ("all", "sqrt", "log"):
+        assert next_save_index(0, 64, mode) < 64

--- a/tests/test_save_mode_final.py
+++ b/tests/test_save_mode_final.py
@@ -1,0 +1,51 @@
+"""Tests for save_mode='final': post-training state only, no trajectory."""
+
+import pytest
+
+from bergson.magic.trainer import next_save_index
+
+
+def _schedule(n, save_mode, save_interval=0):
+    """Every step the training loop would save at (it saves before step i<n)."""
+    saves, cur = [], 0
+    while cur < n:
+        saves.append(cur)
+        cur = next_save_index(cur, n, save_mode, save_interval)
+    return saves
+
+
+def test_final_schedules_nothing_before_the_end():
+    # next_save_index jumps straight to n, so the loop (which only tests i<n)
+    # never fires. Step 0 in particular must NOT be written.
+    assert next_save_index(0, 100, "final") == 100
+
+
+def test_final_is_constant_space_in_n():
+    for n in (10, 100, 10_000):
+        assert next_save_index(0, n, "final") == n
+
+
+@pytest.mark.parametrize("mode", ["all", "sqrt", "log"])
+def test_trajectory_modes_still_save_during_training(mode):
+    sched = _schedule(64, mode)
+    assert sched[0] == 0
+    assert len(sched) > 1, f"{mode} should save more than the initial state"
+
+
+def test_final_saves_strictly_fewer_than_every_trajectory_mode():
+    n = 64
+    final = 1  # just step_n, written after the loop
+    for mode in ("all", "sqrt", "log"):
+        assert len(_schedule(n, mode)) > final
+
+
+def test_interval_unchanged():
+    assert next_save_index(0, 100, "interval", 25) == 25
+    with pytest.raises(ValueError):
+        next_save_index(0, 100, "interval", 0)
+
+
+def test_final_ignores_save_interval():
+    # 'final' must not require or consult save_interval, unlike 'interval'.
+    assert next_save_index(0, 50, "final", 0) == 50
+    assert next_save_index(0, 50, "final", 7) == 50


### PR DESCRIPTION
Adds `'final'` to `SaveMode` for runs that don't use MAGIC or SOURCE.

### Implementation [chatbot]

- `next_save_index` returns `n` for `'final'`, so the in-loop `i < n` comparison never fires.
- The training loop seeds `next_save = n` rather than `0` under `'final'`, suppressing the usual always-save-the-first-state.
- The post-loop write that `'interval'` already used is extended to `'final'`, producing `step_<n>.ckpt`.
