### PR TITLE
Expose apply_batch_size through InversionConfig

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -102,6 +102,10 @@ class InversionConfig(Serializable):
     damping_factor: float = 0.1
     """Damping / truncation strength, relative to the mean eigenvalue."""
 
+    apply_batch_size: int = 32
+    """Query gradients moved on-device and preconditioned at a time in the
+    inverse application."""
+
 
 @dataclass
 class DistributedConfig(Serializable):

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -134,6 +134,7 @@ def hessian_pipeline(
             ev_correction=hessian_cfg.ev_correction,
             projection_dim=index_cfg.projection_dim,
             projection_type=index_cfg.projection_type,
+            apply_batch_size=hessian_pipeline_cfg.inversion_cfg.apply_batch_size,
         )
         launch_distributed_run(
             "apply_hessian",


### PR DESCRIPTION
EkfacConfig.apply_batch_size is the batch size for queries, which in EK-FAC each produce a gradient of the same size as the model weights, but the EK-FAC pipeline does not pass apply_batch_size to EkfacConfig.