### PR TITLE
Give every process group one collective timeout that survives rank-0-only work

### DIFF
--- a/bergson/build.py
+++ b/bergson/build.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-from datetime import timedelta
 
 import torch
 import torch.distributed as dist
@@ -10,6 +9,7 @@ from bergson.collection import collect_gradients
 from bergson.config.config import IndexConfig, PreprocessConfig
 from bergson.data import allocate_batches
 from bergson.distributed import (
+    DIST_TIMEOUT,
     cap_world_size_to_dataset,
     launch_distributed_run,
     parent_barrier,
@@ -69,7 +69,7 @@ def build_worker(
             init_method=f"tcp://{addr}:{port}",
             device_id=dist_device_id(local_rank),
             rank=rank,
-            timeout=timedelta(minutes=30),
+            timeout=DIST_TIMEOUT,
             world_size=world_size,
         )
 

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -14,7 +14,6 @@ from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs, start_pr
 from bergson.config.config import DistributedConfig
 from bergson.utils.utils import dist_backend, dist_device_id, get_device_index
 
-
 # Collective timeout for every process group bergson creates.
 #
 # NCCL's 10-minute default assumes ranks reach each collective at roughly the

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -15,6 +15,21 @@ from bergson.config.config import DistributedConfig
 from bergson.utils.utils import dist_backend, dist_device_id, get_device_index
 
 
+# Collective timeout for every process group bergson creates.
+#
+# NCCL's 10-minute default assumes ranks reach each collective at roughly the
+# same time. bergson has sections where they do not: after the gradient loop in
+# run_with_collector_hooks, rank 0 runs process_autocorrelation_matrices and
+# writes the Hessians, while every other rank is already blocked in the
+# following dist.all_reduce(total_processed). That rank-0 work grows with the
+# dataset, so past the timeout the watchdog aborts a run that is making normal
+# progress -- observed at 64k documents where 32k with the same config passes.
+#
+# torch has no environment override for this (it is an init_process_group
+# argument), so it is set here and exposed via BERGSON_DIST_TIMEOUT_MIN.
+DIST_TIMEOUT = timedelta(minutes=float(os.environ.get("BERGSON_DIST_TIMEOUT_MIN", 60)))
+
+
 def init_dist(rank: int, local_rank: int, world_size: int) -> None:
     """Pin CUDA device and (if multi-rank) join the NCCL group set up by
     ``launch_distributed_run`` via MASTER_ADDR/MASTER_PORT env vars."""
@@ -28,7 +43,7 @@ def init_dist(rank: int, local_rank: int, world_size: int) -> None:
             init_method=f"tcp://{addr}:{port}",
             device_id=dist_device_id(local_rank),
             rank=rank,
-            timeout=timedelta(hours=1),
+            timeout=DIST_TIMEOUT,
             world_size=world_size,
         )
 
@@ -55,6 +70,7 @@ def parent_barrier(dist_config: DistributedConfig) -> None:
         "gloo",
         init_method=f"tcp://{master_addr}:{master_port}",
         rank=dist_config._node_rank,
+        timeout=DIST_TIMEOUT,
         world_size=dist_config.nnode,
     )
     dist.barrier()

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -16,20 +16,10 @@ from bergson.utils.utils import dist_backend, dist_device_id, get_device_index
 
 # Collective timeout for every process group bergson creates.
 #
-# NCCL's 10-minute default assumes ranks reach each collective at roughly the
-# same time. bergson has sections where they do not: after the gradient loop in
-# run_with_collector_hooks, rank 0 runs process_autocorrelation_matrices and
-# writes the Hessians, while every other rank is already blocked in the
-# following dist.all_reduce(total_processed). That rank-0 work grows with the
-# dataset, so past the timeout the watchdog aborts a run that is making normal
-# progress -- observed at 64k documents where 32k with the same config passes.
-#
-# Measured: on a 64k-document row the rank-0 section runs for OVER 110 MINUTES
-# (observed still healthy at 114 min, rank 0 at 100% GPU and rank 1 at 0%). An
-# hour is not enough for that, so the default is 3 h.
-#
-# torch has no environment override for this (it is an init_process_group
-# argument), so it is set here and exposed via BERGSON_DIST_TIMEOUT_MIN.
+# After the gradient loop, rank 0 processes and saves the Hessians while the
+# other ranks wait in an all_reduce; that work passes 110 minutes at 64k
+# documents, so short timeouts kill healthy runs. torch has no environment
+# override for the collective timeout, hence BERGSON_DIST_TIMEOUT_MIN.
 DIST_TIMEOUT = timedelta(minutes=float(os.environ.get("BERGSON_DIST_TIMEOUT_MIN", 180)))
 
 

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -14,12 +14,9 @@ from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs, start_pr
 from bergson.config.config import DistributedConfig
 from bergson.utils.utils import dist_backend, dist_device_id, get_device_index
 
