### PR TITLE
feat: support checkpointing per-query MAGIC backwards

### DIFF
--- a/bergson/magic/cli.py
+++ b/bergson/magic/cli.py
@@ -184,10 +184,9 @@ def compute_per_query_magic_scores(
 
     The backward is linear in the cotangent, so this is exact; the forward runs
     once and every query reuses its checkpoints (``cleanup=False``). Per-query
-    scores are written incrementally to ``<run_path>/per_query/q{i}.pt`` so a
-    crash or preemption only loses the in-flight query (resume redoes the
-    forward but skips finished queries), and the final state is restored before
-    each query since the backward walks it back down the trajectory.
+    scores are written incrementally to ``<run_path>/per_query/q{i}.pt``. The
+    final state is restored before each query so the next query can
+    backpropagate through the same trajectory.
     """
     main = global_rank == 0
     device = stream.weights.device
@@ -259,10 +258,13 @@ def compute_per_query_magic_scores(
             debug=run_cfg.debug,
             inplace=True,
             fsdp=run_cfg.fsdp,
+            resume=run_cfg.resume,
+            save_every=run_cfg.backward_save_every,
             save_mode=run_cfg.save_mode,
             max_grad_norm=run_cfg.max_grad_norm,
             grad_accum_steps=run_cfg.grad_accum_steps,
             double_backward_batch_size=run_cfg.double_backward_batch_size,
+            state_prefix=f"backward_q{qi}",
         )
         if world_size > 1:
             dist.all_reduce(bwd_state.weight_grads, op=dist.ReduceOp.SUM)

--- a/bergson/magic/trainer.py
+++ b/bergson/magic/trainer.py
@@ -788,6 +788,7 @@ class Trainer:
         max_grad_norm: float | None = None,
         grad_accum_steps: int = 1,
         double_backward_batch_size: int | None = None,
+        state_prefix: str = "backward",
     ) -> BackwardState:
         """Run a backward pass through the training trajectory saved at `ckpt_dir`.
 
@@ -812,7 +813,7 @@ class Trainer:
                 been processed.
             save_every: If > 0, save the backward state every N steps to allow resuming
                 from interruptions. Backward checkpoints are saved in `ckpt_dir` with
-                the name `backward_rank{rank}.pt`.
+                the name `{state_prefix}_rank{rank}.pt`.
             save_mode: The save mode that was used during the forward trajectory, which
                 determines how checkpoints are spaced and thus how the backward pass
                 should step forward through the trajectory when replaying.
@@ -825,6 +826,7 @@ class Trainer:
                 step uses the two-stage micro-VJP (`Trainer.metagrad_step`).
             double_backward_batch_size: Max sequences per double-backward graph in the
                 micro-VJP; see `TrainingConfig.double_backward_batch_size`.
+            state_prefix: Filename prefix for the saved backward state.
 
         Returns:
             The final backward state after processing the entire trajectory.
@@ -839,12 +841,34 @@ class Trainer:
         main = not dist.is_initialized() or dist.get_rank() == 0
         rank = dist.get_rank() if dist.is_initialized() else 0
 
-        bwd_ckpt_path = os.path.join(ckpt_dir, f"backward_rank{rank}.pt")
+        bwd_ckpt_path = os.path.join(ckpt_dir, f"{state_prefix}_rank{rank}.pt")
 
+        loaded = None
         if resume and os.path.exists(bwd_ckpt_path):
-            bwd_state, ckpt_list, expected_idx, last_idx = self.load_backward_state(
+            loaded = self.load_backward_state(
                 bwd_ckpt_path, ckpt_list, data.device, main
             )
+
+        # Ranks must resume from the same step or the replayed collectives
+        # deadlock; states must match.
+        if dist.is_initialized():
+            resume_step = torch.tensor(
+                [loaded[2] if loaded is not None else -1],
+                device=data.device,
+                dtype=torch.long,
+            )
+            lo, hi = resume_step.clone(), resume_step.clone()
+            dist.all_reduce(lo, op=dist.ReduceOp.MIN)
+            dist.all_reduce(hi, op=dist.ReduceOp.MAX)
+            if lo.item() != hi.item():
+                raise RuntimeError(
+                    f"Backward state in {ckpt_dir} disagrees across ranks "
+                    f"(steps {lo.item()}..{hi.item()}); another run may hold it. "
+                    "Delete the state files to start the backward over."
+                )
+
+        if loaded is not None:
+            bwd_state, ckpt_list, expected_idx, last_idx = loaded
         else:
             expected_idx, _ = ckpt_list[-1]
             last_idx = expected_idx

--- a/tests/test_per_query_magic.py
+++ b/tests/test_per_query_magic.py
@@ -9,6 +9,7 @@ queries have equal token counts so that the aggregate mean-over-tokens loss is
 the uniform mean of the per-query losses. That identity is the correctness gate.
 """
 
+import os
 import tempfile
 
 import pytest
@@ -309,6 +310,79 @@ def test_query_eval_ignores_padding_and_grad_accum(grad_accum_steps):
         torch.testing.assert_close(grads[name], want[name], msg=name)
     counts = torch.tensor([len(x) - 1 for x in ids], dtype=torch.float32)
     torch.testing.assert_close(loss, (per_doc * counts).sum() / counts.sum())
+
+
+def _per_query_resume_setup(tmp_path, num_docs=6, n_query=2):
+    """Train a small trajectory and return a per-query scoring runner that
+    starts from the final trained state, as the CLI's resume path does."""
+    model = _model()
+    optimizer = torchopt.adamw(1e-4, betas=(0.95, 0.975), eps_root=1e-2)
+    trainer, fwd_state = Trainer.initialize(model, optimizer)
+    stream = DataStream(_equal_length_docs(num_docs), batch_size=1, device="cpu")
+    query_ds = _equal_length_docs(n_query, start=100)
+
+    ckpts = str(tmp_path / "checkpoints")
+    fwd_state = trainer.train(fwd_state, stream, inplace=True, save_dir=ckpts)
+    final_state = fwd_state.to("cpu").detach_()
+
+    def run(run_path, resume):
+        run_cfg = MagicConfig(
+            run_path=str(run_path),
+            query_method="none",
+            backward_save_every=1,
+            resume=resume,
+        )
+        run_cfg.query.prompt_column = "input_ids"
+        fwd_state.detach_()
+        fwd_state.copy_(final_state)
+        stream.requires_grad = True
+        return compute_per_query_magic_scores(
+            trainer,
+            ckpts,
+            stream,
+            fwd_state,
+            model,
+            query_ds,
+            num_query_docs=n_query,
+            run_cfg=run_cfg,
+            world_size=1,
+            global_rank=0,
+            pad_count=0,
+            weight_pad_count=0,
+        )
+
+    return trainer, ckpts, run
+
+
+def test_per_query_backward_resumes_mid_query(tmp_path, monkeypatch, capsys):
+    """A preempted per-query backward resumes from its last saved state and
+    reproduces the uninterrupted scores."""
+    trainer, ckpts, run = _per_query_resume_setup(tmp_path)
+    clean = run(tmp_path / "clean", resume=False)
+
+    # Preempt query 0 after its second mid-backward save.
+    orig_save = Trainer.save_backward_state
+    saves = []
+
+    def crashing(self, *args, **kwargs):
+        orig_save(self, *args, **kwargs)
+        saves.append(args[1])
+        if len(saves) == 2:
+            raise RuntimeError("preempted")
+
+    monkeypatch.setattr(Trainer, "save_backward_state", crashing)
+    with pytest.raises(RuntimeError, match="preempted"):
+        run(tmp_path / "crashed", resume=True)
+    monkeypatch.setattr(Trainer, "save_backward_state", orig_save)
+
+    state_file = os.path.join(ckpts, "backward_q0_rank0.pt")
+    assert os.path.exists(state_file), "interruption must leave a state file"
+    capsys.readouterr()
+
+    resumed = run(tmp_path / "crashed", resume=True)
+    assert "Resuming backward pass" in capsys.readouterr().out
+    assert not os.path.exists(state_file), "state file must be cleaned on success"
+    torch.testing.assert_close(resumed, clean)
 
 
 def test_unsupervised_batch_loss_is_zero():


### PR DESCRIPTION
Fix: missing kwargs in per-query MAGIC callsite.
Feat: Per-query state filenames so a stale state file from one query can't be resumed by another. 