### PR TITLE
Report missing config files clearly

### DIFF
--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -78,15 +78,6 @@ def run_config(config_path: str, command_registry: dict[str, type]) -> None:
         cmd.execute()
 
 
-def _looks_like_config(arg: str) -> bool:
-    """Whether an argument is meant as a config path rather than a subcommand.
-
-    Subcommand names are bare words; config paths carry a YAML suffix or a
-    directory separator.
-    """
-    return arg.endswith((".yaml", ".yml")) or os.sep in arg
-
-
 def main():
     """Parse CLI arguments and dispatch to the selected subcommand.
 
@@ -113,12 +104,9 @@ def main():
     elif len(args) == 2:
         config_path = args[1]
 
-    if config_path is not None and _looks_like_config(config_path):
-        # Decide on the argument's shape, not on whether the file happens to
-        # exist. Testing os.path.isfile here means a missing config falls
-        # through to argparse, which reports it as
-        #     error: argument prog.command: invalid choice: '/path/to/run.yaml'
-        # That reads as a bad subcommand and hides the actual problem.
+    looks_like_config_file = (config_path.endswith((".yaml", ".yml")) or os.sep in config_path)
+
+    if config_path is not None and looks_like_config_file:
         if not os.path.isfile(config_path):
             raise SystemExit(f"bergson: no such config file: {config_path}")
 

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -104,7 +104,9 @@ def main():
     elif len(args) == 2:
         config_path = args[1]
 
-    looks_like_config_file = (config_path.endswith((".yaml", ".yml")) or os.sep in config_path)
+    looks_like_config_file = (
+        config_path.endswith((".yaml", ".yml")) or os.sep in config_path
+    )
 
     if config_path is not None and looks_like_config_file:
         if not os.path.isfile(config_path):

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -104,11 +104,9 @@ def main():
     elif len(args) == 2:
         config_path = args[1]
 
-    looks_like_config_file = config_path is not None and (
+    if config_path is not None and (
         config_path.endswith((".yaml", ".yml")) or os.sep in config_path
-    )
-
-    if looks_like_config_file:
+    ):
         if not os.path.isfile(config_path):
             raise SystemExit(f"bergson: no such config file: {config_path}")
 

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -104,11 +104,11 @@ def main():
     elif len(args) == 2:
         config_path = args[1]
 
-    looks_like_config_file = (
+    looks_like_config_file = config_path is not None and (
         config_path.endswith((".yaml", ".yml")) or os.sep in config_path
     )
 
-    if config_path is not None and looks_like_config_file:
+    if looks_like_config_file:
         if not os.path.isfile(config_path):
             raise SystemExit(f"bergson: no such config file: {config_path}")
 

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -78,6 +78,15 @@ def run_config(config_path: str, command_registry: dict[str, type]) -> None:
         cmd.execute()
 
 
+def _looks_like_config(arg: str) -> bool:
+    """Whether an argument is meant as a config path rather than a subcommand.
+
+    Subcommand names are bare words; config paths carry a YAML suffix or a
+    directory separator.
+    """
+    return arg.endswith((".yaml", ".yml")) or os.sep in arg
+
+
 def main():
     """Parse CLI arguments and dispatch to the selected subcommand.
 
@@ -99,12 +108,20 @@ def main():
     # Config-file mode: accept a YAML file as the sole argument.
     # Leading command words (e.g. `bergson build run/config.yaml`) are ignored.
     config_path: str | None = None
-    if len(args) == 1 and os.path.isfile(args[0]):
+    if len(args) == 1:
         config_path = args[0]
-    elif len(args) == 2 and os.path.isfile(args[1]):
+    elif len(args) == 2:
         config_path = args[1]
 
-    if config_path is not None:
+    if config_path is not None and _looks_like_config(config_path):
+        # Decide on the argument's shape, not on whether the file happens to
+        # exist. Testing os.path.isfile here means a missing config falls
+        # through to argparse, which reports it as
+        #     error: argument prog.command: invalid choice: '/path/to/run.yaml'
+        # That reads as a bad subcommand and hides the actual problem.
+        if not os.path.isfile(config_path):
+            raise SystemExit(f"bergson: no such config file: {config_path}")
+
         run_config(config_path, command_registry)
         return
 

--- a/tests/test_config_runner.py
+++ b/tests/test_config_runner.py
@@ -4,11 +4,12 @@ These tests exercise parsing only — they never call `.execute()`, so they
 need no GPU and no model downloads.
 """
 
+import sys
 from typing import get_args
 
 import pytest
 
-from bergson.__main__ import Build, Hessian, Main
+from bergson.__main__ import Build, Hessian, Main, main
 from bergson.config.config import HessianConfig, IndexConfig, PreprocessConfig
 from bergson.config.config_io import (
     load_subconfig,
@@ -290,3 +291,28 @@ def test_metadata_records_runtime_nccl_version():
         assert tuple(map(int, parts)) == tuple(torch.cuda.nccl.version())
     else:
         assert "nccl_version" not in meta
+
+
+def test_missing_config_path_reports_the_path(tmp_path, monkeypatch, capsys):
+    """A config path that does not exist names itself, rather than argparse's
+    ``invalid choice``, which reads as a bad subcommand and hides the cause."""
+    missing = str(tmp_path / "run" / "tune.yaml")
+    monkeypatch.setattr(sys, "argv", ["bergson", missing])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    message = str(excinfo.value)
+    assert missing in message, message
+    assert "invalid choice" not in message, message
+
+
+def test_bare_unknown_command_still_goes_to_argparse(monkeypatch):
+    """A bare word is a subcommand, so an unknown one keeps argparse's error."""
+    monkeypatch.setattr(sys, "argv", ["bergson", "definitely-not-a-command"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    # argparse exits 2 on a usage error; the config branch raises with a message.
+    assert excinfo.value.code == 2


### PR DESCRIPTION
`bergson <path>` only enters config-file mode when `os.path.isfile(path)`. A path that did not exist fell through to argparse, which reported:

```
error: argument prog.command: invalid choice: '/mnt/.../tune.yaml'
(choose from 'approxunrolling', 'build', 'ekfac', ...)
```

but the real problem is a missing file. 

**Change:** decide config-file mode on whether the argument has YAML suffix or a directory separator
