### PR TITLE
Fix DTensor double-backward patch for torch >= 2.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         run: pip install build twine
       - name: Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.19.1
+        uses: python-semantic-release/python-semantic-release@v10.6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build package
@@ -95,7 +95,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: steps.release.outputs.released == 'true'
       - name: Publish package distributions to GitHub Releases
-        uses: python-semantic-release/publish-action@main
+        uses: python-semantic-release/publish-action@v10.6.2
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/bergson/magic/dtensor_patch.py
+++ b/bergson/magic/dtensor_patch.py
@@ -28,6 +28,21 @@ def apply_dtensor_patch():
     _PATCHED = True
 
 
+def _ctx_backward_dtypes(ctx):
+    """Read the backward dtypes off a Redistribute autograd ctx.
+
+    torch <= 2.12 stores them as `backward_dtype` / `original_dtype`; torch
+    2.13 renamed them to `bwd_op_dtype` / `bwd_out_dtype`.
+    """
+    backward_dtype = getattr(ctx, "backward_dtype", None)
+    if backward_dtype is None:
+        backward_dtype = getattr(ctx, "bwd_op_dtype", None)
+    original_dtype = getattr(ctx, "original_dtype", None)
+    if original_dtype is None:
+        original_dtype = getattr(ctx, "bwd_out_dtype", None)
+    return backward_dtype, original_dtype
+
+
 def _patch_redistribute():
     import torch.distributed.tensor._api as dtensor
     from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
@@ -149,12 +164,13 @@ def _patch_redistribute():
         @staticmethod
         def backward(ctx, *grad_outputs):  # type: ignore[override]
             grad2_output = grad_outputs[0]
+            backward_dtype, original_dtype = _ctx_backward_dtypes(ctx)
             output_dtensor = NestedRedistribute.apply(
                 grad2_output,
                 ctx.current_spec,
                 ctx.async_op,
-                ctx.backward_dtype,
-                ctx.original_dtype,
+                backward_dtype,
+                original_dtype,
             )
 
             return (output_dtensor, None, None, None, None)
@@ -162,12 +178,13 @@ def _patch_redistribute():
     @staticmethod
     def _new_redistribute_backward(ctx, grad_output):
         previous_spec = ctx.current_spec
+        backward_dtype, original_dtype = _ctx_backward_dtypes(ctx)
         output_dtensor = NestedRedistribute.apply(
             grad_output,
             previous_spec,
             ctx.async_op,
-            ctx.backward_dtype,
-            ctx.original_dtype,
+            backward_dtype,
+            original_dtype,
         )
         return (output_dtensor, None, None, None, None, None)
 


### PR DESCRIPTION
`apply_dtensor_patch` replaces `Redistribute.backward` with a version that reads `ctx.backward_dtype` and `ctx.original_dtype`.

torch's `Redistribute.forward` stored those attributes up to 2.12. From 2.13 it routes dtypes through a `_DtypeConfig` and stores `ctx.bwd_op_dtype` / `ctx.bwd_out_dtype` instead, so the old names are absent and the first backward raises:

```
AttributeError: 'RedistributeBackward' object has no attribute 'backward_dtype'
```

This makes `fsdp=True` unusable for any model.

## Fix

Read the dtypes through a small helper that accepts either spelling, so the patch keeps working on torch <= 2.12 and on >= 2.13. Reproduced on torch 2.13.0+cu126 (gpt2, `nproc_per_node=2`, `fsdp: true`); with the fix the same run trains normally. Not size- or architecture-specific.

## Also: fix the release job

The release step fails on main with `type object 'Actor' has no attribute 'name_email_regex'`: GitPython 3.1.60 removed `Actor.name_email_regex`, which the pinned `python-semantic-release@v9.19.1` action still reads at config load ([upstream #1476](https://github.com/python-semantic-release/python-semantic-release/issues/1476)). The fix only landed in v10.6.2, so this bumps the action (and pins `publish-action` to match). All options whose defaults changed in v10 (`allow_zero_version`, `mask_initial_release`, `parse_squash_commits`, `ignore_merge_commits`) are already set explicitly in `pyproject.toml`, so behavior is unchanged. Verified `semantic-release --noop version` with 10.6.2 + GitPython 3.1.61 loads the config cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167XKnE2yoCE162n3jHvxC1