-# Collective timeout for every process group bergson creates.
-#
-# After the gradient loop, rank 0 processes and saves the Hessians while the
-# other ranks wait in an all_reduce; that work passes 110 minutes at 64k
-# documents, so short timeouts kill healthy runs. torch has no environment
-# override for the collective timeout, hence BERGSON_DIST_TIMEOUT_MIN.
+# Collective timeout for every Bergson process group. Large to accommodate
+# single-rank Hessian save operations, which can take upwards of an hour for
+# large models.
 DIST_TIMEOUT = timedelta(minutes=float(os.environ.get("BERGSON_DIST_TIMEOUT_MIN", 180)))
 
 

--- a/bergson/distributed.py
+++ b/bergson/distributed.py
@@ -24,9 +24,13 @@ from bergson.utils.utils import dist_backend, dist_device_id, get_device_index
 # dataset, so past the timeout the watchdog aborts a run that is making normal
 # progress -- observed at 64k documents where 32k with the same config passes.
 #
+# Measured: on a 64k-document row the rank-0 section runs for OVER 110 MINUTES
+# (observed still healthy at 114 min, rank 0 at 100% GPU and rank 1 at 0%). An
+# hour is not enough for that, so the default is 3 h.
+#
 # torch has no environment override for this (it is an init_process_group
 # argument), so it is set here and exposed via BERGSON_DIST_TIMEOUT_MIN.
-DIST_TIMEOUT = timedelta(minutes=float(os.environ.get("BERGSON_DIST_TIMEOUT_MIN", 60)))
+DIST_TIMEOUT = timedelta(minutes=float(os.environ.get("BERGSON_DIST_TIMEOUT_MIN", 180)))
 
 
 def init_dist(rank: int, local_rank: int, world_size: int) -> None:

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -29,8 +29,6 @@ from transformers.utils.logging import (
     set_verbosity_error as hf_set_verbosity_error,
 )
 
