### PR TITLE
Differentiate filtering and LDS evaluation config

### DIFF
--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -31,7 +31,7 @@ from ..config.config import (
     ValidationConfig,
 )
 from ..config.config_io import save_run_config
-from ..config.validation import LDSConfig, SubsetBank
+from ..config.validation import LDSConfig
 from ..diagnose import DiagnoseConfig, diagnose
 from ..hessians.hessian_approximations import approximate_hessians
 from ..magic import MagicConfig, run_magic
@@ -306,10 +306,8 @@ class Validate(ValidationConfig):
         """Run the validation."""
         assert self.scores, "Path to attribution scores must be provided."
 
-        if isinstance(self.method, LDSConfig) and isinstance(
-            self.method.subsets, SubsetBank
-        ):
-            evaluate_retrained(self, self.method.subsets.paths, score_path=self.scores)
+        if isinstance(self.method, LDSConfig) and self.method.subsets == "bank":
+            evaluate_retrained(self, self.method.paths, score_path=self.scores)
         else:
             run_magic(
                 self,

--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -31,6 +31,7 @@ from ..config.config import (
     ValidationConfig,
 )
 from ..config.config_io import save_run_config
+from ..config.validation import LDSConfig, SubsetBank
 from ..diagnose import DiagnoseConfig, diagnose
 from ..hessians.hessian_approximations import approximate_hessians
 from ..magic import MagicConfig, run_magic
@@ -298,31 +299,21 @@ class Validate(ValidationConfig):
     scores: str = ""
     """Path to saved attribution scores for validation."""
 
-    retrained_dir: str | list[str] = ""
-    """Optional: evaluate on existing run directories of leave-k-out re-trained
-    models written with ``save_models=true``; multiple directories (a yaml list,
-    or comma-separated on the CLI) average the query losses over the runs."""
-
     baseline_model: str = ""
     """Optional path to baseline model trained on the full dataset."""
-
-    @property
-    def retrained_dirs(self) -> list[str]:
-        if isinstance(self.retrained_dir, str):
-            return [d for d in self.retrained_dir.split(",") if d]
-        return list(self.retrained_dir)
 
     def execute(self):
         """Run the validation."""
         assert self.scores, "Path to attribution scores must be provided."
 
-        if self.retrained_dirs and self.method == "lds":
-            evaluate_retrained(self, self.retrained_dirs, score_path=self.scores)
+        if isinstance(self.method, LDSConfig) and isinstance(
+            self.method.subsets, SubsetBank
+        ):
+            evaluate_retrained(self, self.method.subsets.paths, score_path=self.scores)
         else:
             run_magic(
                 self,
                 score_path=self.scores,
                 validate=True,
                 baseline_model=self.baseline_model,
-                retrained_dir=self.retrained_dirs,
             )

--- a/bergson/config/__init__.py
+++ b/bergson/config/__init__.py
@@ -21,8 +21,26 @@ from .config import (
     TrainingConfig,
     ValidationConfig,
 )
+from .validation import (
+    ControlBank,
+    FilterConfig,
+    LDSConfig,
+    NoControls,
+    RandomControls,
+    RandomSubsets,
+    SubsetBank,
+    WeightStepConfig,
+)
 
 __all__ = [
+    "ControlBank",
+    "FilterConfig",
+    "LDSConfig",
+    "NoControls",
+    "RandomControls",
+    "RandomSubsets",
+    "SubsetBank",
+    "WeightStepConfig",
     "ApproxUnrollingConfig",
     "AttentionConfig",
     "AttributionConfig",

--- a/bergson/config/__init__.py
+++ b/bergson/config/__init__.py
@@ -22,24 +22,16 @@ from .config import (
     ValidationConfig,
 )
 from .validation import (
-    ControlBank,
+    ControlsConfig,
     FilterConfig,
     LDSConfig,
-    NoControls,
-    RandomControls,
-    RandomSubsets,
-    SubsetBank,
     WeightStepConfig,
 )
 
 __all__ = [
-    "ControlBank",
+    "ControlsConfig",
     "FilterConfig",
     "LDSConfig",
-    "NoControls",
-    "RandomControls",
-    "RandomSubsets",
-    "SubsetBank",
     "WeightStepConfig",
     "ApproxUnrollingConfig",
     "AttentionConfig",

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -471,7 +471,7 @@ class ValidationConfig(TrainingConfig, ABC):
 
     controls: Literal["auto", "load", "retrain", "skip"] = "auto"
     """Where the random-control baseline comes from. ``auto`` loads from
-    ``retrained_dir`` if set, else retrains ``num_subsets`` in-process."""
+    ``retrained_dir`` if set, else retrains ``num_subsets`` controls."""
 
     subset_weight: float = 0.0
     """Training weight assigned to each subset's documents during the retrain

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -469,6 +469,20 @@ class ValidationConfig(TrainingConfig, ABC):
     filter-* method the number of random filters it is compared against;
     ``0`` skips them, as does a bank of retrained models."""
 
+    controls: Literal["auto", "load", "retrain", "skip"] = "auto"
+    """Where the random-control baseline comes from.
+
+    ``auto`` keeps the historical precedence: load from ``retrained_dir`` if it is
+    set, else retrain ``num_subsets`` in-process, else skip. The other values state
+    the intent and fail loudly when it cannot be met.
+
+    Worth stating explicitly because controls are retrained PER PROCESS. The
+    controls are N trained models for the whole run, and scoring them against every
+    query is only forward passes -- so splitting a filter across S shards and
+    letting each retrain its own turns N controls into N*S trainings. Build them
+    once and point every shard's ``retrained_dir`` at the result
+    (``controls: load``) instead."""
+
     subset_weight: float = 0.0
     """Training weight assigned to each subset's documents during the retrain
     (the rest stay at 1.0). ``0.0`` (default) is standard leave-k-out removal."""

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -473,9 +473,7 @@ class ValidationConfig(TrainingConfig, ABC):
     """Where the random-control baseline comes from.
 
     ``auto`` loads from ``retrained_dir`` if set, else retrains ``num_subsets``
-    in-process. The other values state the intent and fail loudly
-    when it cannot be met. Controls are retrained per process, so sharded runs
-    should build them once and share them via ``retrained_dir``."""
+    in-process."""
 
     subset_weight: float = 0.0
     """Training weight assigned to each subset's documents during the retrain

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -473,7 +473,7 @@ class ValidationConfig(TrainingConfig, ABC):
     """Where the random-control baseline comes from.
 
     ``auto`` loads from ``retrained_dir`` if set, else retrains ``num_subsets``
-    in-process, else skips. The other values state the intent and fail loudly
+    in-process. The other values state the intent and fail loudly
     when it cannot be met. Controls are retrained per process, so sharded runs
     should build them once and share them via ``retrained_dir``."""
 

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -470,10 +470,8 @@ class ValidationConfig(TrainingConfig, ABC):
     ``0`` skips them, as does a bank of retrained models."""
 
     controls: Literal["auto", "load", "retrain", "skip"] = "auto"
-    """Where the random-control baseline comes from.
-
-    ``auto`` loads from ``retrained_dir`` if set, else retrains ``num_subsets``
-    in-process."""
+    """Where the random-control baseline comes from. ``auto`` loads from
+    ``retrained_dir`` if set, else retrains ``num_subsets`` in-process."""
 
     subset_weight: float = 0.0
     """Training weight assigned to each subset's documents during the retrain

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -472,16 +472,10 @@ class ValidationConfig(TrainingConfig, ABC):
     controls: Literal["auto", "load", "retrain", "skip"] = "auto"
     """Where the random-control baseline comes from.
 
-    ``auto`` keeps the historical precedence: load from ``retrained_dir`` if it is
-    set, else retrain ``num_subsets`` in-process, else skip. The other values state
-    the intent and fail loudly when it cannot be met.
-
-    Worth stating explicitly because controls are retrained PER PROCESS. The
-    controls are N trained models for the whole run, and scoring them against every
-    query is only forward passes -- so splitting a filter across S shards and
-    letting each retrain its own turns N controls into N*S trainings. Build them
-    once and point every shard's ``retrained_dir`` at the result
-    (``controls: load``) instead."""
+    ``auto`` loads from ``retrained_dir`` if set, else retrains ``num_subsets``
+    in-process, else skips. The other values state the intent and fail loudly
+    when it cannot be met. Controls are retrained per process, so sharded runs
+    should build them once and share them via ``retrained_dir``."""
 
     subset_weight: float = 0.0
     """Training weight assigned to each subset's documents during the retrain

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -478,11 +478,11 @@ class ValidationConfig(TrainingConfig, ABC):
     """Exclude rows whose attribution scores are all zero from the removal pool."""
 
     method: Union[LDSConfig, FilterConfig, WeightStepConfig] = tagged_subgroups(
-        {"lds": LDSConfig, "filter": FilterConfig, "weight-step": WeightStepConfig},
+        {"lds": LDSConfig, "filter": FilterConfig, "weight_step": WeightStepConfig},
         default="lds",
         tag="kind",
     )
-    """Validation experiment; only its own sampling/control options are exposed."""
+    """Configuration for the selected validation method."""
 
     @classmethod
     def from_dict(cls, obj, drop_extra_fields=None):

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -475,7 +475,9 @@ class ValidationConfig(TrainingConfig, ABC):
     """Weight assigned to removed documents; zero means full removal."""
 
     exclude_zero_scores: bool = False
-    """Exclude rows whose attribution scores are all zero from the removal pool."""
+    """When True, drop doc_ids with score == 0 from the validation
+    permutation. These scores may be produced by items with fewer than
+    2 tokens."""
 
     method: Union[LDSConfig, FilterConfig, WeightStepConfig] = tagged_subgroups(
         {"lds": LDSConfig, "filter": FilterConfig, "weight_step": WeightStepConfig},

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -472,7 +472,8 @@ class ValidationConfig(TrainingConfig, ABC):
     ``none`` will perform one backward per query."""
 
     subset_weight: float = 0.0
-    """Weight assigned to removed documents; zero means full removal."""
+    """Training weight assigned to each subset's documents during the retrain
+    (the rest stay at 1.0). ``0.0`` (default) is standard leave-k-out removal."""
 
     exclude_zero_scores: bool = False
     """When True, drop doc_ids with score == 0 from the validation

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -3,12 +3,19 @@ import os
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Union
 
 import torch
 from simple_parsing import Serializable, field
 
 from ..hessians.inversion import Inversion
+from .validation import (
+    FilterConfig,
+    LDSConfig,
+    WeightStepConfig,
+    migrate_validation_config,
+    tagged_subgroups,
+)
 
 SaveMode = Literal["all", "sqrt", "log", "interval", "final"]
 
@@ -464,54 +471,24 @@ class ValidationConfig(TrainingConfig, ABC):
     """How query gradients are combined before the MAGIC backward.
     ``none`` will perform one backward per query."""
 
-    num_subsets: int = 100
-    """Number of leave-k-out subsets for Spearman correlation, or for a
-    filter-* method the number of random filters it is compared against;
-    ``0`` skips them, as does a bank of retrained models."""
-
-    controls: Literal["auto", "load", "retrain", "skip"] = "auto"
-    """Where the random-control baseline comes from. ``auto`` loads from
-    ``retrained_dir`` if set, else retrains ``num_subsets`` controls."""
-
     subset_weight: float = 0.0
-    """Training weight assigned to each subset's documents during the retrain
-    (the rest stay at 1.0). ``0.0`` (default) is standard leave-k-out removal."""
-
-    weight_lrs: list[float] = field(default_factory=list)
-    """Gradient step on the data weights: for each lr, retrain once with doc
-    weights ``1 - lr * score`` (mean over query columns) instead of leave-k-out
-    subsets, and compare the query loss change to its first-order prediction."""
+    """Weight assigned to removed documents; zero means full removal."""
 
     exclude_zero_scores: bool = False
-    """When True, drop doc_ids with score == 0 from the validation
-    permutation. These scores may be produced by items with fewer than
-    2 tokens."""
+    """Exclude rows whose attribution scores are all zero from the removal pool."""
 
-    subsets: str = ""
-    """Path to a subsets.json to reuse; defaults to ``<run_path>/subsets.json``."""
+    method: Union[LDSConfig, FilterConfig, WeightStepConfig] = tagged_subgroups(
+        {"lds": LDSConfig, "filter": FilterConfig, "weight-step": WeightStepConfig},
+        default="lds",
+        tag="kind",
+    )
+    """Validation experiment; only its own sampling/control options are exposed."""
 
-    subset_start: int = 0
-    """First subset index to retrain. With ``subset_stop``, splits the
-    retraining across independent processes; the subsets are drawn from
-    ``seed``, so every process agrees on the full list."""
-
-    subset_stop: int | None = None
-    """One past the last subset index to retrain; ``None`` means ``num_subsets``."""
-
-    subset_fraction: float = 0.0
-    """Fraction of data filtered during a retrain. When > 0 subsets are sampled
-    independently without replacement within a subset, but with replacement
-    across subsets, and contain ``round(subset_fraction * pool)`` documents
-    — e.g. 0.05 filters 5 percent of documents per subset. When 0.0, the
-    dataset is randomly partitioned into ``num_subsets`` disjoint subsets
-    for ```lds```, or for a filter-* method the size is 1 / num_subsets."""
-
-    method: Literal["lds", "filter-proponents", "filter-detractors"] = "lds"
-    """``lds`` filters ```num_subsets``` random subsets of the data and
-    correlates the query loss change with the summed attribution scores.
-    ``filter`` methods filter either the top- or bottom-scoring
-    ``subset_fraction`` of data, then retrain and measure the query loss
-    change against ``num_subsets`` random filters of the same size."""
+    @classmethod
+    def from_dict(cls, obj, drop_extra_fields=None):
+        return super().from_dict(
+            migrate_validation_config(obj), drop_extra_fields=drop_extra_fields
+        )
 
 
 @dataclass

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -35,11 +35,6 @@ def tagged_subgroups(choices: Mapping[str, type[T]], *, default: str, tag: str) 
     )
 
 
-def _positive_count(count: int):
-    if count <= 0:
-        raise ValueError("count must be positive; use controls: {source: skip} to skip")
-
-
 @dataclass
 class RandomSubsets(Serializable):
     """LDS observations, generated independently of attribution scores."""
@@ -54,7 +49,6 @@ class RandomSubsets(Serializable):
     """Optional subsets.json to reuse instead of sampling."""
 
     def __post_init__(self):
-        _positive_count(self.count)
         if self.sampling not in ("partition", "random"):
             raise ValueError("sampling must be partition or random")
         if not 0 < self.fraction <= 1:
@@ -79,9 +73,6 @@ class RandomControls(Serializable):
     count: int = 3
     sampling_seed: int = 42
 
-    def __post_init__(self):
-        _positive_count(self.count)
-
 
 @dataclass
 class ControlBank(SubsetBank):
@@ -89,11 +80,6 @@ class ControlBank(SubsetBank):
 
     count: int | None = 3
     """Number of bank entries to evaluate; None uses all entries."""
-
-    def __post_init__(self):
-        super().__post_init__()
-        if self.count is not None:
-            _positive_count(self.count)
 
 
 @dataclass

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -46,7 +46,6 @@ class ControlsConfig(Serializable):
     """Number of controls; None evaluates every entry in a bank."""
     paths: list[str] = field(default_factory=list)
     """Retrain bank directories, used with kind: bank."""
-    sampling_seed: int = 42
 
 
 @dataclass
@@ -55,11 +54,9 @@ class LDSConfig(Serializable):
 
     subsets: Literal["retrain", "bank"] = "retrain"
     count: int = 100
-    sampling: Literal["partition", "random"] = "partition"
-    """Partition the pool, or draw count independent fixed-size subsets."""
-    fraction: float = 0.05
-    """Removal fraction for random sampling; partition uses count equal chunks."""
-    sampling_seed: int = 42
+    fraction: float = 0.0
+    """Zero partitions the pool into count subsets; a positive value draws
+    count random subsets containing this fraction of the pool."""
     manifest: str = ""
     """Optional subsets.json to reuse instead of sampling."""
     paths: list[str] = field(default_factory=list)
@@ -70,10 +67,6 @@ class LDSConfig(Serializable):
     """Exclusive final subset index; None uses the full list."""
 
     def __post_init__(self):
-        if self.sampling not in ("partition", "random"):
-            raise ValueError("sampling must be partition or random")
-        if not 0 < self.fraction <= 1:
-            raise ValueError("fraction must be in (0, 1]")
         if self.start < 0 or (self.stop is not None and self.stop <= self.start):
             raise ValueError("LDS requires 0 <= start < stop")
 
@@ -83,7 +76,7 @@ class FilterConfig(Serializable):
     """Remove one ranked tail and optionally compare with random removals."""
 
     direction: Literal["proponents", "detractors"] = "proponents"
-    fraction: float = 0.05
+    fraction: float = 0.01
     """Fraction of the eligible data to remove."""
     controls: ControlsConfig = field(default_factory=ControlsConfig)
 
@@ -132,7 +125,7 @@ def migrate_validation_config(obj: dict) -> dict:
                 f"Cannot mix nested method with legacy fields: {sorted(legacy)}"
             )
         return obj
-    if method is None and not legacy and obj.get("seed", 42) == 42:
+    if method is None and not legacy:
         return obj
     warnings.warn(
         "Flat validation options are deprecated; use a nested method config "
@@ -147,7 +140,6 @@ def migrate_validation_config(obj: dict) -> dict:
     paths = old.get("retrained_dir", [])
     if isinstance(paths, str):
         paths = [p for p in paths.split(",") if p]
-    sampling_seed = obj.get("seed", 42)
     if method == "lds":
         if old.get("weight_lrs") and not paths:
             obj["method"] = {"kind": "weight_step", "lrs": old["weight_lrs"]}
@@ -157,9 +149,7 @@ def migrate_validation_config(obj: dict) -> dict:
                 "subsets": "bank" if paths else "retrain",
                 "paths": paths,
                 "count": count,
-                "sampling": "random" if fraction > 0 else "partition",
-                "fraction": fraction if fraction > 0 else 0.05,
-                "sampling_seed": sampling_seed,
+                "fraction": fraction,
                 "manifest": old.get("subsets", ""),
                 "start": old.get("subset_start", 0),
                 "stop": old.get("subset_stop"),
@@ -186,7 +176,6 @@ def migrate_validation_config(obj: dict) -> dict:
             controls = {
                 "kind": "retrain",
                 "count": count,
-                "sampling_seed": sampling_seed,
             }
         else:
             controls = {"kind": "none"}

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -8,7 +8,7 @@ from simple_parsing import Serializable, field, subgroups
 
 
 def tagged_subgroups(choices: dict[str, Any], *, default: str, tag: str):
-    """Use CLI subgroups without losing their identity in YAML round trips.
+    """Preserve subgroup identity across CLI parsing and YAML round trips.
 
     SimpleParsing's default Union decoder tries alternatives in order and can
     silently discard fields. Decode only the explicitly selected concrete type.
@@ -80,7 +80,7 @@ class RandomControls(Serializable):
 
 @dataclass
 class ControlBank(SubsetBank):
-    """Use the first count bank entries, chosen independently of their losses."""
+    """Evaluate the first count bank entries."""
 
     count: int | None = 3
     """Number of bank entries to evaluate; None uses all entries."""
@@ -93,7 +93,7 @@ class ControlBank(SubsetBank):
 
 @dataclass
 class NoControls(Serializable):
-    """Measure the ranked removal without a random comparison."""
+    """Skip random-control evaluation."""
 
 
 @dataclass
@@ -121,7 +121,7 @@ class FilterConfig(Serializable):
 
     direction: Literal["proponents", "detractors"] = "proponents"
     fraction: float = 0.05
-    """Fraction removed, independent of the control count."""
+    """Fraction of the eligible data to remove."""
     controls: Union[RandomControls, ControlBank, NoControls] = tagged_subgroups(
         {"random": RandomControls, "bank": ControlBank, "skip": NoControls},
         default="random",

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -96,8 +96,6 @@ class FilterConfig(Serializable):
     controls: ControlsConfig = field(default_factory=ControlsConfig)
 
     def __post_init__(self):
-        if self.direction not in ("proponents", "detractors"):
-            raise ValueError("direction must be proponents or detractors")
         if not 0 < self.fraction <= 1:
             raise ValueError("filter fraction must be in (0, 1]")
 

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -42,10 +42,14 @@ class ControlsConfig(Serializable):
     kind: Literal["retrain", "bank", "none"] = field(
         default="retrain", alias="controls"
     )
+    """Where the random filters come from: retrained here, read from a bank of
+    runs written with ``save_models=true``, or skipped entirely."""
     count: int | None = 3
-    """Number of controls; None evaluates every entry in a bank."""
+    """Number of random filters the ranked filter is compared against;
+    ``None`` evaluates every entry in a bank."""
     paths: list[str] = field(default_factory=list)
-    """Retrain bank directories, used with kind: bank."""
+    """Run directories of random-filter re-trained models, used with
+    ``kind: bank``; multiple directories average the query losses over the runs."""
 
 
 @dataclass
@@ -53,18 +57,28 @@ class LDSConfig(Serializable):
     """Correlate subset score sums with retrained query loss changes."""
 
     subsets: Literal["retrain", "bank"] = "retrain"
+    """Where the leave-k-out models come from: retrained here, or read from a
+    bank of runs written with ``save_models=true``."""
     count: int = 100
+    """Number of leave-k-out subsets for the Spearman correlation."""
     fraction: float = 0.0
-    """Zero partitions the pool into count subsets; a positive value draws
-    count random subsets containing this fraction of the pool."""
+    """Fraction of data filtered during a retrain. When > 0 subsets are sampled
+    independently without replacement within a subset, but with replacement
+    across subsets, and contain ``round(fraction * pool)`` documents — e.g. 0.05
+    filters 5 percent of documents per subset. When 0.0, the dataset is randomly
+    partitioned into ``count`` disjoint subsets."""
     manifest: str = ""
-    """Optional subsets.json to reuse instead of sampling."""
+    """Path to a subsets.json to reuse; defaults to ``<run_path>/subsets.json``."""
     paths: list[str] = field(default_factory=list)
-    """Retrain bank directories, used with subsets: bank."""
+    """Run directories of leave-k-out re-trained models, used with
+    ``subsets: bank``; multiple directories (a yaml list, or comma-separated on
+    the CLI) average the query losses over the runs."""
     start: int = 0
-    """First subset to evaluate/retrain, for sharding an LDS run."""
+    """First subset index to retrain. With ``stop``, splits the retraining
+    across independent processes; the subsets are drawn from ``seed``, so every
+    process agrees on the full list."""
     stop: int | None = None
-    """Exclusive final subset index; None uses the full list."""
+    """One past the last subset index to retrain; ``None`` means ``count``."""
 
     def __post_init__(self):
         if self.start < 0 or (self.stop is not None and self.stop <= self.start):
@@ -76,6 +90,7 @@ class FilterConfig(Serializable):
     """Remove one ranked tail and optionally compare with random removals."""
 
     direction: Literal["proponents", "detractors"] = "proponents"
+    """Which end of the score ranking to filter out."""
     fraction: float = 0.01
     """Fraction of the eligible data to remove."""
     controls: ControlsConfig = field(default_factory=ControlsConfig)
@@ -96,6 +111,9 @@ class WeightStepConfig(Serializable):
     """Compare weight-gradient steps with their first-order predictions."""
 
     lrs: list[float] = field(default_factory=lambda: [1.0])
+    """Gradient step on the data weights: for each lr, retrain once with doc
+    weights ``1 - lr * score`` (mean over query columns) instead of leave-k-out
+    subsets, and compare the query loss change to its first-order prediction."""
 
     def __post_init__(self):
         if not self.lrs:

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -3,7 +3,7 @@
 import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Literal, TypeVar, Union
+from typing import Literal, TypeVar
 
 from simple_parsing import Serializable, field, subgroups
 
@@ -36,9 +36,24 @@ def tagged_subgroups(choices: Mapping[str, type[T]], *, default: str, tag: str) 
 
 
 @dataclass
-class RandomSubsets(Serializable):
-    """LDS observations, generated independently of attribution scores."""
+class ControlsConfig(Serializable):
+    """Random-removal comparisons for filtering."""
 
+    kind: Literal["retrain", "bank", "none"] = field(
+        default="retrain", alias="controls"
+    )
+    count: int | None = 3
+    """Number of controls; None evaluates every entry in a bank."""
+    paths: list[str] = field(default_factory=list)
+    """Retrain bank directories, used with kind: bank."""
+    sampling_seed: int = 42
+
+
+@dataclass
+class LDSConfig(Serializable):
+    """Correlate subset score sums with retrained query loss changes."""
+
+    subsets: Literal["retrain", "bank"] = "retrain"
     count: int = 100
     sampling: Literal["partition", "random"] = "partition"
     """Partition the pool, or draw count independent fixed-size subsets."""
@@ -47,61 +62,18 @@ class RandomSubsets(Serializable):
     sampling_seed: int = 42
     manifest: str = ""
     """Optional subsets.json to reuse instead of sampling."""
-
-    def __post_init__(self):
-        if self.sampling not in ("partition", "random"):
-            raise ValueError("sampling must be partition or random")
-        if not 0 < self.fraction <= 1:
-            raise ValueError("fraction must be in (0, 1]")
-
-
-@dataclass
-class SubsetBank(Serializable):
-    """Existing LDS retrains; corresponding subsets across paths are averaged."""
-
     paths: list[str] = field(default_factory=list)
-
-    def __post_init__(self):
-        if not self.paths or any(not p for p in self.paths):
-            raise ValueError("bank source requires non-empty paths")
-
-
-@dataclass
-class RandomControls(Serializable):
-    """Random filtering comparisons, matched to the experiment's removal size."""
-
-    count: int = 3
-    sampling_seed: int = 42
-
-
-@dataclass
-class ControlBank(SubsetBank):
-    """Evaluate the first count bank entries."""
-
-    count: int | None = 3
-    """Number of bank entries to evaluate; None uses all entries."""
-
-
-@dataclass
-class NoControls(Serializable):
-    """Skip random-control evaluation."""
-
-
-@dataclass
-class LDSConfig(Serializable):
-    """Correlate subset score sums with retrained query loss changes."""
-
-    subsets: Union[RandomSubsets, SubsetBank] = tagged_subgroups(
-        {"random": RandomSubsets, "bank": SubsetBank},
-        default="random",
-        tag="source",
-    )
+    """Retrain bank directories, used with subsets: bank."""
     start: int = 0
     """First subset to evaluate/retrain, for sharding an LDS run."""
     stop: int | None = None
     """Exclusive final subset index; None uses the full list."""
 
     def __post_init__(self):
+        if self.sampling not in ("partition", "random"):
+            raise ValueError("sampling must be partition or random")
+        if not 0 < self.fraction <= 1:
+            raise ValueError("fraction must be in (0, 1]")
         if self.start < 0 or (self.stop is not None and self.stop <= self.start):
             raise ValueError("LDS requires 0 <= start < stop")
 
@@ -113,11 +85,7 @@ class FilterConfig(Serializable):
     direction: Literal["proponents", "detractors"] = "proponents"
     fraction: float = 0.05
     """Fraction of the eligible data to remove."""
-    controls: Union[RandomControls, ControlBank, NoControls] = tagged_subgroups(
-        {"random": RandomControls, "bank": ControlBank, "skip": NoControls},
-        default="random",
-        tag="source",
-    )
+    controls: ControlsConfig = field(default_factory=ControlsConfig)
 
     def __post_init__(self):
         if self.direction not in ("proponents", "detractors"):
@@ -168,7 +136,7 @@ def migrate_validation_config(obj: dict) -> dict:
         return obj
     warnings.warn(
         "Flat validation options are deprecated; use a nested method config "
-        "with kind and source tags",
+        "with a kind tag",
         FutureWarning,
         stacklevel=3,
     )
@@ -184,21 +152,15 @@ def migrate_validation_config(obj: dict) -> dict:
         if old.get("weight_lrs") and not paths:
             obj["method"] = {"kind": "weight_step", "lrs": old["weight_lrs"]}
         else:
-            source = (
-                {"source": "bank", "paths": paths}
-                if paths
-                else {
-                    "source": "random",
-                    "count": count,
-                    "sampling": "random" if fraction > 0 else "partition",
-                    "fraction": fraction if fraction > 0 else 0.05,
-                    "sampling_seed": sampling_seed,
-                    "manifest": old.get("subsets", ""),
-                }
-            )
             obj["method"] = {
                 "kind": "lds",
-                "subsets": source,
+                "subsets": "bank" if paths else "retrain",
+                "paths": paths,
+                "count": count,
+                "sampling": "random" if fraction > 0 else "partition",
+                "fraction": fraction if fraction > 0 else 0.05,
+                "sampling_seed": sampling_seed,
+                "manifest": old.get("subsets", ""),
                 "start": old.get("subset_start", 0),
                 "stop": old.get("subset_stop"),
             }
@@ -217,17 +179,17 @@ def migrate_validation_config(obj: dict) -> dict:
         if mode == "retrain" and count <= 0:
             raise ValueError("controls: retrain requires num_subsets > 0")
         if mode == "skip":
-            controls = {"source": "skip"}
+            controls = {"kind": "none"}
         elif paths and mode != "retrain":
-            controls = {"source": "bank", "paths": paths, "count": None}
+            controls = {"kind": "bank", "paths": paths, "count": None}
         elif count > 0:
             controls = {
-                "source": "random",
+                "kind": "retrain",
                 "count": count,
                 "sampling_seed": sampling_seed,
             }
         else:
-            controls = {"source": "skip"}
+            controls = {"kind": "none"}
         obj["method"] = {
             "kind": "filter",
             "direction": method.removeprefix("filter-"),

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -147,7 +147,7 @@ class WeightStepConfig(Serializable):
 
     def __post_init__(self):
         if not self.lrs:
-            raise ValueError("weight-step requires at least one lr")
+            raise ValueError("weight_step requires at least one lr")
 
 
 LEGACY_FIELDS = {
@@ -191,7 +191,7 @@ def migrate_validation_config(obj: dict) -> dict:
     sampling_seed = obj.get("seed", 42)
     if method == "lds":
         if old.get("weight_lrs") and not paths:
-            obj["method"] = {"kind": "weight-step", "lrs": old["weight_lrs"]}
+            obj["method"] = {"kind": "weight_step", "lrs": old["weight_lrs"]}
         else:
             source = (
                 {"source": "bank", "paths": paths}

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -1,13 +1,16 @@
 """Method-specific validation experiments and their serialized discriminators."""
 
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Literal, Union
+from typing import Literal, TypeVar, Union
 
 from simple_parsing import Serializable, field, subgroups
 
+T = TypeVar("T", bound=Serializable)
 
-def tagged_subgroups(choices: dict[str, Any], *, default: str, tag: str):
+
+def tagged_subgroups(choices: Mapping[str, type[T]], *, default: str, tag: str) -> T:
     """Preserve subgroup identity across CLI parsing and YAML round trips.
 
     SimpleParsing's default Union decoder tries alternatives in order and can
@@ -27,7 +30,9 @@ def tagged_subgroups(choices: dict[str, Any], *, default: str, tag: str):
             raise ValueError(f"Expected {tag} in {list(choices)}, got {key!r}")
         return choices[key].from_dict(payload, drop_extra_fields=False)
 
-    return subgroups(choices, default=default, encoding_fn=encode, decoding_fn=decode)
+    return subgroups(
+        dict(choices), default=default, encoding_fn=encode, decoding_fn=decode
+    )
 
 
 def _positive_count(count: int):

--- a/bergson/config/validation.py
+++ b/bergson/config/validation.py
@@ -1,0 +1,248 @@
+"""Method-specific validation experiments and their serialized discriminators."""
+
+import warnings
+from dataclasses import dataclass
+from typing import Any, Literal, Union
+
+from simple_parsing import Serializable, field, subgroups
+
+
+def tagged_subgroups(choices: dict[str, Any], *, default: str, tag: str):
+    """Use CLI subgroups without losing their identity in YAML round trips.
+
+    SimpleParsing's default Union decoder tries alternatives in order and can
+    silently discard fields. Decode only the explicitly selected concrete type.
+    """
+
+    def encode(value):
+        key = next(key for key, cls in choices.items() if type(value) is cls)
+        return {tag: key, **value.to_dict()}
+
+    def decode(value):
+        if not isinstance(value, dict):
+            raise ValueError(f"Expected a mapping with {tag}: {list(choices)}")
+        payload = dict(value)
+        key = payload.pop(tag, None)
+        if key not in choices:
+            raise ValueError(f"Expected {tag} in {list(choices)}, got {key!r}")
+        return choices[key].from_dict(payload, drop_extra_fields=False)
+
+    return subgroups(choices, default=default, encoding_fn=encode, decoding_fn=decode)
+
+
+def _positive_count(count: int):
+    if count <= 0:
+        raise ValueError("count must be positive; use controls: {source: skip} to skip")
+
+
+@dataclass
+class RandomSubsets(Serializable):
+    """LDS observations, generated independently of attribution scores."""
+
+    count: int = 100
+    sampling: Literal["partition", "random"] = "partition"
+    """Partition the pool, or draw count independent fixed-size subsets."""
+    fraction: float = 0.05
+    """Removal fraction for random sampling; partition uses count equal chunks."""
+    sampling_seed: int = 42
+    manifest: str = ""
+    """Optional subsets.json to reuse instead of sampling."""
+
+    def __post_init__(self):
+        _positive_count(self.count)
+        if self.sampling not in ("partition", "random"):
+            raise ValueError("sampling must be partition or random")
+        if not 0 < self.fraction <= 1:
+            raise ValueError("fraction must be in (0, 1]")
+
+
+@dataclass
+class SubsetBank(Serializable):
+    """Existing LDS retrains; corresponding subsets across paths are averaged."""
+
+    paths: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not self.paths or any(not p for p in self.paths):
+            raise ValueError("bank source requires non-empty paths")
+
+
+@dataclass
+class RandomControls(Serializable):
+    """Random filtering comparisons, matched to the experiment's removal size."""
+
+    count: int = 3
+    sampling_seed: int = 42
+
+    def __post_init__(self):
+        _positive_count(self.count)
+
+
+@dataclass
+class ControlBank(SubsetBank):
+    """Use the first count bank entries, chosen independently of their losses."""
+
+    count: int | None = 3
+    """Number of bank entries to evaluate; None uses all entries."""
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.count is not None:
+            _positive_count(self.count)
+
+
+@dataclass
+class NoControls(Serializable):
+    """Measure the ranked removal without a random comparison."""
+
+
+@dataclass
+class LDSConfig(Serializable):
+    """Correlate subset score sums with retrained query loss changes."""
+
+    subsets: Union[RandomSubsets, SubsetBank] = tagged_subgroups(
+        {"random": RandomSubsets, "bank": SubsetBank},
+        default="random",
+        tag="source",
+    )
+    start: int = 0
+    """First subset to evaluate/retrain, for sharding an LDS run."""
+    stop: int | None = None
+    """Exclusive final subset index; None uses the full list."""
+
+    def __post_init__(self):
+        if self.start < 0 or (self.stop is not None and self.stop <= self.start):
+            raise ValueError("LDS requires 0 <= start < stop")
+
+
+@dataclass
+class FilterConfig(Serializable):
+    """Remove one ranked tail and optionally compare with random removals."""
+
+    direction: Literal["proponents", "detractors"] = "proponents"
+    fraction: float = 0.05
+    """Fraction removed, independent of the control count."""
+    controls: Union[RandomControls, ControlBank, NoControls] = tagged_subgroups(
+        {"random": RandomControls, "bank": ControlBank, "skip": NoControls},
+        default="random",
+        tag="source",
+    )
+
+    def __post_init__(self):
+        if self.direction not in ("proponents", "detractors"):
+            raise ValueError("direction must be proponents or detractors")
+        if not 0 < self.fraction <= 1:
+            raise ValueError("filter fraction must be in (0, 1]")
+
+    @property
+    def name(self) -> str:
+        return f"filter-{self.direction}"
+
+
+@dataclass
+class WeightStepConfig(Serializable):
+    """Compare weight-gradient steps with their first-order predictions."""
+
+    lrs: list[float] = field(default_factory=lambda: [1.0])
+
+    def __post_init__(self):
+        if not self.lrs:
+            raise ValueError("weight-step requires at least one lr")
+
+
+LEGACY_FIELDS = {
+    "num_subsets",
+    "subset_fraction",
+    "subsets",
+    "subset_start",
+    "subset_stop",
+    "weight_lrs",
+    "controls",
+    "retrained_dir",
+}
+
+
+def migrate_validation_config(obj: dict) -> dict:
+    """Resolve old flat YAML once; execution only sees typed method configs."""
+    obj = dict(obj)
+    method = obj.get("method")
+    legacy = LEGACY_FIELDS.intersection(obj)
+    if isinstance(method, dict):
+        if legacy:
+            raise ValueError(
+                f"Cannot mix nested method with legacy fields: {sorted(legacy)}"
+            )
+        return obj
+    if method is None and not legacy and obj.get("seed", 42) == 42:
+        return obj
+    warnings.warn(
+        "Flat validation options are deprecated; use a nested method config "
+        "with kind and source tags",
+        FutureWarning,
+        stacklevel=3,
+    )
+    method = obj.pop("method", "lds")
+    old = {key: obj.pop(key) for key in legacy}
+    count = old.get("num_subsets", 100)
+    fraction = old.get("subset_fraction", 0.0)
+    paths = old.get("retrained_dir", [])
+    if isinstance(paths, str):
+        paths = [p for p in paths.split(",") if p]
+    sampling_seed = obj.get("seed", 42)
+    if method == "lds":
+        if old.get("weight_lrs") and not paths:
+            obj["method"] = {"kind": "weight-step", "lrs": old["weight_lrs"]}
+        else:
+            source = (
+                {"source": "bank", "paths": paths}
+                if paths
+                else {
+                    "source": "random",
+                    "count": count,
+                    "sampling": "random" if fraction > 0 else "partition",
+                    "fraction": fraction if fraction > 0 else 0.05,
+                    "sampling_seed": sampling_seed,
+                    "manifest": old.get("subsets", ""),
+                }
+            )
+            obj["method"] = {
+                "kind": "lds",
+                "subsets": source,
+                "start": old.get("subset_start", 0),
+                "stop": old.get("subset_stop"),
+            }
+    elif method in ("filter-proponents", "filter-detractors"):
+        if fraction == 0:
+            if count <= 0:
+                raise ValueError(
+                    "subset_fraction must be positive when num_subsets is 0"
+                )
+            fraction = 1 / count
+        mode = old.get("controls", "auto")
+        if mode not in ("auto", "load", "retrain", "skip"):
+            raise ValueError(f"Unknown legacy controls mode: {mode}")
+        if mode == "load" and not paths:
+            raise ValueError("controls: load requires retrained_dir")
+        if mode == "retrain" and count <= 0:
+            raise ValueError("controls: retrain requires num_subsets > 0")
+        if mode == "skip":
+            controls = {"source": "skip"}
+        elif paths and mode != "retrain":
+            controls = {"source": "bank", "paths": paths, "count": None}
+        elif count > 0:
+            controls = {
+                "source": "random",
+                "count": count,
+                "sampling_seed": sampling_seed,
+            }
+        else:
+            controls = {"source": "skip"}
+        obj["method"] = {
+            "kind": "filter",
+            "direction": method.removeprefix("filter-"),
+            "fraction": fraction,
+            "controls": controls,
+        }
+    else:
+        raise ValueError(f"Unknown legacy validation method: {method!r}")
+    return obj

--- a/bergson/huggingface.py
+++ b/bergson/huggingface.py
@@ -373,7 +373,7 @@ class GradientCollectorCallback(TrainerCallback):
 
         if dist.is_initialized():
             # Gather training order from all processes
-            all_orders = [None] * dist.get_world_size()
+            all_orders: list[list[dict] | None] = [None] * dist.get_world_size()
             dist.all_gather_object(all_orders, self.order)
 
             # Only rank 0 saves the merged data

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -3,7 +3,6 @@ import json
 import os
 import shutil
 import time
-from collections.abc import Sequence
 from dataclasses import asdict, replace
 from pathlib import Path
 
@@ -31,6 +30,7 @@ from transformers.utils.logging import (
 
 from ..config.config import TrainingConfig, ValidationConfig
 from ..config.config_io import save_run_config
+from ..config.validation import LDSConfig
 from ..data import (
     compute_num_token_grads,
     load_scores_loss_signed,
@@ -396,7 +396,6 @@ def worker(
     score_path: str = "",
     validate: bool = False,
     baseline_model: str = "",
-    retrained_dir: Sequence[str] = (),
 ):
     if torch.cuda.is_available():
         torch.cuda.set_device(get_device_index(rank))
@@ -511,7 +510,11 @@ def worker(
             )
 
     # A sliced run leaves the shared baseline to the process that starts at 0.
-    trails_slice = isinstance(run_cfg, ValidationConfig) and run_cfg.subset_start != 0
+    trails_slice = (
+        isinstance(run_cfg, ValidationConfig)
+        and isinstance(run_cfg.method, LDSConfig)
+        and run_cfg.method.start != 0
+    )
     if run_cfg.save_models and global_rank == 0 and not trails_slice:
         # For the leave-k-out family the trained model is the query baseline
         # that evaluate_retrained reads from retrained/base.
@@ -667,7 +670,6 @@ def worker(
         run_cfg,
         scores,
         multi_query,
-        retrained_dir=retrained_dir,
         global_rank=global_rank,
         rank=rank,
         schedule=schedule,
@@ -689,7 +691,6 @@ def run_magic(
     score_path: str = "",
     validate: bool = False,
     baseline_model: str = "",
-    retrained_dir: Sequence[str] = (),
 ):
     """Train ``run_cfg``, score the query set, and validate those scores."""
     if validate and not isinstance(run_cfg, ValidationConfig):
@@ -745,7 +746,6 @@ def run_magic(
             score_path,
             validate,
             baseline_model,
-            retrained_dir,
         ],
         run_cfg.distributed,
     )

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -527,7 +527,7 @@ def tail_filter_retrain(
     # Otherwise compute the baseline.
     dirs = [Path(d) for d in retrained_dir]
 
-    # Resolve the control source; explicit modes fail loudly when unmet.
+    # Resolve the control source.
     mode = getattr(run_cfg, "controls", "auto")
     if mode == "load" and not dirs:
         raise ValueError(

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -561,11 +561,10 @@ def tail_filter_retrain(
     elif mode != "skip" and run_cfg.num_subsets > 0:
         subsets = _baseline_subsets(run_cfg, valid_indices, num_filtered)
         if global_rank == 0:
-            print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
             print(
-                "  note: control retrains are per process; sharded runs should "
-                "build them once and share via retrained_dir (controls: load)"
+                "No retrain dir detected. Random selection controls will be retrained."
             )
+            print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
         random_baseline = baseline_vec
         random_losses = torch.stack(
             [

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -527,9 +527,7 @@ def tail_filter_retrain(
     # Otherwise compute the baseline.
     dirs = [Path(d) for d in retrained_dir]
 
-    # Resolve where the random controls come from. `auto` is the historical
-    # precedence; an explicit value is checked so a config cannot silently get a
-    # different baseline than it asks for.
+    # Resolve the control source; explicit modes fail loudly when unmet.
     mode = getattr(run_cfg, "controls", "auto")
     if mode == "load" and not dirs:
         raise ValueError(
@@ -565,10 +563,8 @@ def tail_filter_retrain(
         if global_rank == 0:
             print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
             print(
-                f"  note: these {len(subsets)} control retrains are per process. "
-                "If this run is one shard of a sharded filter, every other shard "
-                "is retraining its own copy. Build them once and set "
-                "retrained_dir (controls: load) to share them."
+                "  note: control retrains are per process; sharded runs should "
+                "build them once and share via retrained_dir (controls: load)"
             )
         random_baseline = baseline_vec
         random_losses = torch.stack(

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -526,6 +526,22 @@ def tail_filter_retrain(
     # Load existing baseline if it exists - a random filter retrain.
     # Otherwise compute the baseline.
     dirs = [Path(d) for d in retrained_dir]
+
+    # Resolve where the random controls come from. `auto` is the historical
+    # precedence; an explicit value is checked so a config cannot silently get a
+    # different baseline than it asks for.
+    mode = getattr(run_cfg, "controls", "auto")
+    if mode == "load" and not dirs:
+        raise ValueError(
+            "controls: load requires retrained_dir to point at retrained subsets"
+        )
+    if mode == "retrain":
+        if run_cfg.num_subsets <= 0:
+            raise ValueError("controls: retrain requires num_subsets > 0")
+        dirs = []
+    elif mode == "skip":
+        dirs = []
+
     if dirs:
         subsets = load_and_validate_subsets_match(run_cfg, dirs, num_filtered)
         bank_base, bank_base_per_doc, per_subset = load_bank_losses(
@@ -544,10 +560,16 @@ def tail_filter_retrain(
         )
         random_losses = per_subset.reshape(len(subsets), num_queries)
         source = "bank " + ", ".join(str(d) for d in dirs)
-    elif run_cfg.num_subsets > 0:
+    elif mode != "skip" and run_cfg.num_subsets > 0:
         subsets = _baseline_subsets(run_cfg, valid_indices, num_filtered)
         if global_rank == 0:
             print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
+            print(
+                f"  note: these {len(subsets)} control retrains are per process. "
+                "If this run is one shard of a sharded filter, every other shard "
+                "is retraining its own copy. Build them once and set "
+                "retrained_dir (controls: load) to share them."
+            )
         random_baseline = baseline_vec
         random_losses = torch.stack(
             [
@@ -561,6 +583,7 @@ def tail_filter_retrain(
             print(
                 "No random baseline: set num_subsets > 0, or retrained_dir to a "
                 "path to random-subset retrains"
+                + (" (controls: skip was requested)" if mode == "skip" else "")
             )
         return
 

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -577,11 +577,13 @@ def tail_filter_retrain(
         source = "retrained here"
     else:
         if global_rank == 0:
-            print(
-                "No random baseline: set num_subsets > 0, or retrained_dir to a "
-                "path to random-subset retrains"
-                + (" (controls: skip was requested)" if mode == "skip" else "")
-            )
+            if mode == "skip":
+                print("Skipping random baseline (controls: skip)")
+            else:
+                print(
+                    "No random baseline: set num_subsets > 0, or retrained_dir "
+                    "to a path to random-subset retrains"
+                )
         return
 
     if global_rank != 0:

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -561,9 +561,11 @@ def tail_filter_retrain(
     elif mode != "skip" and run_cfg.num_subsets > 0:
         subsets = _baseline_subsets(run_cfg, valid_indices, num_filtered)
         if global_rank == 0:
-            print(
-                "No retrain dir detected. Random selection controls will be retrained."
-            )
+            if mode == "auto":
+                print(
+                    "No retrain dir detected. "
+                    "Random selection controls will be retrained."
+                )
             print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
         random_baseline = baseline_vec
         random_losses = torch.stack(

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -330,10 +330,10 @@ def load_bank_losses(
 
 
 def _baseline_subsets(
-    controls: ControlsConfig, valid_indices: torch.Tensor, k: int
+    controls: ControlsConfig, valid_indices: torch.Tensor, k: int, seed: int
 ) -> list[torch.Tensor]:
     """Random removal sets of ``k`` documents to compare the filter against."""
-    rng = torch.Generator().manual_seed(controls.sampling_seed)
+    rng = torch.Generator().manual_seed(seed)
     return [
         valid_indices[torch.randperm(len(valid_indices), generator=rng)[:k]]
         for _ in range(controls.count or 0)
@@ -556,7 +556,7 @@ def tail_filter_retrain(
         random_losses = per_subset.reshape(len(subsets), num_queries)
         source = "bank " + ", ".join(str(d) for d in dirs)
     elif controls.kind == "retrain":
-        subsets = _baseline_subsets(controls, valid_indices, num_filtered)
+        subsets = _baseline_subsets(controls, valid_indices, num_filtered, run_cfg.seed)
         if global_rank == 0:
             print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
         random_baseline = baseline_vec
@@ -771,8 +771,8 @@ def validate_scores(
         with open(subsets_path) as f:
             subsets = [torch.tensor(s, dtype=torch.long) for s in json.load(f)]
     else:
-        rng = torch.Generator().manual_seed(method.sampling_seed)
-        if method.sampling == "random":
+        rng = torch.Generator().manual_seed(run_cfg.seed)
+        if method.fraction > 0:
             # Draw potentially overlapping samples
             subset_size = max(1, round(method.fraction * len(valid_indices)))
 
@@ -792,7 +792,7 @@ def validate_scores(
             # but prevents the early subsets from being biased towards higher
             # or lower scores.
             subsets = list(perm.chunk(method.count))
-            rng = random.Random(method.sampling_seed)
+            rng = random.Random(run_cfg.seed)
             rng.shuffle(subsets)
 
     start = run_cfg.method.start

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -32,12 +32,9 @@ from transformers.utils.logging import (
 from .config.config import ValidationConfig
 from .config.config_io import get_config_field, save_run_config
 from .config.validation import (
-    ControlBank,
+    ControlsConfig,
     FilterConfig,
     LDSConfig,
-    NoControls,
-    RandomControls,
-    RandomSubsets,
     WeightStepConfig,
 )
 from .data import load_scores_loss_signed, pad_and_tensor
@@ -333,13 +330,13 @@ def load_bank_losses(
 
 
 def _baseline_subsets(
-    controls: RandomControls, valid_indices: torch.Tensor, k: int
+    controls: ControlsConfig, valid_indices: torch.Tensor, k: int
 ) -> list[torch.Tensor]:
     """Random removal sets of ``k`` documents to compare the filter against."""
     rng = torch.Generator().manual_seed(controls.sampling_seed)
     return [
         valid_indices[torch.randperm(len(valid_indices), generator=rng)[:k]]
-        for _ in range(controls.count)
+        for _ in range(controls.count or 0)
     ]
 
 
@@ -430,7 +427,7 @@ def tail_filter_retrain(
     """Retrain with one tail of the score ranking filtered out.
 
     Random filters removing the same number of documents run alongside it,
-    retrained here or read from a bank; ``source: skip`` omits them.
+    retrained here or read from a bank; ``kind: none`` omits them.
     ``load_scores_loss_signed`` signs proponents negative (they reduce
     query loss), so a positive ``loss_change`` means the filter worsened query
     performance -- the opposite sign to the LDS ``diff`` column.
@@ -451,7 +448,7 @@ def tail_filter_retrain(
     # Resolve and validate bank metadata before any ranked retraining.
     dirs = []
     subsets = []
-    if isinstance(controls, ControlBank):
+    if controls.kind == "bank":
         dirs = [Path(d) for d in controls.paths]
         subsets = load_and_validate_subsets_match(run_cfg, dirs, num_filtered)
         if controls.count is not None:
@@ -541,7 +538,7 @@ def tail_filter_retrain(
         )
         print(f"Saved tail-filter data to {csv_path}")
 
-    if isinstance(controls, ControlBank):
+    if controls.kind == "bank":
         bank_base, bank_base_per_doc, per_subset = load_bank_losses(
             run_cfg,
             dirs,
@@ -558,7 +555,7 @@ def tail_filter_retrain(
         )
         random_losses = per_subset.reshape(len(subsets), num_queries)
         source = "bank " + ", ".join(str(d) for d in dirs)
-    elif isinstance(controls, RandomControls):
+    elif controls.kind == "retrain":
         subsets = _baseline_subsets(controls, valid_indices, num_filtered)
         if global_rank == 0:
             print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
@@ -571,9 +568,8 @@ def tail_filter_retrain(
         )
         source = "retrained here"
     else:
-        assert isinstance(controls, NoControls)
         if global_rank == 0:
-            print("Skipping random baseline (controls source: skip)")
+            print("Skipping random baseline (controls kind: none)")
         return
 
     if global_rank != 0:
@@ -768,24 +764,23 @@ def validate_scores(
 
     method = run_cfg.method
     assert isinstance(method, LDSConfig)
-    sampling = method.subsets
-    if not isinstance(sampling, RandomSubsets):
+    if method.subsets == "bank":
         raise ValueError("LDS bank sources must use evaluate_retrained")
-    subsets_path = sampling.manifest or os.path.join(run_cfg.run_path, "subsets.json")
+    subsets_path = method.manifest or os.path.join(run_cfg.run_path, "subsets.json")
     if os.path.exists(subsets_path):
         with open(subsets_path) as f:
             subsets = [torch.tensor(s, dtype=torch.long) for s in json.load(f)]
     else:
-        rng = torch.Generator().manual_seed(sampling.sampling_seed)
-        if sampling.sampling == "random":
+        rng = torch.Generator().manual_seed(method.sampling_seed)
+        if method.sampling == "random":
             # Draw potentially overlapping samples
-            subset_size = max(1, round(sampling.fraction * len(valid_indices)))
+            subset_size = max(1, round(method.fraction * len(valid_indices)))
 
             subsets = [
                 valid_indices[
                     torch.randperm(len(valid_indices), generator=rng)[:subset_size]
                 ]
-                for _ in range(sampling.count)
+                for _ in range(method.count)
             ]
         else:
             # Draw non-overlapping samples
@@ -796,8 +791,8 @@ def validate_scores(
             # the final correlation since all subsets are eventually evaluated,
             # but prevents the early subsets from being biased towards higher
             # or lower scores.
-            subsets = list(perm.chunk(sampling.count))
-            rng = random.Random(sampling.sampling_seed)
+            subsets = list(perm.chunk(method.count))
+            rng = random.Random(method.sampling_seed)
             rng.shuffle(subsets)
 
     start = run_cfg.method.start

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -11,7 +11,6 @@ import hashlib
 import json
 import os
 import random
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Callable
 
@@ -32,6 +31,15 @@ from transformers.utils.logging import (
 
 from .config.config import ValidationConfig
 from .config.config_io import get_config_field, save_run_config
+from .config.validation import (
+    ControlBank,
+    FilterConfig,
+    LDSConfig,
+    NoControls,
+    RandomControls,
+    RandomSubsets,
+    WeightStepConfig,
+)
 from .data import load_scores_loss_signed, pad_and_tensor
 from .magic.data_stream import DataStream, mask_padded_rows, pad_dataset_to_batch_size
 from .magic.grad_accum import loss_denom, split_batch
@@ -232,7 +240,7 @@ def load_and_validate_subsets_match(
         if max(abs(n - num_filtered) for n in sizes) > 1:
             raise ValueError(
                 f"{d} removes {sizes} docs per subset but the filter removes "
-                f"{num_filtered}; set subset_fraction to match."
+                f"{num_filtered}; set method.fraction to match."
             )
         for field, ours in [
             ("model", run_cfg.model),
@@ -325,13 +333,13 @@ def load_bank_losses(
 
 
 def _baseline_subsets(
-    run_cfg: ValidationConfig, valid_indices: torch.Tensor, k: int
+    controls: RandomControls, valid_indices: torch.Tensor, k: int
 ) -> list[torch.Tensor]:
     """Random removal sets of ``k`` documents to compare the filter against."""
-    rng = torch.Generator().manual_seed(run_cfg.seed)
+    rng = torch.Generator().manual_seed(controls.sampling_seed)
     return [
         valid_indices[torch.randperm(len(valid_indices), generator=rng)[:k]]
-        for _ in range(run_cfg.num_subsets)
+        for _ in range(controls.count)
     ]
 
 
@@ -418,30 +426,40 @@ def tail_filter_retrain(
     num_queries: int,
     pad_count: int,
     weight_pad_count: int,
-    retrained_dir: Sequence[str],
 ):
     """Retrain with one tail of the score ranking filtered out.
 
     Random filters removing the same number of documents run alongside it,
-    retrained here or read from a bank; ``num_subsets = 0`` and no bank skips
-    them. ``load_scores_loss_signed`` signs proponents negative (they reduce
+    retrained here or read from a bank; ``source: skip`` omits them.
+    ``load_scores_loss_signed`` signs proponents negative (they reduce
     query loss), so a positive ``loss_change`` means the filter worsened query
     performance -- the opposite sign to the LDS ``diff`` column.
     """
+    method = run_cfg.method
+    assert isinstance(method, FilterConfig)
+    controls = method.controls
     if run_cfg.exclude_zero_scores:
         valid_indices = torch.nonzero((flat_scores != 0).any(dim=1), as_tuple=True)[0]
     else:
         valid_indices = torch.arange(flat_scores.shape[0])
 
     pool = len(valid_indices)
-    if run_cfg.subset_fraction == 0.0:
-        if run_cfg.num_subsets <= 0:
-            raise ValueError(
-                "subset_fraction must be positive when num_subsets is 0: there is "
-                "no leave-k-out chunk size for the filter to match"
-            )
-        run_cfg.subset_fraction = 1 / run_cfg.num_subsets
-    num_filtered = max(1, round(run_cfg.subset_fraction * pool))
+    if not pool:
+        raise ValueError("Cannot filter an empty eligible removal pool")
+    num_filtered = max(1, round(method.fraction * pool))
+
+    # Resolve and validate bank metadata before any ranked retraining.
+    dirs = []
+    subsets = []
+    if isinstance(controls, ControlBank):
+        dirs = [Path(d) for d in controls.paths]
+        subsets = load_and_validate_subsets_match(run_cfg, dirs, num_filtered)
+        if controls.count is not None:
+            if controls.count > len(subsets):
+                raise ValueError("control count exceeds the number of bank subsets")
+            subsets = subsets[: controls.count]
+        if not subsets:
+            raise ValueError("Control bank contains no subsets")
 
     baseline_vec = (
         baseline_per_doc[:num_queries] if multi_query else torch.tensor([baseline])
@@ -487,7 +505,7 @@ def tail_filter_retrain(
     hf_disable_pbar()
     hf_set_verbosity_error()
 
-    csv_path = os.path.join(run_cfg.run_path, f"{run_cfg.method.replace('-', '_')}.csv")
+    csv_path = os.path.join(run_cfg.run_path, f"{method.name.replace('-', '_')}.csv")
     filter_csv = CSVWriter(
         csv_path,
         columns=["query", "n_removed", "baseline_loss", "filtered_loss", "loss_change"],
@@ -495,10 +513,10 @@ def tail_filter_retrain(
     )
 
     filter_changes = torch.zeros(num_queries)
-    pbar = tqdm(range(num_queries), desc=run_cfg.method, disable=global_rank != 0)
+    pbar = tqdm(range(num_queries), desc=method.name, disable=global_rank != 0)
     for q in pbar:
         removed = _select_filter_slice(
-            flat_scores, valid_indices, q, num_filtered, run_cfg.method
+            flat_scores, valid_indices, q, num_filtered, method.name
         )
         losses = retrain_and_eval(removed)
 
@@ -516,32 +534,14 @@ def tail_filter_retrain(
     filter_csv.close()
     if global_rank == 0:
         print(
-            f"{run_cfg.method}: mean loss change {filter_changes.mean():.6f} "
+            f"{method.name}: mean loss change {filter_changes.mean():.6f} "
             f"over {num_queries} quer{'y' if num_queries == 1 else 'ies'} "
             f"({num_filtered} of {pool} docs removed per query, "
             f"{num_filtered / pool:.3%})"
         )
         print(f"Saved tail-filter data to {csv_path}")
 
-    # Load existing baseline if it exists - a random filter retrain.
-    # Otherwise compute the baseline.
-    dirs = [Path(d) for d in retrained_dir]
-
-    # Resolve the control source.
-    mode = getattr(run_cfg, "controls", "auto")
-    if mode == "load" and not dirs:
-        raise ValueError(
-            "controls: load requires retrained_dir to point at retrained subsets"
-        )
-    if mode == "retrain":
-        if run_cfg.num_subsets <= 0:
-            raise ValueError("controls: retrain requires num_subsets > 0")
-        dirs = []
-    elif mode == "skip":
-        dirs = []
-
-    if dirs:
-        subsets = load_and_validate_subsets_match(run_cfg, dirs, num_filtered)
+    if isinstance(controls, ControlBank):
         bank_base, bank_base_per_doc, per_subset = load_bank_losses(
             run_cfg,
             dirs,
@@ -558,14 +558,9 @@ def tail_filter_retrain(
         )
         random_losses = per_subset.reshape(len(subsets), num_queries)
         source = "bank " + ", ".join(str(d) for d in dirs)
-    elif mode != "skip" and run_cfg.num_subsets > 0:
-        subsets = _baseline_subsets(run_cfg, valid_indices, num_filtered)
+    elif isinstance(controls, RandomControls):
+        subsets = _baseline_subsets(controls, valid_indices, num_filtered)
         if global_rank == 0:
-            if mode == "auto":
-                print(
-                    "No retrain dir detected. "
-                    "Random selection controls will be retrained."
-                )
             print(f"Retraining {len(subsets)} random subsets of {num_filtered} docs")
         random_baseline = baseline_vec
         random_losses = torch.stack(
@@ -576,14 +571,9 @@ def tail_filter_retrain(
         )
         source = "retrained here"
     else:
+        assert isinstance(controls, NoControls)
         if global_rank == 0:
-            if mode == "skip":
-                print("Skipping random baseline (controls: skip)")
-            else:
-                print(
-                    "No random baseline: set num_subsets > 0, or retrained_dir "
-                    "to a path to random-subset retrains"
-                )
+            print("Skipping random baseline (controls source: skip)")
         return
 
     if global_rank != 0:
@@ -615,7 +605,7 @@ def tail_filter_retrain(
 
     _report_filter_baseline(
         run_cfg.run_path,
-        run_cfg.method,
+        method.name,
         filter_changes,
         random_changes,
         num_filtered,
@@ -640,7 +630,6 @@ def validate_scores(
     query_weight_pad_count: int,
     pad_count: int,
     weight_pad_count: int,
-    retrained_dir: Sequence[str] = (),
 ):
     """Validate attribution scores via leave-subset-out retraining.
 
@@ -677,7 +666,7 @@ def validate_scores(
     num_queries = scores.shape[-1] if multi_query else 1
     flat_scores = scores.reshape(-1, num_queries)
 
-    if run_cfg.method != "lds":
+    if isinstance(run_cfg.method, FilterConfig):
         tail_filter_retrain(
             run_cfg,
             flat_scores,
@@ -693,11 +682,10 @@ def validate_scores(
             num_queries=num_queries,
             pad_count=pad_count,
             weight_pad_count=weight_pad_count,
-            retrained_dir=retrained_dir,
         )
         return
 
-    if run_cfg.weight_lrs:
+    if isinstance(run_cfg.method, WeightStepConfig):
         # Gradient step on the data weights: retrain with w = 1 - lr * score
         # for each lr and compare the query loss change to the first-order
         # prediction lr * <s_q, s_step>.
@@ -714,7 +702,7 @@ def validate_scores(
             enabled=global_rank == 0,
         )
 
-        for lr in run_cfg.weight_lrs:
+        for lr in run_cfg.method.lrs:
             trainer, fwd_state, model = prepare_trainer(run_cfg, rank, schedule)
             fwd_state.detach_()
 
@@ -778,21 +766,26 @@ def validate_scores(
     else:
         valid_indices = torch.arange(flat_scores.shape[0])
 
-    subsets_path = run_cfg.subsets or os.path.join(run_cfg.run_path, "subsets.json")
+    method = run_cfg.method
+    assert isinstance(method, LDSConfig)
+    sampling = method.subsets
+    if not isinstance(sampling, RandomSubsets):
+        raise ValueError("LDS bank sources must use evaluate_retrained")
+    subsets_path = sampling.manifest or os.path.join(run_cfg.run_path, "subsets.json")
     if os.path.exists(subsets_path):
         with open(subsets_path) as f:
             subsets = [torch.tensor(s, dtype=torch.long) for s in json.load(f)]
     else:
-        rng = torch.Generator().manual_seed(run_cfg.seed)
-        if run_cfg.subset_fraction > 0:
+        rng = torch.Generator().manual_seed(sampling.sampling_seed)
+        if sampling.sampling == "random":
             # Draw potentially overlapping samples
-            subset_size = max(1, round(run_cfg.subset_fraction * len(valid_indices)))
+            subset_size = max(1, round(sampling.fraction * len(valid_indices)))
 
             subsets = [
                 valid_indices[
                     torch.randperm(len(valid_indices), generator=rng)[:subset_size]
                 ]
-                for _ in range(run_cfg.num_subsets)
+                for _ in range(sampling.count)
             ]
         else:
             # Draw non-overlapping samples
@@ -803,12 +796,12 @@ def validate_scores(
             # the final correlation since all subsets are eventually evaluated,
             # but prevents the early subsets from being biased towards higher
             # or lower scores.
-            subsets = list(perm.chunk(run_cfg.num_subsets))
-            rng = random.Random(run_cfg.seed)
+            subsets = list(perm.chunk(sampling.count))
+            rng = random.Random(sampling.sampling_seed)
             rng.shuffle(subsets)
 
-    start = run_cfg.subset_start
-    stop = len(subsets) if run_cfg.subset_stop is None else run_cfg.subset_stop
+    start = run_cfg.method.start
+    stop = len(subsets) if run_cfg.method.stop is None else run_cfg.method.stop
     sliced = (start, stop) != (0, len(subsets))
 
     csv_name = f"validation_{start}_{stop}.csv" if sliced else "validation.csv"
@@ -970,6 +963,7 @@ def evaluate_retrained(
     ``save_models=true`` and evaluates attribution scores. No training
     happens so evaluation is cheap.
     """
+    assert isinstance(run_cfg.method, LDSConfig)
     assert score_path, "evaluate_retrained requires precomputed --scores"
     dirs = [
         Path(d)
@@ -1069,8 +1063,8 @@ def evaluate_retrained(
     else:
         print(f"Baseline query loss (no leave-out): {baseline}")
 
-    start = run_cfg.subset_start
-    stop = len(subsets) if run_cfg.subset_stop is None else run_cfg.subset_stop
+    start = run_cfg.method.start
+    stop = len(subsets) if run_cfg.method.stop is None else run_cfg.method.stop
     sliced = (start, stop) != (0, len(subsets))
 
     csv_name = f"validation_{start}_{stop}.csv" if sliced else "validation.csv"

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -441,8 +441,6 @@ def tail_filter_retrain(
         valid_indices = torch.arange(flat_scores.shape[0])
 
     pool = len(valid_indices)
-    if not pool:
-        raise ValueError("Cannot filter an empty eligible removal pool")
     num_filtered = max(1, round(method.fraction * pool))
 
     # Resolve and validate bank metadata before any ranked retraining.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -237,7 +237,7 @@ Training & Evaluation
        --data.truncation \
        --query.dataset NeelNanda/pile-10k \
        --query.split "train[:8]" \
-       --num_subsets 10
+       --count 10
 
 .. autoclass:: bergson.__main__.Recall
    :members:

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -13,11 +13,6 @@ To evaluate attributions of large models that cannot be re-trained many times, w
 Validation experiments
 ----------------------
 
-``validate`` and MAGIC's optional validation use one method-specific config.
-Training and query settings remain shared. LDS holds its subset settings;
-filtering has a ``controls`` config. CLI help shows the selected method's
-arguments.
-
 Filtering
 ~~~~~~~~~
 
@@ -36,10 +31,7 @@ default to three retrains.
 
 ``--direction detractors`` removes the opposite end of the score ranking.
 Bank controls evaluate the first ``count`` entries. Multiple ``--paths`` average
-corresponding bank entries. Their removal sets must match across banks, and
-their removal sizes and training settings must be comparable with the filtering
-experiment. Bank counts larger than the available entries are rejected; YAML
-``count: null`` uses all.
+corresponding bank entries.
 
 Equivalent YAML:
 
@@ -59,8 +51,6 @@ Equivalent YAML:
 
 Use ``controls: {kind: none}`` to omit the comparison, or
 ``controls: {kind: bank, paths: [runs/bank], count: 2}`` to reuse retrains.
-A random control is a new random removal set. The shared ``seed`` controls
-subset selection and training randomness.
 
 LDS
 ~~~
@@ -90,30 +80,12 @@ data:
            start: 0
            stop: null
 
-``fraction: 0`` divides the pool into ``count`` subsets. A positive ``fraction``
-draws ``count`` independent random subsets of that size. Subset selection uses
-the shared training ``seed``. ``manifest`` can point to an existing
-``subsets.json``; otherwise an existing manifest in the run directory is reused.
 ``start`` and ``stop`` select a range for sharded retraining or evaluation.
-To evaluate a bank, set ``subsets: bank`` and ``paths: [runs/bank]`` in the LDS
-method config.
+To evaluate using an existing bank of retrained models, set ``subsets: bank``
+and ``paths: [runs/bank]`` in the LDS method config.
 
-Weight steps and migration
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Weight steps
+~~~~~~~~~~~~
 
-Weight-step validation is a separate method:
 ``--method weight_step --lrs 0.1 0.2``, or
 ``method: {kind: weight_step, lrs: [0.1, 0.2]}`` in YAML.
-
-Existing flat YAML configs remain readable with a deprecation warning. Migration
-preserves their old defaults, including filtering's implicit ``1 / num_subsets``
-removal fraction, training-seed-based subset sampling, and use of every bank
-entry. Newly saved configs use a ``kind`` tag to identify the selected method.
-Mixing legacy flat options with a nested method config is rejected.
-
-CLI invocations and direct Python construction should use the new method configs:
-``--num_subsets`` becomes ``--count``, ``--subset_fraction`` becomes
-``--fraction``, and ``--retrained_dir`` becomes the selected bank source's
-``--paths``. The old ``--method filter-proponents`` becomes
-``--method filter --direction proponents``. The legacy global ``controls`` modes
-are replaced by the filtering ``--controls retrain/bank/none`` selector.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -103,8 +103,8 @@ Weight steps and migration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Weight-step validation is a separate method:
-``--method weight-step --lrs 0.1 0.2``, or
-``method: {kind: weight-step, lrs: [0.1, 0.2]}`` in YAML.
+``--method weight_step --lrs 0.1 0.2``, or
+``method: {kind: weight_step, lrs: [0.1, 0.2]}`` in YAML.
 
 Existing flat YAML configs remain readable with a deprecation warning. Migration
 preserves their old defaults, including filtering's implicit ``1 / num_subsets``

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -9,3 +9,113 @@ To evaluate attributions of large models that cannot be re-trained many times, w
 .. TODO: Evaluating attribution scores — ``bergson validate`` (leave-k-out
    retraining / linear datamodeling score), ``bergson recall`` (synthetic
    factual recall, MRR / Recall@k), and ``bergson metasmoothness``.
+
+Validation experiments
+----------------------
+
+``validate`` and MAGIC's optional validation use one method-specific config.
+Training and query settings remain shared. LDS has a ``subsets`` source;
+filtering has an optional ``controls`` source. Only the selected method's
+arguments appear in CLI help.
+
+Filtering
+~~~~~~~~~
+
+Remove a ranked fraction of the data and compare its query loss change with
+random removals of the same size. The fraction defaults to 0.05; random controls
+default to three retrains. Changing the control count never changes the fraction.
+
+.. code-block:: bash
+
+   bergson validate runs/filter --scores runs/magic/scores \
+       --method filter --direction proponents --fraction 0.05 --count 3
+   bergson validate runs/filter-only --scores runs/magic/scores \
+       --method filter --fraction 0.05 --controls skip
+   bergson validate runs/filter-bank --scores runs/magic/scores \
+       --method filter --fraction 0.05 --controls bank --paths runs/bank --count 2
+
+``--direction detractors`` removes the opposite end of the score ranking.
+Bank controls evaluate the first ``count`` entries, selected independently of
+losses or attribution scores. Multiple ``--paths`` average corresponding bank
+entries. Their removal sets must match across banks, and their removal sizes and
+training settings must be comparable with the filtering experiment. Bank counts
+larger than the available entries are rejected; YAML ``count: null`` uses all.
+
+Equivalent YAML:
+
+.. code-block:: yaml
+
+   steps:
+     - validate:
+         run_path: runs/filter
+         scores: runs/magic/scores
+         method:
+           kind: filter
+           direction: proponents
+           fraction: 0.05
+           controls:
+             source: random
+             count: 3
+             sampling_seed: 42
+
+Use ``controls: {source: skip}`` to omit the comparison, or
+``controls: {source: bank, paths: [runs/bank], count: 2}`` to reuse retrains.
+A random control is a new random removal set; ``sampling_seed`` controls those
+sets, while the shared training ``seed`` controls training randomness.
+
+LDS
+~~~
+
+LDS defaults to a random partition into 100 subsets. To instead sample 100
+independent removals, each containing five percent of the eligible data:
+
+.. code-block:: bash
+
+   bergson validate runs/lds --scores runs/magic/scores \
+       --method lds --sampling random --fraction 0.05 --count 100
+   bergson validate runs/lds-bank --scores runs/magic/scores \
+       --method lds --subsets bank --paths runs/bank
+
+.. code-block:: yaml
+
+   steps:
+     - validate:
+         run_path: runs/lds
+         scores: runs/magic/scores
+         method:
+           kind: lds
+           subsets:
+             source: random
+             sampling: random
+             fraction: 0.05
+             count: 100
+             sampling_seed: 42
+           start: 0
+           stop: null
+
+``sampling: partition`` divides the pool by ``count`` and does not use
+``fraction``. ``manifest`` can point to an existing ``subsets.json``; otherwise
+an existing manifest in the run directory is reused. ``start`` and ``stop``
+select a range for sharded retraining or evaluation. A bank source is written
+as ``subsets: {source: bank, paths: [runs/bank]}``.
+
+Weight steps and migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Weight-step validation is a separate method:
+``--method weight-step --lrs 0.1 0.2``, or
+``method: {kind: weight-step, lrs: [0.1, 0.2]}`` in YAML.
+
+Existing flat YAML configs remain readable with a deprecation warning. Migration
+preserves their old defaults, including filtering's implicit ``1 / num_subsets``
+removal fraction, training-seed-based subset sampling, and use of every bank
+entry. Newly saved configs contain explicit ``kind`` and ``source`` tags so a
+filter config cannot be mistaken for LDS when reloaded. Mixing legacy flat
+options with a nested method config is rejected.
+
+CLI invocations and direct Python construction should use the new method configs:
+``--num_subsets`` becomes ``--count``, ``--subset_fraction`` becomes ``--fraction``
+(with ``--sampling random`` for LDS), and ``--retrained_dir`` becomes the selected
+bank source's ``--paths``. The old ``--method filter-proponents`` becomes
+``--method filter --direction proponents``. The legacy global ``controls`` modes
+are replaced by the filtering-only ``--controls random/bank/skip`` selector.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -22,7 +22,7 @@ Filtering
 ~~~~~~~~~
 
 Remove a ranked fraction of the data and compare its query loss change with
-random removals of the same size. The fraction defaults to 0.05; random controls
+random removals of the same size. The fraction defaults to 0.01; random controls
 default to three retrains.
 
 .. code-block:: bash
@@ -56,12 +56,11 @@ Equivalent YAML:
            controls:
              kind: retrain
              count: 3
-             sampling_seed: 42
 
 Use ``controls: {kind: none}`` to omit the comparison, or
 ``controls: {kind: bank, paths: [runs/bank], count: 2}`` to reuse retrains.
-A random control is a new random removal set; ``sampling_seed`` controls those
-sets. The shared training ``seed`` controls training randomness.
+A random control is a new random removal set. The shared ``seed`` controls
+subset selection and training randomness.
 
 LDS
 ~~~
@@ -73,7 +72,7 @@ data:
 .. code-block:: bash
 
    bergson validate runs/lds --scores runs/magic/scores \
-       --method lds --sampling random --fraction 0.05 --count 100
+       --method lds --fraction 0.05 --count 100
    bergson validate runs/lds-bank --scores runs/magic/scores \
        --method lds --subsets bank --paths runs/bank
 
@@ -86,18 +85,18 @@ data:
          method:
            kind: lds
            subsets: retrain
-           sampling: random
            fraction: 0.05
            count: 100
-           sampling_seed: 42
            start: 0
            stop: null
 
-``sampling: partition`` divides the pool by ``count``. With ``sampling: random``,
-``fraction`` sets the removal size. ``manifest`` can point to an existing
+``fraction: 0`` divides the pool into ``count`` subsets. A positive ``fraction``
+draws ``count`` independent random subsets of that size. Subset selection uses
+the shared training ``seed``. ``manifest`` can point to an existing
 ``subsets.json``; otherwise an existing manifest in the run directory is reused.
-``start`` and ``stop`` select a range for sharded retraining or evaluation. To evaluate a bank, set
-``subsets: bank`` and ``paths: [runs/bank]`` in the LDS method config.
+``start`` and ``stop`` select a range for sharded retraining or evaluation.
+To evaluate a bank, set ``subsets: bank`` and ``paths: [runs/bank]`` in the LDS
+method config.
 
 Weight steps and migration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -113,8 +112,7 @@ entry. Newly saved configs use a ``kind`` tag to identify the selected method.
 Mixing legacy flat options with a nested method config is rejected.
 
 CLI invocations and direct Python construction should use the new method configs:
-``--num_subsets`` becomes ``--count``, ``--subset_fraction`` becomes ``--fraction``
-(with ``--sampling random`` for LDS), and ``--retrained_dir`` becomes the selected
-bank source's ``--paths``. The old ``--method filter-proponents`` becomes
+``--num_subsets`` becomes ``--count``, ``--subset_fraction`` becomes ``--fraction``,
+and ``--retrained_dir`` becomes the selected bank source's ``--paths``. The old ``--method filter-proponents`` becomes
 ``--method filter --direction proponents``. The legacy global ``controls`` modes
 are replaced by the filtering ``--controls retrain/bank/none`` selector.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -112,7 +112,8 @@ entry. Newly saved configs use a ``kind`` tag to identify the selected method.
 Mixing legacy flat options with a nested method config is rejected.
 
 CLI invocations and direct Python construction should use the new method configs:
-``--num_subsets`` becomes ``--count``, ``--subset_fraction`` becomes ``--fraction``,
-and ``--retrained_dir`` becomes the selected bank source's ``--paths``. The old ``--method filter-proponents`` becomes
+``--num_subsets`` becomes ``--count``, ``--subset_fraction`` becomes
+``--fraction``, and ``--retrained_dir`` becomes the selected bank source's
+``--paths``. The old ``--method filter-proponents`` becomes
 ``--method filter --direction proponents``. The legacy global ``controls`` modes
 are replaced by the filtering ``--controls retrain/bank/none`` selector.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -14,9 +14,9 @@ Validation experiments
 ----------------------
 
 ``validate`` and MAGIC's optional validation use one method-specific config.
-Training and query settings remain shared. LDS has a ``subsets`` source;
-filtering has an optional ``controls`` source. CLI help shows the selected
-method's arguments.
+Training and query settings remain shared. LDS holds its subset settings;
+filtering has a ``controls`` config. CLI help shows the selected method's
+arguments.
 
 Filtering
 ~~~~~~~~~
@@ -30,15 +30,16 @@ default to three retrains.
    bergson validate runs/filter --scores runs/magic/scores \
        --method filter --direction proponents --fraction 0.05 --count 3
    bergson validate runs/filter-only --scores runs/magic/scores \
-       --method filter --fraction 0.05 --controls skip
+       --method filter --fraction 0.05 --controls none
    bergson validate runs/filter-bank --scores runs/magic/scores \
        --method filter --fraction 0.05 --controls bank --paths runs/bank --count 2
 
 ``--direction detractors`` removes the opposite end of the score ranking.
 Bank controls evaluate the first ``count`` entries. Multiple ``--paths`` average
-corresponding bank entries. Their removal sets must match across banks, and their removal sizes and
-training settings must be comparable with the filtering experiment. Bank counts
-larger than the available entries are rejected; YAML ``count: null`` uses all.
+corresponding bank entries. Their removal sets must match across banks, and
+their removal sizes and training settings must be comparable with the filtering
+experiment. Bank counts larger than the available entries are rejected; YAML
+``count: null`` uses all.
 
 Equivalent YAML:
 
@@ -53,12 +54,12 @@ Equivalent YAML:
            direction: proponents
            fraction: 0.05
            controls:
-             source: random
+             kind: retrain
              count: 3
              sampling_seed: 42
 
-Use ``controls: {source: skip}`` to omit the comparison, or
-``controls: {source: bank, paths: [runs/bank], count: 2}`` to reuse retrains.
+Use ``controls: {kind: none}`` to omit the comparison, or
+``controls: {kind: bank, paths: [runs/bank], count: 2}`` to reuse retrains.
 A random control is a new random removal set; ``sampling_seed`` controls those
 sets. The shared training ``seed`` controls training randomness.
 
@@ -84,20 +85,19 @@ data:
          scores: runs/magic/scores
          method:
            kind: lds
-           subsets:
-             source: random
-             sampling: random
-             fraction: 0.05
-             count: 100
-             sampling_seed: 42
+           subsets: retrain
+           sampling: random
+           fraction: 0.05
+           count: 100
+           sampling_seed: 42
            start: 0
            stop: null
 
 ``sampling: partition`` divides the pool by ``count``. With ``sampling: random``,
-``fraction`` sets the removal size. ``manifest`` can point to an existing ``subsets.json``; otherwise
-an existing manifest in the run directory is reused. ``start`` and ``stop``
-select a range for sharded retraining or evaluation. A bank source is written
-as ``subsets: {source: bank, paths: [runs/bank]}``.
+``fraction`` sets the removal size. ``manifest`` can point to an existing
+``subsets.json``; otherwise an existing manifest in the run directory is reused.
+``start`` and ``stop`` select a range for sharded retraining or evaluation. To evaluate a bank, set
+``subsets: bank`` and ``paths: [runs/bank]`` in the LDS method config.
 
 Weight steps and migration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,13 +109,12 @@ Weight-step validation is a separate method:
 Existing flat YAML configs remain readable with a deprecation warning. Migration
 preserves their old defaults, including filtering's implicit ``1 / num_subsets``
 removal fraction, training-seed-based subset sampling, and use of every bank
-entry. Newly saved configs use ``kind`` and ``source`` tags to identify the
-selected method and source. Mixing legacy flat
-options with a nested method config is rejected.
+entry. Newly saved configs use a ``kind`` tag to identify the selected method.
+Mixing legacy flat options with a nested method config is rejected.
 
 CLI invocations and direct Python construction should use the new method configs:
 ``--num_subsets`` becomes ``--count``, ``--subset_fraction`` becomes ``--fraction``
 (with ``--sampling random`` for LDS), and ``--retrained_dir`` becomes the selected
 bank source's ``--paths``. The old ``--method filter-proponents`` becomes
 ``--method filter --direction proponents``. The legacy global ``controls`` modes
-are replaced by the filtering-only ``--controls random/bank/skip`` selector.
+are replaced by the filtering ``--controls retrain/bank/none`` selector.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -15,15 +15,15 @@ Validation experiments
 
 ``validate`` and MAGIC's optional validation use one method-specific config.
 Training and query settings remain shared. LDS has a ``subsets`` source;
-filtering has an optional ``controls`` source. Only the selected method's
-arguments appear in CLI help.
+filtering has an optional ``controls`` source. CLI help shows the selected
+method's arguments.
 
 Filtering
 ~~~~~~~~~
 
 Remove a ranked fraction of the data and compare its query loss change with
 random removals of the same size. The fraction defaults to 0.05; random controls
-default to three retrains. Changing the control count never changes the fraction.
+default to three retrains.
 
 .. code-block:: bash
 
@@ -35,9 +35,8 @@ default to three retrains. Changing the control count never changes the fraction
        --method filter --fraction 0.05 --controls bank --paths runs/bank --count 2
 
 ``--direction detractors`` removes the opposite end of the score ranking.
-Bank controls evaluate the first ``count`` entries, selected independently of
-losses or attribution scores. Multiple ``--paths`` average corresponding bank
-entries. Their removal sets must match across banks, and their removal sizes and
+Bank controls evaluate the first ``count`` entries. Multiple ``--paths`` average
+corresponding bank entries. Their removal sets must match across banks, and their removal sizes and
 training settings must be comparable with the filtering experiment. Bank counts
 larger than the available entries are rejected; YAML ``count: null`` uses all.
 
@@ -61,13 +60,14 @@ Equivalent YAML:
 Use ``controls: {source: skip}`` to omit the comparison, or
 ``controls: {source: bank, paths: [runs/bank], count: 2}`` to reuse retrains.
 A random control is a new random removal set; ``sampling_seed`` controls those
-sets, while the shared training ``seed`` controls training randomness.
+sets. The shared training ``seed`` controls training randomness.
 
 LDS
 ~~~
 
-LDS defaults to a random partition into 100 subsets. To instead sample 100
-independent removals, each containing five percent of the eligible data:
+LDS defaults to a random partition into 100 subsets. The following command
+samples 100 independent removals, each containing five percent of the eligible
+data:
 
 .. code-block:: bash
 
@@ -93,8 +93,8 @@ independent removals, each containing five percent of the eligible data:
            start: 0
            stop: null
 
-``sampling: partition`` divides the pool by ``count`` and does not use
-``fraction``. ``manifest`` can point to an existing ``subsets.json``; otherwise
+``sampling: partition`` divides the pool by ``count``. With ``sampling: random``,
+``fraction`` sets the removal size. ``manifest`` can point to an existing ``subsets.json``; otherwise
 an existing manifest in the run directory is reused. ``start`` and ``stop``
 select a range for sharded retraining or evaluation. A bank source is written
 as ``subsets: {source: bank, paths: [runs/bank]}``.
@@ -109,8 +109,8 @@ Weight-step validation is a separate method:
 Existing flat YAML configs remain readable with a deprecation warning. Migration
 preserves their old defaults, including filtering's implicit ``1 / num_subsets``
 removal fraction, training-seed-based subset sampling, and use of every bank
-entry. Newly saved configs contain explicit ``kind`` and ``source`` tags so a
-filter config cannot be mistaken for LDS when reloaded. Mixing legacy flat
+entry. Newly saved configs use ``kind`` and ``source`` tags to identify the
+selected method and source. Mixing legacy flat
 options with a nested method config is rejected.
 
 CLI invocations and direct Python construction should use the new method configs:

--- a/examples/compare_smollm2_8k/ekfac.yaml
+++ b/examples/compare_smollm2_8k/ekfac.yaml
@@ -55,7 +55,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_smollm2_8k/ekfac/scores
-      retrained_dir: runs/compare_smollm2_8k/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_smollm2_8k/random
 
       data:
         dataset: runs/damping_transfer/data/smollm2_train_8k

--- a/examples/compare_smollm2_8k/magic.yaml
+++ b/examples/compare_smollm2_8k/magic.yaml
@@ -47,8 +47,10 @@ steps:
         lr_end: 0.00004
         warmup_steps: 0.25
 
-      num_subsets: 100
-      subset_fraction: 0.01
+      method:
+        kind: lds
+        count: 100
+        fraction: 0.01
       # 0.26.0 changed the default to skip in-run validation.
       skip_validation: false
 

--- a/examples/compare_smollm2_8k/source.yaml
+++ b/examples/compare_smollm2_8k/source.yaml
@@ -91,7 +91,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_smollm2_8k/source/scores
-      retrained_dir: runs/compare_smollm2_8k/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_smollm2_8k/random
 
       data:
         dataset: runs/damping_transfer/data/smollm2_train_8k

--- a/examples/compare_smollm2_8k/source_adam.yaml
+++ b/examples/compare_smollm2_8k/source_adam.yaml
@@ -92,7 +92,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_smollm2_8k/source_adam/scores
-      retrained_dir: runs/compare_smollm2_8k/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_smollm2_8k/random
 
       data:
         dataset: runs/damping_transfer/data/smollm2_train_8k

--- a/examples/compare_smollm2_8k/trackstar.yaml
+++ b/examples/compare_smollm2_8k/trackstar.yaml
@@ -45,7 +45,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_smollm2_8k/trackstar/scores
-      retrained_dir: runs/compare_smollm2_8k/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_smollm2_8k/random
 
       data:
         dataset: runs/damping_transfer/data/smollm2_train_8k

--- a/examples/compare_smollm2_8k/trackstar_adam.yaml
+++ b/examples/compare_smollm2_8k/trackstar_adam.yaml
@@ -46,7 +46,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_smollm2_8k/trackstar_adam/scores
-      retrained_dir: runs/compare_smollm2_8k/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_smollm2_8k/random
 
       data:
         dataset: runs/damping_transfer/data/smollm2_train_8k

--- a/examples/compare_wikitext/ekfac.yaml
+++ b/examples/compare_wikitext/ekfac.yaml
@@ -54,7 +54,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_wikitext/ekfac/scores
-      retrained_dir: runs/compare_wikitext/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_wikitext/random
 
       data:
         dataset: EleutherAI/bergson-wikitext-512-chunks

--- a/examples/compare_wikitext/magic.yaml
+++ b/examples/compare_wikitext/magic.yaml
@@ -46,8 +46,10 @@ steps:
         warmup_steps: 0.25
 
       skip_validation: false
-      num_subsets: 100
-      subset_fraction: 0.01
+      method:
+        kind: lds
+        count: 100
+        fraction: 0.01
 
       save_models: true
       save_optimizer_state: last

--- a/examples/compare_wikitext/source.yaml
+++ b/examples/compare_wikitext/source.yaml
@@ -83,7 +83,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_wikitext/source/scores
-      retrained_dir: runs/compare_wikitext/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_wikitext/random
 
       data:
         dataset: EleutherAI/bergson-wikitext-512-chunks

--- a/examples/compare_wikitext/source_adam.yaml
+++ b/examples/compare_wikitext/source_adam.yaml
@@ -90,7 +90,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_wikitext/source_adam/scores
-      retrained_dir: runs/compare_wikitext/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_wikitext/random
 
       data:
         dataset: EleutherAI/bergson-wikitext-512-chunks

--- a/examples/compare_wikitext/trackstar.yaml
+++ b/examples/compare_wikitext/trackstar.yaml
@@ -44,7 +44,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_wikitext/trackstar/scores
-      retrained_dir: runs/compare_wikitext/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_wikitext/random
 
       data:
         dataset: EleutherAI/bergson-wikitext-512-chunks

--- a/examples/compare_wikitext/trackstar_adam.yaml
+++ b/examples/compare_wikitext/trackstar_adam.yaml
@@ -43,7 +43,11 @@ steps:
       overwrite: true
 
       scores: runs/compare_wikitext/trackstar_adam/scores
-      retrained_dir: runs/compare_wikitext/random
+      method:
+        kind: lds
+        subsets: bank
+        paths:
+          - runs/compare_wikitext/random
 
       data:
         dataset: EleutherAI/bergson-wikitext-512-chunks

--- a/examples/double_backward_pretrain.py
+++ b/examples/double_backward_pretrain.py
@@ -16,7 +16,7 @@ Usage:
         --query.split "train[:1]"
 """
 
-from bergson.config import DataConfig, LRScheduleConfig
+from bergson.config import DataConfig, LDSConfig, LRScheduleConfig
 from bergson.magic import MagicConfig, run_magic
 
 
@@ -35,7 +35,7 @@ def main():
         ),
         batch_size=8,
         lr_schedule=LRScheduleConfig(lr=1e-5, warmup_steps=10),
-        num_subsets=100,
+        method=LDSConfig(count=100),
         seed=42,
     )
     run_magic(run_cfg)

--- a/examples/magic/gpt2_wikitext_bank.yaml
+++ b/examples/magic/gpt2_wikitext_bank.yaml
@@ -1,5 +1,5 @@
 # Build a GPT-2 / WikiText leave-k-out re-train bank (single node): MAGIC
-# attribution plus 400 retrained leave-out models saved for later evaluation.
+# attribution plus 100 retrained leave-out models saved for later evaluation.
 
 # Run with `bergson examples/magic/gpt2_wikitext_bank.yaml`
 

--- a/examples/magic/gpt2_wikitext_bank.yaml
+++ b/examples/magic/gpt2_wikitext_bank.yaml
@@ -35,11 +35,10 @@ steps:
         lr_end: 0.00008
         warmup_steps: 0.25
 
-      subset_strategy: random
       wandb_project: magic
       method:
         kind: lds
         count: 100
         fraction: 0.01
-      save_optimizer_state: True
-      save_retrained_models: True
+      save_optimizer_state: last
+      save_models: True

--- a/examples/magic/gpt2_wikitext_bank.yaml
+++ b/examples/magic/gpt2_wikitext_bank.yaml
@@ -37,7 +37,9 @@ steps:
 
       subset_strategy: random
       wandb_project: magic
-      num_subsets: 100
-      subset_fraction: 0.01
+      method:
+        kind: lds
+        count: 100
+        fraction: 0.01
       save_optimizer_state: True
       save_retrained_models: True

--- a/examples/magic/gpt2_wikitext_replication.yaml
+++ b/examples/magic/gpt2_wikitext_replication.yaml
@@ -48,8 +48,10 @@ steps:
         warmup_steps: 0.25
 
       skip_validation: false
-      num_subsets: 100
-      subset_fraction: 0.01
+      method:
+        kind: lds
+        count: 100
+        fraction: 0.01
 
       wandb_project: magic
       save_optimizer_state: last

--- a/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_retrain.yaml
+++ b/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_retrain.yaml
@@ -35,8 +35,11 @@ steps:
       lr_scheduler_type: constant
       lr: 3.0e-05
     train_mode: true
-    num_subsets: 100
-    subset_fraction: 0.5
+    method:
+      kind: lds
+      count: 100
+      fraction: 0.5
+      manifest: runs/wikitext_repro/retrain_seed1004/subsets.json
     save_models: true
     matrix:
       seed:
@@ -45,4 +48,3 @@ steps:
       - 1006
       - 1007
       - 1008
-    subsets: runs/wikitext_repro/retrain_seed1004/subsets.json

--- a/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_validate.yaml
+++ b/examples/replicate_bae_approx_unrolling_source/wikitext_gpt2_validate.yaml
@@ -9,12 +9,15 @@ steps:
     model: gpt2
     overwrite: true
     scores: runs/wikitext_repro/if_scores/scores
-    retrained_dir:
-    - runs/wikitext_repro/retrain_seed1004
-    - runs/wikitext_repro/retrain_seed1005
-    - runs/wikitext_repro/retrain_seed1006
-    - runs/wikitext_repro/retrain_seed1007
-    - runs/wikitext_repro/retrain_seed1008
+    method:
+      kind: lds
+      subsets: bank
+      paths:
+      - runs/wikitext_repro/retrain_seed1004
+      - runs/wikitext_repro/retrain_seed1005
+      - runs/wikitext_repro/retrain_seed1006
+      - runs/wikitext_repro/retrain_seed1007
+      - runs/wikitext_repro/retrain_seed1008
     batch_size: 64
     data: &id001
       dataset: EleutherAI/bergson-wikitext-2-4656-chunks
@@ -29,12 +32,15 @@ steps:
     model: gpt2
     overwrite: true
     scores: runs/wikitext_repro/source_scores/scores
-    retrained_dir:
-    - runs/wikitext_repro/retrain_seed1004
-    - runs/wikitext_repro/retrain_seed1005
-    - runs/wikitext_repro/retrain_seed1006
-    - runs/wikitext_repro/retrain_seed1007
-    - runs/wikitext_repro/retrain_seed1008
+    method:
+      kind: lds
+      subsets: bank
+      paths:
+      - runs/wikitext_repro/retrain_seed1004
+      - runs/wikitext_repro/retrain_seed1005
+      - runs/wikitext_repro/retrain_seed1006
+      - runs/wikitext_repro/retrain_seed1007
+      - runs/wikitext_repro/retrain_seed1008
     batch_size: 64
     data: *id001
     query: *id002

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 from .cli_command import bergson_cmd, bergson_env
 
 SUBCOMMANDS = [
+    "validate",
     "build",
     "ekfac",
     "hessian",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ import pytest
 from .cli_command import bergson_cmd, bergson_env
 
 SUBCOMMANDS = [
-    "validate",
     "build",
     "ekfac",
     "hessian",

--- a/tests/test_distributed_magic.py
+++ b/tests/test_distributed_magic.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 
 from bergson.config import DataConfig, DistributedConfig, LRScheduleConfig
+from bergson.config.validation import LDSConfig, RandomSubsets
 from bergson.data import load_scores_loss_signed
 from bergson.magic.cli import MagicConfig, run_magic
 
@@ -64,7 +65,7 @@ def magic_cfg(
         batch_size=8,
         num_epochs=1,
         overwrite=True,
-        num_subsets=2,
+        method=LDSConfig(subsets=RandomSubsets(count=2)),
         max_grad_norm=MAX_GRAD_NORM if clip else None,
         grad_accum_steps=grad_accum,
         train_mode=dropout > 0,

--- a/tests/test_distributed_magic.py
+++ b/tests/test_distributed_magic.py
@@ -12,7 +12,7 @@ import pytest
 import torch
 
 from bergson.config import DataConfig, DistributedConfig, LRScheduleConfig
-from bergson.config.validation import LDSConfig, RandomSubsets
+from bergson.config.validation import LDSConfig
 from bergson.data import load_scores_loss_signed
 from bergson.magic.cli import MagicConfig, run_magic
 
@@ -65,7 +65,7 @@ def magic_cfg(
         batch_size=8,
         num_epochs=1,
         overwrite=True,
-        method=LDSConfig(subsets=RandomSubsets(count=2)),
+        method=LDSConfig(count=2),
         max_grad_norm=MAX_GRAD_NORM if clip else None,
         grad_accum_steps=grad_accum,
         train_mode=dropout > 0,

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -152,48 +152,28 @@ def _e2e_shared(tmp_path) -> dict:
     }
 
 
-@pytest.mark.parametrize("count", [0, 1, 3])
-def test_a_filter_run_compares_against_random_filters(tmp_path, count):
+def test_a_filter_run_compares_against_random_filters(tmp_path):
     from bergson.cli.commands import Magic, Validate
 
     shared = _e2e_shared(tmp_path)
     Magic.from_dict(shared | {"run_path": str(tmp_path / "magic")}).execute()
     run = tmp_path / "filter"
-    shared.pop("num_subsets")
-    shared.pop("subset_fraction")
     Validate.from_dict(
         shared
         | {
             "run_path": str(run),
             "scores": str(tmp_path / "magic" / "scores"),
-            "method": {
-                "kind": "filter",
-                "fraction": 0.25,
-                "controls": (
-                    {"source": "random", "count": count}
-                    if count
-                    else {"source": "skip"}
-                ),
-            },
+            "method": "filter-proponents",
         }
     ).execute()
 
-    with open(run / "filter_proponents.csv") as f:
-        assert all(int(row["n_removed"]) == 2 for row in csv.DictReader(f))
-    if count == 0:
-        assert not (run / "random_filter.csv").exists()
-        assert not (run / "filter_summary.csv").exists()
-        return
-
     with open(run / "random_filter.csv") as f:
         random_rows = list(csv.DictReader(f))
-    assert {r["subset"] for r in random_rows} == {str(i) for i in range(count)}
-    assert all(int(r["n_removed"]) == 2 for r in random_rows)
+    assert {r["subset"] for r in random_rows} == {"0", "1"}
     with open(run / "filter_summary.csv") as f:
         summary = list(csv.DictReader(f))
     assert [r["query"] for r in summary] == ["0", "1"]
-    assert all(1 <= int(r["rank"]) <= count + 1 for r in summary)
-    assert all(int(r["n_removed"]) == 2 for r in summary)
+    assert all(1 <= int(r["rank"]) <= 3 for r in summary)
 
 
 def test_a_bank_gives_the_same_random_filters_as_retraining_them(tmp_path):
@@ -226,27 +206,3 @@ def test_a_bank_gives_the_same_random_filters_as_retraining_them(tmp_path):
     here = random_changes("here")
     from_bank = random_changes("from_bank", retrained_dir=str(bank))
     assert [round(float(x), 5) for x in from_bank] == [round(float(x), 5) for x in here]
-
-    # A small control budget evaluates only a prefix of the same bank. The
-    # cache key includes its count, so it cannot reuse a full-bank tensor.
-    shared.pop("num_subsets")
-    shared.pop("subset_fraction")
-    limited = tmp_path / "limited_bank"
-    Validate.from_dict(
-        shared
-        | {
-            "run_path": str(limited),
-            "scores": scores,
-            "method": {
-                "kind": "filter",
-                "fraction": 0.25,
-                "controls": {"source": "bank", "paths": [str(bank)], "count": 1},
-            },
-        }
-    ).execute()
-    with open(limited / "random_filter.csv") as f:
-        rows = list(csv.DictReader(f))
-    assert {r["subset"] for r in rows} == {"0"}
-    assert [round(float(r["loss_change"]), 5) for r in rows] == [
-        round(float(x), 5) for x in from_bank[:2]
-    ]

--- a/tests/test_validate_filter.py
+++ b/tests/test_validate_filter.py
@@ -88,7 +88,7 @@ def test_bank_of_the_same_removal_size_is_accepted(tmp_path):
 
 def test_bank_of_a_different_removal_size_is_rejected(tmp_path):
     root = _bank(tmp_path, [[0, 1], [2, 3]])
-    with pytest.raises(ValueError, match="set subset_fraction to match"):
+    with pytest.raises(ValueError, match="set method.fraction to match"):
         load_and_validate_subsets_match(_cfg(tmp_path), [root], num_filtered=10)
 
 
@@ -152,28 +152,48 @@ def _e2e_shared(tmp_path) -> dict:
     }
 
 
-def test_a_filter_run_compares_against_random_filters(tmp_path):
+@pytest.mark.parametrize("count", [0, 1, 3])
+def test_a_filter_run_compares_against_random_filters(tmp_path, count):
     from bergson.cli.commands import Magic, Validate
 
     shared = _e2e_shared(tmp_path)
     Magic.from_dict(shared | {"run_path": str(tmp_path / "magic")}).execute()
     run = tmp_path / "filter"
+    shared.pop("num_subsets")
+    shared.pop("subset_fraction")
     Validate.from_dict(
         shared
         | {
             "run_path": str(run),
             "scores": str(tmp_path / "magic" / "scores"),
-            "method": "filter-proponents",
+            "method": {
+                "kind": "filter",
+                "fraction": 0.25,
+                "controls": (
+                    {"source": "random", "count": count}
+                    if count
+                    else {"source": "skip"}
+                ),
+            },
         }
     ).execute()
 
+    with open(run / "filter_proponents.csv") as f:
+        assert all(int(row["n_removed"]) == 2 for row in csv.DictReader(f))
+    if count == 0:
+        assert not (run / "random_filter.csv").exists()
+        assert not (run / "filter_summary.csv").exists()
+        return
+
     with open(run / "random_filter.csv") as f:
         random_rows = list(csv.DictReader(f))
-    assert {r["subset"] for r in random_rows} == {"0", "1"}
+    assert {r["subset"] for r in random_rows} == {str(i) for i in range(count)}
+    assert all(int(r["n_removed"]) == 2 for r in random_rows)
     with open(run / "filter_summary.csv") as f:
         summary = list(csv.DictReader(f))
     assert [r["query"] for r in summary] == ["0", "1"]
-    assert all(1 <= int(r["rank"]) <= 3 for r in summary)
+    assert all(1 <= int(r["rank"]) <= count + 1 for r in summary)
+    assert all(int(r["n_removed"]) == 2 for r in summary)
 
 
 def test_a_bank_gives_the_same_random_filters_as_retraining_them(tmp_path):
@@ -206,3 +226,27 @@ def test_a_bank_gives_the_same_random_filters_as_retraining_them(tmp_path):
     here = random_changes("here")
     from_bank = random_changes("from_bank", retrained_dir=str(bank))
     assert [round(float(x), 5) for x in from_bank] == [round(float(x), 5) for x in here]
+
+    # A small control budget evaluates only a prefix of the same bank. The
+    # cache key includes its count, so it cannot reuse a full-bank tensor.
+    shared.pop("num_subsets")
+    shared.pop("subset_fraction")
+    limited = tmp_path / "limited_bank"
+    Validate.from_dict(
+        shared
+        | {
+            "run_path": str(limited),
+            "scores": scores,
+            "method": {
+                "kind": "filter",
+                "fraction": 0.25,
+                "controls": {"source": "bank", "paths": [str(bank)], "count": 1},
+            },
+        }
+    ).execute()
+    with open(limited / "random_filter.csv") as f:
+        rows = list(csv.DictReader(f))
+    assert {r["subset"] for r in rows} == {"0"}
+    assert [round(float(r["loss_change"]), 5) for r in rows] == [
+        round(float(x), 5) for x in from_bank[:2]
+    ]

--- a/tests/test_validate_routing.py
+++ b/tests/test_validate_routing.py
@@ -100,3 +100,22 @@ def test_validation_needs_a_validation_config(tmp_path):
     cfg = TrainingConfig(run_path=str(tmp_path), model=MODEL)
     with pytest.raises(TypeError, match="ValidationConfig"):
         run_magic(cfg, validate=True)
+
+
+def test_weight_step_method_runs_without_lds_subsets(tmp_path):
+    shared = _datasets(tmp_path)
+    magic_run = tmp_path / "magic"
+    Magic.from_dict(shared | {"run_path": str(magic_run)}).execute()
+    shared.pop("num_subsets")
+    run = tmp_path / "weight-step"
+    Validate.from_dict(
+        shared
+        | {
+            "run_path": str(run),
+            "scores": str(magic_run / "scores"),
+            "method": {"kind": "weight-step", "lrs": [0.01]},
+        }
+    ).execute()
+    assert (run / "weight_step.csv").exists()
+    assert not (run / "validation.csv").exists()
+    assert not (run / "subsets.json").exists()

--- a/tests/test_validate_routing.py
+++ b/tests/test_validate_routing.py
@@ -100,22 +100,3 @@ def test_validation_needs_a_validation_config(tmp_path):
     cfg = TrainingConfig(run_path=str(tmp_path), model=MODEL)
     with pytest.raises(TypeError, match="ValidationConfig"):
         run_magic(cfg, validate=True)
-
-
-def test_weight_step_method_runs_without_lds_subsets(tmp_path):
-    shared = _datasets(tmp_path)
-    magic_run = tmp_path / "magic"
-    Magic.from_dict(shared | {"run_path": str(magic_run)}).execute()
-    shared.pop("num_subsets")
-    run = tmp_path / "weight-step"
-    Validate.from_dict(
-        shared
-        | {
-            "run_path": str(run),
-            "scores": str(magic_run / "scores"),
-            "method": {"kind": "weight-step", "lrs": [0.01]},
-        }
-    ).execute()
-    assert (run / "weight_step.csv").exists()
-    assert not (run / "validation.csv").exists()
-    assert not (run / "subsets.json").exists()

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -1,277 +1,42 @@
-"""Method-specific configs through the real CLI and YAML entry points."""
-
-from typing import get_args
+"""CLI/YAML identity and compatibility for method-specific validation configs."""
 
 import pytest
-import yaml
 from simple_parsing import ArgumentParser, ConflictResolution
 
 from bergson.__main__ import Main
 from bergson.cli.commands import Validate
 from bergson.config.config_io import parse_steps, read_config, save_run_config
-from bergson.config.validation import (
-    ControlBank,
-    FilterConfig,
-    LDSConfig,
-    NoControls,
-    RandomControls,
-    RandomSubsets,
-    SubsetBank,
-    WeightStepConfig,
-)
-
-registry = {
-    cls.__name__.lower(): cls
-    for cls in get_args(Main.__dataclass_fields__["command"].type)
-}
+from bergson.config.validation import FilterConfig, RandomControls
 
 
-def parse_cli(args):
+def test_filter_cli_survives_yaml_roundtrip(tmp_path):
     parser = ArgumentParser(conflict_resolution=ConflictResolution.EXPLICIT)
     parser.add_arguments(Main, dest="prog")
-    return parser.parse_args(args).prog.command
+    cfg = parser.parse_args(
+        ["validate", str(tmp_path), "--method", "filter", "--count", "1"]
+    ).prog.command
+    assert cfg.method == FilterConfig(fraction=0.05, controls=RandomControls(count=1))
 
-
-@pytest.mark.parametrize(
-    "flags,method_type,source_type,count",
-    [
-        ([], LDSConfig, RandomSubsets, 100),
-        (["--method", "filter"], FilterConfig, RandomControls, 3),
-        (["--method", "filter", "--count", "1"], FilterConfig, RandomControls, 1),
-        (["--method", "filter", "--controls", "skip"], FilterConfig, NoControls, None),
-        (
-            [
-                "--method",
-                "filter",
-                "--controls",
-                "bank",
-                "--paths",
-                "/bank",
-                "--count",
-                "2",
-            ],
-            FilterConfig,
-            ControlBank,
-            2,
-        ),
-        (
-            ["--method", "lds", "--subsets", "bank", "--paths", "/bank"],
-            LDSConfig,
-            SubsetBank,
-            None,
-        ),
-    ],
-)
-def test_cli_and_saved_config_roundtrip(
-    flags, method_type, source_type, count, tmp_path
-):
-    cfg = parse_cli(["validate", "runs/probe", *flags])
-    assert type(cfg.method) is method_type
-    source = cfg.method.controls if method_type is FilterConfig else cfg.method.subsets
-    assert type(source) is source_type
-    if count is not None:
-        assert source.count == count
     save_run_config(cfg, tmp_path)
-    restored = parse_steps(read_config(tmp_path)["steps"], registry)[0][1]
+    restored = parse_steps(read_config(tmp_path)["steps"], {"validate": Validate})[0][1]
     assert restored == cfg
-    assert type(restored.method) is method_type
+    assert isinstance(restored.method, FilterConfig)
 
 
-def test_yaml_pipeline_and_matrix():
-    steps = yaml.safe_load("""
-- validate:
-    run_path: runs/control_{n}
-    matrix: {n: [1, 2, 3]}
-    method:
-      kind: filter
-      fraction: 0.05
-      controls: {source: random, count: "{n}"}
-""")
-    configs = [cfg for _, cfg in parse_steps(steps, registry)]
-    assert [cfg.method.controls.count for cfg in configs] == [1, 2, 3]
-    assert all(cfg.method.fraction == 0.05 for cfg in configs)
-
-
-@pytest.mark.parametrize(
-    "flags",
-    [
-        ["--method", "lds", "--controls", "skip"],
-        ["--method", "filter", "--subsets", "random"],
-        ["--method", "filter", "--controls", "skip", "--count", "3"],
-        [
-            "--method",
-            "filter",
-            "--controls",
-            "bank",
-            "--paths",
-            "/bank",
-            "--sampling_seed",
-            "1",
-        ],
-    ],
-)
-def test_cli_rejects_inactive_options(flags):
-    with pytest.raises(SystemExit) as exc:
-        parse_cli(["validate", "runs/probe", *flags])
-    assert exc.value.code == 2
-
-
-@pytest.mark.parametrize(
-    "method",
-    [
-        {"kind": "lds", "controls": {"source": "skip"}},
-        {"kind": "filter", "subsets": {"source": "random"}},
-        {"kind": "filter", "controls": {"source": "skip", "count": 3}},
-        {"kind": "filter", "controls": {"source": "random", "fraction": 0.1}},
-        {"kind": "unknown"},
-        {"controls": {"source": "random"}},
-    ],
-)
-def test_yaml_rejects_inactive_or_untagged_options(method):
-    with pytest.raises((ValueError, TypeError, RuntimeError)):
-        Validate.from_dict(
-            {"run_path": "runs/probe", "method": method}, drop_extra_fields=False
-        )
-
-
-@pytest.mark.parametrize(
-    "method,expected,absent",
-    [
-        ("filter", "--controls", "--subsets"),
-        ("lds", "--subsets", "--controls"),
-    ],
-)
-def test_method_specific_help(method, expected, absent, capsys):
-    with pytest.raises(SystemExit) as exc:
-        parse_cli(["validate", "--method", method, "--help"])
-    assert exc.value.code == 0
-    output = capsys.readouterr().out
-    assert expected in output
-    assert absent not in output
-
-
-@pytest.mark.parametrize(
-    "legacy,expected",
-    [
-        ({"seed": 9}, LDSConfig(subsets=RandomSubsets(sampling_seed=9))),
-        ({"num_subsets": 7}, LDSConfig(subsets=RandomSubsets(count=7))),
-        (
-            {"num_subsets": 7, "subset_fraction": 0.2, "seed": 9},
-            LDSConfig(
-                subsets=RandomSubsets(
-                    count=7, sampling="random", fraction=0.2, sampling_seed=9
-                )
-            ),
-        ),
-        (
-            {"retrained_dir": "a,b", "subset_start": 1, "subset_stop": 3},
-            LDSConfig(subsets=SubsetBank(paths=["a", "b"]), start=1, stop=3),
-        ),
-        (
-            {"method": "filter-proponents", "num_subsets": 3},
-            FilterConfig(fraction=1 / 3, controls=RandomControls(count=3)),
-        ),
-        (
-            {"method": "filter-detractors", "num_subsets": 0, "subset_fraction": 0.1},
-            FilterConfig(direction="detractors", fraction=0.1, controls=NoControls()),
-        ),
-        (
-            {"method": "filter-proponents", "retrained_dir": ["a"], "num_subsets": 2},
-            FilterConfig(fraction=0.5, controls=ControlBank(paths=["a"], count=None)),
-        ),
-        (
-            {"method": "filter-proponents", "retrained_dir": "a", "controls": "skip"},
-            FilterConfig(fraction=0.01, controls=NoControls()),
-        ),
-        (
-            {
-                "method": "filter-proponents",
-                "retrained_dir": "a",
-                "controls": "retrain",
-            },
-            FilterConfig(fraction=0.01, controls=RandomControls(count=100)),
-        ),
-        ({"weight_lrs": [0.1, 0.2]}, WeightStepConfig(lrs=[0.1, 0.2])),
-    ],
-)
-def test_legacy_yaml_preserves_semantics_and_saves_nested(legacy, expected):
+def test_legacy_filter_preserves_removal_size_and_sampling_seed():
     with pytest.warns(FutureWarning):
-        cfg = Validate.from_dict({"run_path": "runs/probe", **legacy})
-    assert cfg.method == expected
+        cfg = Validate.from_dict(
+            {
+                "run_path": "runs/filter",
+                "method": "filter-proponents",
+                "num_subsets": 3,
+                "seed": 9,
+            }
+        )
+    assert cfg.method == FilterConfig(
+        fraction=1 / 3, controls=RandomControls(count=3, sampling_seed=9)
+    )
     payload = cfg.to_dict()
-    assert isinstance(payload["method"], dict)
+    assert payload["method"]["kind"] == "filter"
     assert "num_subsets" not in payload
     assert Validate.from_dict(payload, drop_extra_fields=False) == cfg
-
-
-@pytest.mark.parametrize(
-    "method",
-    [
-        {"kind": "filter", "fraction": 0},
-        {"kind": "filter", "fraction": 1.1},
-        {"kind": "filter", "controls": {"source": "random", "count": 0}},
-        {"kind": "filter", "controls": {"source": "bank", "paths": []}},
-        {"kind": "lds", "subsets": {"source": "random", "count": 0}},
-        {"kind": "lds", "start": 2, "stop": 1},
-        {"kind": "weight-step", "lrs": []},
-    ],
-)
-def test_invalid_experiments_fail_during_parsing(method):
-    with pytest.raises(ValueError):
-        Validate.from_dict({"run_path": "runs/probe", "method": method})
-
-
-def test_mixed_old_and_new_fields_rejected():
-    with pytest.raises(ValueError, match="Cannot mix"):
-        Validate.from_dict({"method": {"kind": "filter"}, "num_subsets": 3})
-
-
-def test_weight_step_cli_and_roundtrip():
-    cfg = parse_cli(
-        ["validate", "runs/probe", "--method", "weight-step", "--lrs", "0.1", "0.2"]
-    )
-    assert cfg.method == WeightStepConfig(lrs=[0.1, 0.2])
-    assert Validate.from_dict(cfg.to_dict()) == cfg
-
-
-def test_sampling_seed_is_independent_of_training_seed():
-    cfg = parse_cli(
-        [
-            "validate",
-            "runs/probe",
-            "--method",
-            "filter",
-            "--seed",
-            "9",
-            "--sampling_seed",
-            "4",
-        ]
-    )
-    assert cfg.seed == 9
-    assert cfg.method.controls.sampling_seed == 4
-
-
-@pytest.mark.parametrize("source", ["random", "skip", "bank"])
-def test_filter_dispatch_always_runs_ranked_retraining(source, monkeypatch):
-    calls = []
-    monkeypatch.setattr(
-        "bergson.cli.commands.run_magic", lambda *a, **kw: calls.append(kw)
-    )
-    monkeypatch.setattr(
-        "bergson.cli.commands.evaluate_retrained",
-        lambda *a, **kw: pytest.fail("LDS dispatch"),
-    )
-    controls = {"source": source}
-    if source == "bank":
-        controls["paths"] = ["bank"]
-    Validate.from_dict(
-        {
-            "run_path": "runs/probe",
-            "scores": "s",
-            "method": {
-                "kind": "filter",
-                "controls": controls,
-            },
-        }
-    ).execute()
-    assert len(calls) == 1 and calls[0]["validate"]

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -6,16 +6,25 @@ from simple_parsing import ArgumentParser, ConflictResolution
 from bergson.__main__ import Main
 from bergson.cli.commands import Validate
 from bergson.config.config_io import parse_steps, read_config, save_run_config
-from bergson.config.validation import FilterConfig, RandomControls
+from bergson.config.validation import ControlsConfig, FilterConfig
 
 
 def test_filter_cli_survives_yaml_roundtrip(tmp_path):
     parser = ArgumentParser(conflict_resolution=ConflictResolution.EXPLICIT)
     parser.add_arguments(Main, dest="prog")
     cfg = parser.parse_args(
-        ["validate", str(tmp_path), "--method", "filter", "--count", "1"]
+        [
+            "validate",
+            str(tmp_path),
+            "--method",
+            "filter",
+            "--controls",
+            "retrain",
+            "--count",
+            "1",
+        ]
     ).prog.command
-    assert cfg.method == FilterConfig(fraction=0.05, controls=RandomControls(count=1))
+    assert cfg.method == FilterConfig(fraction=0.05, controls=ControlsConfig(count=1))
 
     save_run_config(cfg, tmp_path)
     restored = parse_steps(read_config(tmp_path)["steps"], {"validate": Validate})[0][1]
@@ -34,7 +43,7 @@ def test_legacy_filter_preserves_removal_size_and_sampling_seed():
             }
         )
     assert cfg.method == FilterConfig(
-        fraction=1 / 3, controls=RandomControls(count=3, sampling_seed=9)
+        fraction=1 / 3, controls=ControlsConfig(count=3, sampling_seed=9)
     )
     payload = cfg.to_dict()
     assert payload["method"]["kind"] == "filter"

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -1,0 +1,277 @@
+"""Method-specific configs through the real CLI and YAML entry points."""
+
+from typing import get_args
+
+import pytest
+import yaml
+from simple_parsing import ArgumentParser, ConflictResolution
+
+from bergson.__main__ import Main
+from bergson.cli.commands import Validate
+from bergson.config.config_io import parse_steps, read_config, save_run_config
+from bergson.config.validation import (
+    ControlBank,
+    FilterConfig,
+    LDSConfig,
+    NoControls,
+    RandomControls,
+    RandomSubsets,
+    SubsetBank,
+    WeightStepConfig,
+)
+
+registry = {
+    cls.__name__.lower(): cls
+    for cls in get_args(Main.__dataclass_fields__["command"].type)
+}
+
+
+def parse_cli(args):
+    parser = ArgumentParser(conflict_resolution=ConflictResolution.EXPLICIT)
+    parser.add_arguments(Main, dest="prog")
+    return parser.parse_args(args).prog.command
+
+
+@pytest.mark.parametrize(
+    "flags,method_type,source_type,count",
+    [
+        ([], LDSConfig, RandomSubsets, 100),
+        (["--method", "filter"], FilterConfig, RandomControls, 3),
+        (["--method", "filter", "--count", "1"], FilterConfig, RandomControls, 1),
+        (["--method", "filter", "--controls", "skip"], FilterConfig, NoControls, None),
+        (
+            [
+                "--method",
+                "filter",
+                "--controls",
+                "bank",
+                "--paths",
+                "/bank",
+                "--count",
+                "2",
+            ],
+            FilterConfig,
+            ControlBank,
+            2,
+        ),
+        (
+            ["--method", "lds", "--subsets", "bank", "--paths", "/bank"],
+            LDSConfig,
+            SubsetBank,
+            None,
+        ),
+    ],
+)
+def test_cli_and_saved_config_roundtrip(
+    flags, method_type, source_type, count, tmp_path
+):
+    cfg = parse_cli(["validate", "runs/probe", *flags])
+    assert type(cfg.method) is method_type
+    source = cfg.method.controls if method_type is FilterConfig else cfg.method.subsets
+    assert type(source) is source_type
+    if count is not None:
+        assert source.count == count
+    save_run_config(cfg, tmp_path)
+    restored = parse_steps(read_config(tmp_path)["steps"], registry)[0][1]
+    assert restored == cfg
+    assert type(restored.method) is method_type
+
+
+def test_yaml_pipeline_and_matrix():
+    steps = yaml.safe_load("""
+- validate:
+    run_path: runs/control_{n}
+    matrix: {n: [1, 2, 3]}
+    method:
+      kind: filter
+      fraction: 0.05
+      controls: {source: random, count: "{n}"}
+""")
+    configs = [cfg for _, cfg in parse_steps(steps, registry)]
+    assert [cfg.method.controls.count for cfg in configs] == [1, 2, 3]
+    assert all(cfg.method.fraction == 0.05 for cfg in configs)
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--method", "lds", "--controls", "skip"],
+        ["--method", "filter", "--subsets", "random"],
+        ["--method", "filter", "--controls", "skip", "--count", "3"],
+        [
+            "--method",
+            "filter",
+            "--controls",
+            "bank",
+            "--paths",
+            "/bank",
+            "--sampling_seed",
+            "1",
+        ],
+    ],
+)
+def test_cli_rejects_inactive_options(flags):
+    with pytest.raises(SystemExit) as exc:
+        parse_cli(["validate", "runs/probe", *flags])
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        {"kind": "lds", "controls": {"source": "skip"}},
+        {"kind": "filter", "subsets": {"source": "random"}},
+        {"kind": "filter", "controls": {"source": "skip", "count": 3}},
+        {"kind": "filter", "controls": {"source": "random", "fraction": 0.1}},
+        {"kind": "unknown"},
+        {"controls": {"source": "random"}},
+    ],
+)
+def test_yaml_rejects_inactive_or_untagged_options(method):
+    with pytest.raises((ValueError, TypeError, RuntimeError)):
+        Validate.from_dict(
+            {"run_path": "runs/probe", "method": method}, drop_extra_fields=False
+        )
+
+
+@pytest.mark.parametrize(
+    "method,expected,absent",
+    [
+        ("filter", "--controls", "--subsets"),
+        ("lds", "--subsets", "--controls"),
+    ],
+)
+def test_method_specific_help(method, expected, absent, capsys):
+    with pytest.raises(SystemExit) as exc:
+        parse_cli(["validate", "--method", method, "--help"])
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert expected in output
+    assert absent not in output
+
+
+@pytest.mark.parametrize(
+    "legacy,expected",
+    [
+        ({"seed": 9}, LDSConfig(subsets=RandomSubsets(sampling_seed=9))),
+        ({"num_subsets": 7}, LDSConfig(subsets=RandomSubsets(count=7))),
+        (
+            {"num_subsets": 7, "subset_fraction": 0.2, "seed": 9},
+            LDSConfig(
+                subsets=RandomSubsets(
+                    count=7, sampling="random", fraction=0.2, sampling_seed=9
+                )
+            ),
+        ),
+        (
+            {"retrained_dir": "a,b", "subset_start": 1, "subset_stop": 3},
+            LDSConfig(subsets=SubsetBank(paths=["a", "b"]), start=1, stop=3),
+        ),
+        (
+            {"method": "filter-proponents", "num_subsets": 3},
+            FilterConfig(fraction=1 / 3, controls=RandomControls(count=3)),
+        ),
+        (
+            {"method": "filter-detractors", "num_subsets": 0, "subset_fraction": 0.1},
+            FilterConfig(direction="detractors", fraction=0.1, controls=NoControls()),
+        ),
+        (
+            {"method": "filter-proponents", "retrained_dir": ["a"], "num_subsets": 2},
+            FilterConfig(fraction=0.5, controls=ControlBank(paths=["a"], count=None)),
+        ),
+        (
+            {"method": "filter-proponents", "retrained_dir": "a", "controls": "skip"},
+            FilterConfig(fraction=0.01, controls=NoControls()),
+        ),
+        (
+            {
+                "method": "filter-proponents",
+                "retrained_dir": "a",
+                "controls": "retrain",
+            },
+            FilterConfig(fraction=0.01, controls=RandomControls(count=100)),
+        ),
+        ({"weight_lrs": [0.1, 0.2]}, WeightStepConfig(lrs=[0.1, 0.2])),
+    ],
+)
+def test_legacy_yaml_preserves_semantics_and_saves_nested(legacy, expected):
+    with pytest.warns(FutureWarning):
+        cfg = Validate.from_dict({"run_path": "runs/probe", **legacy})
+    assert cfg.method == expected
+    payload = cfg.to_dict()
+    assert isinstance(payload["method"], dict)
+    assert "num_subsets" not in payload
+    assert Validate.from_dict(payload, drop_extra_fields=False) == cfg
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        {"kind": "filter", "fraction": 0},
+        {"kind": "filter", "fraction": 1.1},
+        {"kind": "filter", "controls": {"source": "random", "count": 0}},
+        {"kind": "filter", "controls": {"source": "bank", "paths": []}},
+        {"kind": "lds", "subsets": {"source": "random", "count": 0}},
+        {"kind": "lds", "start": 2, "stop": 1},
+        {"kind": "weight-step", "lrs": []},
+    ],
+)
+def test_invalid_experiments_fail_during_parsing(method):
+    with pytest.raises(ValueError):
+        Validate.from_dict({"run_path": "runs/probe", "method": method})
+
+
+def test_mixed_old_and_new_fields_rejected():
+    with pytest.raises(ValueError, match="Cannot mix"):
+        Validate.from_dict({"method": {"kind": "filter"}, "num_subsets": 3})
+
+
+def test_weight_step_cli_and_roundtrip():
+    cfg = parse_cli(
+        ["validate", "runs/probe", "--method", "weight-step", "--lrs", "0.1", "0.2"]
+    )
+    assert cfg.method == WeightStepConfig(lrs=[0.1, 0.2])
+    assert Validate.from_dict(cfg.to_dict()) == cfg
+
+
+def test_sampling_seed_is_independent_of_training_seed():
+    cfg = parse_cli(
+        [
+            "validate",
+            "runs/probe",
+            "--method",
+            "filter",
+            "--seed",
+            "9",
+            "--sampling_seed",
+            "4",
+        ]
+    )
+    assert cfg.seed == 9
+    assert cfg.method.controls.sampling_seed == 4
+
+
+@pytest.mark.parametrize("source", ["random", "skip", "bank"])
+def test_filter_dispatch_always_runs_ranked_retraining(source, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "bergson.cli.commands.run_magic", lambda *a, **kw: calls.append(kw)
+    )
+    monkeypatch.setattr(
+        "bergson.cli.commands.evaluate_retrained",
+        lambda *a, **kw: pytest.fail("LDS dispatch"),
+    )
+    controls = {"source": source}
+    if source == "bank":
+        controls["paths"] = ["bank"]
+    Validate.from_dict(
+        {
+            "run_path": "runs/probe",
+            "scores": "s",
+            "method": {
+                "kind": "filter",
+                "controls": controls,
+            },
+        }
+    ).execute()
+    assert len(calls) == 1 and calls[0]["validate"]

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -24,7 +24,7 @@ def test_filter_cli_survives_yaml_roundtrip(tmp_path):
             "1",
         ]
     ).prog.command
-    assert cfg.method == FilterConfig(fraction=0.05, controls=ControlsConfig(count=1))
+    assert cfg.method == FilterConfig(fraction=0.01, controls=ControlsConfig(count=1))
 
     save_run_config(cfg, tmp_path)
     restored = parse_steps(read_config(tmp_path)["steps"], {"validate": Validate})[0][1]
@@ -42,9 +42,8 @@ def test_legacy_filter_preserves_removal_size_and_sampling_seed():
                 "seed": 9,
             }
         )
-    assert cfg.method == FilterConfig(
-        fraction=1 / 3, controls=ControlsConfig(count=3, sampling_seed=9)
-    )
+    assert cfg.method == FilterConfig(fraction=1 / 3, controls=ControlsConfig(count=3))
+    assert cfg.seed == 9
     payload = cfg.to_dict()
     assert payload["method"]["kind"] == "filter"
     assert "num_subsets" not in payload


### PR DESCRIPTION
The control retrain source is currently chosen using a confusing decision tree: a non-empty `retrained_dir` loads a bank, otherwise `num_subsets > 0` retrains in-process, otherwise controls are skipped. 

Add backwards compatible clarification field: `ValidationConfig.controls: auto | load | retrain | skip`.

| value | behaviour |
|---|---|
| `auto` | **default** — the existing precedence, so no behaviour changes |
| `load` | require `retrained_dir`; error rather than silently retraining |
| `retrain` | require `num_subsets > 0`; ignore any bank |
| `skip` | no random baseline |