### PR TITLE
Harden per-query MAGIC

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -204,6 +204,25 @@ def compute_per_query_magic_scores(
         if isinstance(buf, torch.Tensor) and buf.is_floating_point()
     ]
 
+    # The backward silently attributes only whatever trajectory it can read:
+    # if checkpoints disappear mid-run (a purged shared directory, dangling
+    # symlinks), later queries produce near-empty score vectors with no error.
+    # Snapshot the trajectory listing and verify it before every query.
+    traj_ckpts = sorted(n for n in orig_ckpts if n.startswith("step_"))
+
+    def _verify_trajectory():
+        missing = [
+            n
+            for n in traj_ckpts
+            if not os.path.exists(os.path.join(ckpts_path, n))
+        ]
+        if missing:
+            raise FileNotFoundError(
+                f"{len(missing)}/{len(traj_ckpts)} trajectory checkpoints "
+                f"missing from {ckpts_path} (e.g. {missing[:3]}); refusing to "
+                "score queries against a truncated trajectory"
+            )
+
     per_query = []
     for qi in range(num_query_docs):
         qpath = os.path.join(scores_dir, f"q{qi}.pt")
@@ -237,6 +256,7 @@ def compute_per_query_magic_scores(
         )
         if one_pad:
             qstream.weights.data[-one_wpad:] = 0.0
+        _verify_trajectory()
         qgrads, _ = compute_query_gradients(
             fwd_state, model, qstream, "mean", run_cfg.fsdp, run_cfg.grad_accum_steps
         )
@@ -273,7 +293,10 @@ def compute_per_query_magic_scores(
         if pad_count:
             s = s[:-weight_pad_count] if s.ndim == 1 else s[:-pad_count]
         if main:
-            torch.save(s, qpath)
+            # Atomic write: a run killed mid-save must not leave a partial
+            # file under the name the resume check accepts as complete.
+            torch.save(s, qpath + ".tmp")
+            os.replace(qpath + ".tmp", qpath)
         per_query.append(s)
 
         # Free per-query state and any temp checkpoints the backward wrote.

--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -204,23 +204,21 @@ def compute_per_query_magic_scores(
         if isinstance(buf, torch.Tensor) and buf.is_floating_point()
     ]
 
-    # The backward silently attributes only whatever trajectory it can read:
-    # if checkpoints disappear mid-run (a purged shared directory, dangling
-    # symlinks), later queries produce near-empty score vectors with no error.
-    # Snapshot the trajectory listing and verify it before every query.
+    # Ensure all backward states are present on-disk before each query.
     traj_ckpts = sorted(n for n in orig_ckpts if n.startswith("step_"))
 
-    def _verify_trajectory():
+    def assert_ckpts_exist():
+        # `.metadata` is written last, so the resume path treats a checkpoint
+        # without one as incomplete.
         missing = [
             n
             for n in traj_ckpts
-            if not os.path.exists(os.path.join(ckpts_path, n))
+            if not os.path.exists(os.path.join(ckpts_path, n, ".metadata"))
         ]
         if missing:
             raise FileNotFoundError(
                 f"{len(missing)}/{len(traj_ckpts)} trajectory checkpoints "
-                f"missing from {ckpts_path} (e.g. {missing[:3]}); refusing to "
-                "score queries against a truncated trajectory"
+                f"missing from {ckpts_path} (e.g. {missing[:3]}); exiting."
             )
 
     per_query = []
@@ -256,7 +254,7 @@ def compute_per_query_magic_scores(
         )
         if one_pad:
             qstream.weights.data[-one_wpad:] = 0.0
-        _verify_trajectory()
+        assert_ckpts_exist()
         qgrads, _ = compute_query_gradients(
             fwd_state, model, qstream, "mean", run_cfg.fsdp, run_cfg.grad_accum_steps
         )
@@ -293,8 +291,7 @@ def compute_per_query_magic_scores(
         if pad_count:
             s = s[:-weight_pad_count] if s.ndim == 1 else s[:-pad_count]
         if main:
-            # Atomic write: a run killed mid-save must not leave a partial
-            # file under the name the resume check accepts as complete.
+            # Atomic write
             torch.save(s, qpath + ".tmp")
             os.replace(qpath + ".tmp", qpath)
         per_query.append(s)


### PR DESCRIPTION
Make it harder to mess up serial queries with MAGIC attribution:
1. Fix: mid-save q{i}.pt were being accepted on resume. 
2. Fix: If trajectory checkpoints were deleted mid-run, the run wouldn't throw an error and the scores would be invalid (partially zeros). We now check for this before each query