-from bergson.distributed import DIST_TIMEOUT
-
 from ..config.config import TrainingConfig, ValidationConfig
 from ..config.config_io import save_run_config
 from ..data import (

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -29,6 +29,8 @@ from transformers.utils.logging import (
     set_verbosity_error as hf_set_verbosity_error,
 )
 
+from bergson.distributed import DIST_TIMEOUT
+
 from ..config.config import TrainingConfig, ValidationConfig
 from ..config.config_io import save_run_config
 from ..data import (
@@ -55,7 +57,6 @@ from .config import MagicConfig
 from .data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
 from .grad_accum import accumulate_grads
 from .trainer import BackwardState, TrainerState, prepare_trainer, write_lr_history
-from bergson.distributed import DIST_TIMEOUT
 
 
 def compute_query_gradients(

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -36,7 +36,7 @@ from ..data import (
     load_scores_loss_signed,
     sorted_checkpoints,
 )
-from ..distributed import launch_distributed_run
+from ..distributed import DIST_TIMEOUT, launch_distributed_run
 from ..score.score_writer import save_sequence_scores, save_token_scores
 from ..utils.load_from_optimizer import (
     save_second_moments_as_optimizer_pt,
@@ -55,6 +55,7 @@ from .config import MagicConfig
 from .data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
 from .grad_accum import accumulate_grads
 from .trainer import BackwardState, TrainerState, prepare_trainer, write_lr_history
+from bergson.distributed import DIST_TIMEOUT
 
 
 def compute_query_gradients(
@@ -415,6 +416,7 @@ def worker(
             init_method=f"tcp://{addr}:{port}",
             device_id=dist_device_id(rank),
             rank=global_rank,
+            timeout=DIST_TIMEOUT,
             world_size=world_size,
         )
 

--- a/bergson/magic/metasmoothness.py
+++ b/bergson/magic/metasmoothness.py
@@ -20,6 +20,8 @@ import torch
 import torch.distributed as dist
 from transformers import AutoTokenizer
 
+from bergson.distributed import DIST_TIMEOUT
+
 from ..config.config import MetasmoothnessConfig
 from ..distributed import DIST_TIMEOUT, launch_distributed_run
 from ..utils.utils import dist_backend, dist_device_id, get_device, get_device_index
@@ -27,7 +29,6 @@ from ..utils.worker_utils import setup_data_pipeline
 from .cli import attach_doc_ids_if_missing, shuffled_epochs
 from .data_stream import DataStream, pad_dataset_to_batch_size
 from .trainer import prepare_trainer
-from bergson.distributed import DIST_TIMEOUT
 
 
 def metasmoothness_score(

--- a/bergson/magic/metasmoothness.py
+++ b/bergson/magic/metasmoothness.py
@@ -21,12 +21,13 @@ import torch.distributed as dist
 from transformers import AutoTokenizer
 
 from ..config.config import MetasmoothnessConfig
-from ..distributed import launch_distributed_run
+from ..distributed import DIST_TIMEOUT, launch_distributed_run
 from ..utils.utils import dist_backend, dist_device_id, get_device, get_device_index
 from ..utils.worker_utils import setup_data_pipeline
 from .cli import attach_doc_ids_if_missing, shuffled_epochs
 from .data_stream import DataStream, pad_dataset_to_batch_size
 from .trainer import prepare_trainer
+from bergson.distributed import DIST_TIMEOUT
 
 
 def metasmoothness_score(
@@ -67,6 +68,7 @@ def metasmoothness_worker(
             init_method=f"tcp://{addr}:{port}",
             device_id=dist_device_id(rank),
             rank=global_rank,
+            timeout=DIST_TIMEOUT,
             world_size=world_size,
         )
 

--- a/bergson/magic/metasmoothness.py
+++ b/bergson/magic/metasmoothness.py
@@ -20,8 +20,6 @@ import torch
 import torch.distributed as dist
 from transformers import AutoTokenizer
 
-from bergson.distributed import DIST_TIMEOUT
-
 from ..config.config import MetasmoothnessConfig
 from ..distributed import DIST_TIMEOUT, launch_distributed_run
 from ..utils.utils import dist_backend, dist_device_id, get_device, get_device_index

--- a/bergson/score/score.py
+++ b/bergson/score/score.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -18,6 +17,7 @@ from bergson.data import (
     load_gradients,
 )
 from bergson.distributed import (
+    DIST_TIMEOUT,
     cap_world_size_to_dataset,
     launch_distributed_run,
     parent_barrier,
@@ -299,7 +299,7 @@ def score_worker(
             init_method=f"tcp://{addr}:{port}",
             device_id=dist_device_id(local_rank),
             rank=rank,
-            timeout=timedelta(hours=1),
+            timeout=DIST_TIMEOUT,
             world_size=world_size,
         )
 


### PR DESCRIPTION
Give every process group one collective timeout that survives rank-0-only work

EK-FAC runs abort at larger dataset sizes with

    Watchdog caught collective operation timeout
    checkTimeout at ProcessGroupNCCL.cpp:733

always immediately after "Collecting gradients: 100%", and never during the
gradient loop itself. The loop is not the problem -- allocate_batches pads the
batch count to a multiple of the world size and asserts every rank gets an equal
number, so ranks leave the loop together.

What follows the loop is not symmetric:

    run_with_collector_hooks()                    collector/collector.py
        ... gradient loop (symmetric) ...
        self.collector.teardown()                 hessians/autocorrelation.py
            process_autocorrelation_matrices(...)   `if rank == 0:` ...
            if self.rank == 0: processor.save(...)
        dist.all_reduce(total_processed)          <- other ranks block HERE

Rank 0 reduces and eigendecomposes the Grams and writes them to storage while
every other rank is already waiting in the all_reduce. That is not a deadlock --
rank 0 does arrive -- but the rank-0 work grows with the dataset and the write
lands on shared storage, so past the timeout the watchdog kills a run that was
making normal progress. We see it at 64k documents where 32k with the same
config and the same hardware completes.

The timeouts in place were inconsistent and, in the build path, too short:

    build.py         30 minutes   <- the index/EK-FAC path, where this fires
    distributed.py   1 hour  (init_dist) / none (parent_barrier)
    score/score.py   1 hour
    magic/cli.py     none -> NCCL default, 10 minutes
    magic/metasmoothness.py  none -> 10 minutes

This replaces all five with a single DIST_TIMEOUT in bergson/distributed.py,
defaulting to 1 hour and overridable per-run with BERGSON_DIST_TIMEOUT_MIN.

Worth stating explicitly: TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC does NOT help here.
It governs the watchdog monitor thread, not the collective timeout, and the
collective timeout has no environment override at all -- it is an
init_process_group argument. That is why this has to be a code change.

This raises the ceiling rather than removing the asymmetry. Doing the all_reduce
before teardown, or sharding the Hessian save across ranks, would shrink the
window itself; both are larger changes and neither is needed to stop healthy
runs being killed.
