### PR TITLE
Fix resume skipping an interrupted Hessian fit

### DIFF
--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -113,7 +113,11 @@ def hessian_pipeline(
 
     # ── Step 2: Fit Hessian factors on training data ──────────────────────
     print(f"Step 2/4: Fitting {method} factors on training data...")
-    if not _step_complete(hessian_path, resume):
+    # Check the path the fit actually promotes (`hessian/<method>`), not the
+    # parent directory: creating `hessian/<method>.part` also creates
+    # `hessian/`, so checking the parent classifies an interrupted fit as
+    # complete and step 3 crashes on (or silently misreads) missing factors.
+    if not _step_complete(f"{hessian_path}/{method}", resume):
         with _timed("step2_fit_hessian", durations):
             hessian_index_cfg = deepcopy(index_cfg)
             # approximate_hessians writes to this exact path; step 3 reads it

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -113,10 +113,6 @@ def hessian_pipeline(
 
     # ── Step 2: Fit Hessian factors on training data ──────────────────────
     print(f"Step 2/4: Fitting {method} factors on training data...")
-    # Check the path the fit actually promotes (`hessian/<method>`), not the
-    # parent directory: creating `hessian/<method>.part` also creates
-    # `hessian/`, so checking the parent classifies an interrupted fit as
-    # complete and step 3 crashes on (or silently misreads) missing factors.
     if not _step_complete(f"{hessian_path}/{method}", resume):
         with _timed("step2_fit_hessian", durations):
             hessian_index_cfg = deepcopy(index_cfg)

--- a/bergson/huggingface.py
+++ b/bergson/huggingface.py
@@ -373,7 +373,7 @@ class GradientCollectorCallback(TrainerCallback):
 
         if dist.is_initialized():
             # Gather training order from all processes
-            all_orders = [None] * dist.get_world_size()
+            all_orders: list[list[dict] | None] = [None] * dist.get_world_size()
             dist.all_gather_object(all_orders, self.order)
 
             # Only rank 0 saves the merged data


### PR DESCRIPTION
`resume` was checking whether `hessian_path` exists rather than `{hessian_path}/{method}`, where the Hessian actually goes when complete.