### PR TITLE
Add TRAK

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build a train‑time gradient store, use our HF Trainer callback. This will i
 
 Bergson supports on-disk gradient stores and on-the-fly queries, and per-token and per-sequence attribution.
 
-`bergson trackstar` and `bergson ekfac` both orchestrate multi-step attribution recipes over a model checkpoint. `bergson trak` runs [TRAK](https://arxiv.org/abs/2303.14186): projected gradients whitened by their damped Gram inverse, weighted by one minus the training example's label probability, optionally ensembled over checkpoints.
+`bergson trackstar` and `bergson ekfac` both orchestrate multi-step attribution recipes over a model checkpoint. `bergson trak` runs [TRAK](https://arxiv.org/abs/2303.14186): random projections of the margin-output gradients, whitened by the inverse Gram over the training set, weighted by one minus the training example's label probability, and averaged over independently trained models.
 
 At a lower level, you can build your own gradient store for efficient serial queries using `bergson build`. Collection-time gradient compression makes the store space-efficient, and a FAISS integration enables fast KNN search over large stores - see `bergson query`, or `Attributor` in the programmatic interface. For small queries and methods that don't use gradient compression (e.g., EK-FAC), you can score a dataset in a single pass using an in-memory query index of precomputed gradients. Dataset items may be scored using max, mean, and individual scoring strategies, enabling [LESS](https://arxiv.org/pdf/2402.04333)-style data filtering. See `bergson score` and `bergson build`.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build a train‑time gradient store, use our HF Trainer callback. This will i
 
 Bergson supports on-disk gradient stores and on-the-fly queries, and per-token and per-sequence attribution.
 
-`bergson trackstar` and `bergson ekfac` both orchestrate multi-step attribution recipes over a model checkpoint.
+`bergson trackstar` and `bergson ekfac` both orchestrate multi-step attribution recipes over a model checkpoint. `bergson trak` runs [TRAK](https://arxiv.org/abs/2303.14186): projected gradients whitened by their damped Gram inverse, weighted by one minus the training example's label probability, optionally ensembled over checkpoints.
 
 At a lower level, you can build your own gradient store for efficient serial queries using `bergson build`. Collection-time gradient compression makes the store space-efficient, and a FAISS integration enables fast KNN search over large stores - see `bergson query`, or `Attributor` in the programmatic interface. For small queries and methods that don't use gradient compression (e.g., EK-FAC), you can score a dataset in a single pass using an in-memory query index of precomputed gradients. Dataset items may be scored using max, mean, and individual scoring strategies, enabling [LESS](https://arxiv.org/pdf/2402.04333)-style data filtering. See `bergson score` and `bergson build`.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build a train‑time gradient store, use our HF Trainer callback. This will i
 
 Bergson supports on-disk gradient stores and on-the-fly queries, and per-token and per-sequence attribution.
 
-`bergson trackstar` and `bergson ekfac` both orchestrate multi-step attribution recipes over a model checkpoint. `bergson trak` runs [TRAK](https://arxiv.org/abs/2303.14186): random projections of the margin-output gradients, whitened by the inverse Gram over the training set, weighted by one minus the training example's label probability, and averaged over independently trained models.
+`bergson trackstar`, `bergson ekfac`, and `bergson trak` all orchestrate multi-step attribution recipes over a model checkpoint. `bergson trak` also supports [ensembling](https://arxiv.org/abs/2303.14186) over independently trained models.
 
 At a lower level, you can build your own gradient store for efficient serial queries using `bergson build`. Collection-time gradient compression makes the store space-efficient, and a FAISS integration enables fast KNN search over large stores - see `bergson query`, or `Attributor` in the programmatic interface. For small queries and methods that don't use gradient compression (e.g., EK-FAC), you can score a dataset in a single pass using an in-memory query index of precomputed gradients. Dataset items may be scored using max, mean, and individual scoring strategies, enabling [LESS](https://arxiv.org/pdf/2402.04333)-style data filtering. See `bergson score` and `bergson build`.
 

--- a/bergson/__main__.py
+++ b/bergson/__main__.py
@@ -22,6 +22,7 @@ from .cli.commands import (
     Test_Model_Configuration,
     Trackstar,
     Train,
+    Trak,
     Validate,
 )
 
@@ -43,6 +44,7 @@ class Main:
         Reduce,
         Score,
         Trackstar,
+        Trak,
         Train,
         Test_Model_Configuration,
         Validate,

--- a/bergson/cli/commands.py
+++ b/bergson/cli/commands.py
@@ -28,6 +28,7 @@ from ..config.config import (
     TrackstarConfig,
     TrackstarIndexConfig,
     TrainingConfig,
+    TrakConfig,
     ValidationConfig,
 )
 from ..config.config_io import save_run_config
@@ -266,6 +267,24 @@ class Trackstar(Serializable):
 
         save_run_config(self, self.index_cfg.run_path)
         trackstar(self.index_cfg, self.trackstar_cfg)
+
+
+@dataclass
+class Trak(Serializable):
+    """Run TRAK: projected-gradient Gram, whitened query index, scoring and
+    ``(1 - p)`` weighting as a single pipeline."""
+
+    # TRAK uses random-projection compression, so override the default
+    # projection_dim of 0.
+    index_cfg: TrackstarIndexConfig
+
+    trak_cfg: TrakConfig
+
+    def execute(self):
+        from .trak import trak
+
+        save_run_config(self, self.index_cfg.run_path)
+        trak(self.index_cfg, self.trak_cfg)
 
 
 @dataclass

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -235,7 +235,7 @@ def trak(index_cfg: IndexConfig, trak_cfg: TrakConfig):
         print(f"[TRAK] checkpoint {i + 1}/{len(trak_cfg.checkpoints)}: {model}")
         member_cfg = deepcopy(index_cfg)
         member_cfg.model = model
-        member_cfg.projection_seed = index_cfg.projection_seed + i
+        member_cfg.projection_seed = (index_cfg.projection_seed or 0) + i
         member_cfg.run_path = f"{index_cfg.run_path}/checkpoint_{i}"
         members.append(_trak_single(member_cfg, trak_cfg, member=True))
     if index_cfg.distributed._node_rank == 0:

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -9,10 +9,10 @@ where ``phi`` is a random projection of the per-example gradient, ``Phi``
 stacks the projected training gradients and ``p_i`` is the model's
 probability of ``z_i``'s labels. The sketch is Bergson's per-module
 double-sided projection (``projection_target="global"`` gives a single global
-sketch when its ``k x d`` matrices fit in memory); the kernel is the joint Gram
-over the concatenated sketch (``hessian method "gram"``) inverted as one
-matrix, or, with ``kernel="per_module"``, the block-diagonal per-module
-``autocorrelation`` Hessian. The damped inverse is applied to the query side,
+sketch when its ``k x d`` matrices fit in memory); the kernel is the
+``autocorrelation`` Hessian with ``scope="joint"`` (one Gram over the
+concatenated sketch, inverted as one matrix) or, with ``kernel="per_module"``,
+its block-diagonal per-module form. The damped inverse is applied to the query side,
 so the pipeline is the trackstar one without Hessian mixing or unit
 normalization, plus the ``(1 - p_i)`` weighting and an optional average over
 independently trained checkpoints.
@@ -139,14 +139,13 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
             return
         validate_run_path(cfg)
 
-    hess_method = "gram" if trak_cfg.kernel == "joint" else "autocorrelation"
     print(f"Step 1/4: Fitting the projected-gradient Gram ({trak_cfg.kernel})...")
     if not _step_complete(gram_path, resume):
         gram_cfg = deepcopy(index_cfg)
         gram_cfg.run_path = gram_path
         _limit_split_for_hess(gram_cfg, trak_cfg.stats_sample_size)
         _validate(gram_cfg)
-        hess_cfg = HessianConfig(method=hess_method)
+        hess_cfg = HessianConfig(method="autocorrelation", scope=trak_cfg.kernel)
         save_run_config(
             Hessian(hessian_cfg=hess_cfg, index_cfg=gram_cfg),
             gram_cfg.partial_run_path,

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -11,7 +11,7 @@ probability of ``z_i``'s labels. ``phi`` is one random projection of the
 whole gradient (``projection_target="global"``: every module's flattened
 gradient is projected with its own block of a single ``k x d`` Rademacher
 matrix and the blocks are summed) and the Gram is the ``autocorrelation``
-Hessian with ``scope="joint"`` over that sketch. The damped inverse is applied
+Hessian with ``structure="joint"`` over that sketch. The damped inverse is applied
 to the query side, so the pipeline is the trackstar one without Hessian
 mixing or unit normalization, plus the ``(1 - p_i)`` weighting and an
 optional average over independently trained checkpoints.
@@ -146,7 +146,7 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
         _validate(gram_cfg)
         # The Gram is over the training examples' own negative log-odds gradients.
         hess_cfg = HessianConfig(
-            method="autocorrelation", scope="joint", use_dataset_labels=True
+            method="autocorrelation", structure="joint", use_dataset_labels=True
         )
         save_run_config(
             Hessian(hessian_cfg=hess_cfg, index_cfg=gram_cfg),

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -21,6 +21,7 @@ import json
 import shutil
 from copy import deepcopy
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import torch
@@ -80,7 +81,7 @@ def _train_label_probs(index_cfg: IndexConfig, batch_size: int) -> np.ndarray:
     return probs
 
 
-def _open_scores(scores_dir: Path, mode: str) -> tuple[np.memmap, dict]:
+def _open_scores(scores_dir: Path, mode: Literal["r", "r+"]) -> tuple[np.memmap, dict]:
     info = json.loads((scores_dir / "info.json").read_text())
     if info.get("attribute_tokens"):
         raise ValueError("TRAK weighting supports per-sequence scores only")

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -46,7 +46,7 @@ from .trackstar import _limit_split_for_hess, _step_complete
 def _train_label_probs(index_cfg: IndexConfig, batch_size: int) -> np.ndarray:
     """Return ``p_i``, the mean label-token probability of every training row
     under the model, so ``1 - p_i`` is the row's TRAK ``Q`` term: the
-    derivative of the loss w.r.t. the margin output, averaged over tokens.
+    derivative of the loss w.r.t. the negative log-odds output, averaged over tokens.
     """
     ds, _ = setup_data_pipeline(index_cfg)
     cfg = deepcopy(index_cfg)
@@ -144,7 +144,7 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
         gram_cfg.run_path = gram_path
         _limit_split_for_hess(gram_cfg, trak_cfg.stats_sample_size)
         _validate(gram_cfg)
-        # The Gram is over the training examples' own margin gradients.
+        # The Gram is over the training examples' own negative log-odds gradients.
         hess_cfg = HessianConfig(
             method="autocorrelation", scope="joint", use_dataset_labels=True
         )
@@ -203,10 +203,10 @@ def trak(index_cfg: IndexConfig, trak_cfg: TrakConfig):
             "TRAK scores random-projected gradients and requires a nonzero "
             "index_cfg.projection_dim; got 0."
         )
-    if index_cfg.loss_fn != "margin":
+    if index_cfg.loss_fn != "log_odds":
         raise ValueError(
-            "TRAK's features are gradients of the margin output function; set "
-            f"index_cfg.loss_fn='margin' (got {index_cfg.loss_fn!r})."
+            "TRAK's features are gradients of the log odds output function; set "
+            f"index_cfg.loss_fn='log_odds' (got {index_cfg.loss_fn!r})."
         )
     if index_cfg.projection_target != "global":
         raise ValueError(

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -1,22 +1,3 @@
-"""TRAK over Bergson's projected-gradient index.
-
-TRAK (Park et al., 2023, https://arxiv.org/abs/2303.14186) scores a training
-example ``z_i`` for a query ``z_q`` as
-
-    phi(z_q)^T (Phi^T Phi + lambda I)^-1 phi(z_i) * (1 - p_i)
-
-where ``phi`` is a random projection of the per-example gradient, ``Phi``
-stacks the projected training gradients and ``p_i`` is the model's
-probability of ``z_i``'s labels. ``phi`` is one random projection of the
-whole gradient (``projection_target="global"``: every module's flattened
-gradient is projected with its own block of a single ``k x d`` Rademacher
-matrix and the blocks are summed) and the Gram is the ``autocorrelation``
-Hessian with ``structure="joint"`` over that sketch. The damped inverse is applied
-to the query side, so the pipeline is the trackstar one without Hessian
-mixing or unit normalization, plus the ``(1 - p_i)`` weighting and an
-optional average over independently trained checkpoints.
-"""
-
 import json
 import shutil
 from copy import deepcopy

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -7,11 +7,15 @@ example ``z_i`` for a query ``z_q`` as
 
 where ``phi`` is a random projection of the per-example gradient, ``Phi``
 stacks the projected training gradients and ``p_i`` is the model's
-probability of ``z_i``'s labels. Bergson fits ``Phi^T Phi`` per module as the
-``autocorrelation`` Hessian and applies its damped inverse through the dense
-preconditioner, so the pipeline is the trackstar one without Hessian mixing or
-unit normalization, plus the ``(1 - p_i)`` weighting and an optional average
-over independently trained checkpoints.
+probability of ``z_i``'s labels. The sketch is Bergson's per-module
+double-sided projection (``projection_target="global"`` gives a single global
+sketch when its ``k x d`` matrices fit in memory); the kernel is the joint Gram
+over the concatenated sketch (``hessian method "gram"``) inverted as one
+matrix, or, with ``kernel="per_module"``, the block-diagonal per-module
+``autocorrelation`` Hessian. The damped inverse is applied to the query side,
+so the pipeline is the trackstar one without Hessian mixing or unit
+normalization, plus the ``(1 - p_i)`` weighting and an optional average over
+independently trained checkpoints.
 """
 
 import json
@@ -135,13 +139,14 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
             return
         validate_run_path(cfg)
 
-    print("Step 1/4: Fitting the projected-gradient Gram on the training set...")
+    hess_method = "gram" if trak_cfg.kernel == "joint" else "autocorrelation"
+    print(f"Step 1/4: Fitting the projected-gradient Gram ({trak_cfg.kernel})...")
     if not _step_complete(gram_path, resume):
         gram_cfg = deepcopy(index_cfg)
         gram_cfg.run_path = gram_path
         _limit_split_for_hess(gram_cfg, trak_cfg.stats_sample_size)
         _validate(gram_cfg)
-        hess_cfg = HessianConfig(method="autocorrelation")
+        hess_cfg = HessianConfig(method=hess_method)
         save_run_config(
             Hessian(hessian_cfg=hess_cfg, index_cfg=gram_cfg),
             gram_cfg.partial_run_path,

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -183,11 +183,7 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
 
     print("Step 4/4: Weighting training rows by (1 - p_i)...")
     weights_file = Path(scores_path) / "trak_weights.npy"
-    if (
-        trak_cfg.q_weighting == "one_minus_p"
-        and index_cfg.distributed._node_rank == 0
-        and not weights_file.exists()
-    ):
+    if index_cfg.distributed._node_rank == 0 and not weights_file.exists():
         if index_cfg.attribute_tokens:
             raise ValueError("TRAK's (1 - p) weighting needs per-sequence scores")
         probs = _train_label_probs(index_cfg, trak_cfg.loss_batch_size)

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -1,0 +1,213 @@
+"""TRAK over Bergson's projected-gradient index.
+
+TRAK (Park et al., 2023, https://arxiv.org/abs/2303.14186) scores a training
+example ``z_i`` for a query ``z_q`` as
+
+    phi(z_q)^T (Phi^T Phi + lambda I)^-1 phi(z_i) * (1 - p_i)
+
+where ``phi`` is a random projection of the per-example gradient, ``Phi``
+stacks the projected training gradients and ``p_i`` is the model's
+probability of ``z_i``'s labels. Bergson fits ``Phi^T Phi`` per module as the
+``autocorrelation`` Hessian and applies its damped inverse through the dense
+preconditioner, so the pipeline is the trackstar one without Hessian mixing or
+unit normalization, plus the ``(1 - p_i)`` weighting and an optional average
+over independently trained checkpoints.
+"""
+
+import json
+import shutil
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from ..build import build
+from ..config.config import HessianConfig, IndexConfig, TrakConfig
+from ..config.config_io import save_run_config
+from ..data import pad_and_tensor
+from ..distributed import parent_barrier
+from ..hessians.hessian_approximations import approximate_hessians
+from ..score.score import score_dataset
+from ..utils.worker_utils import (
+    setup_data_pipeline,
+    setup_model_and_peft,
+    validate_run_path,
+)
+from .commands import Build, Hessian, Score
+from .trackstar import _limit_split_for_hess, _step_complete
+
+
+def _train_label_probs(index_cfg: IndexConfig, batch_size: int) -> np.ndarray:
+    """Return ``p_i = exp(-mean token CE)`` of every training row under the model.
+
+    The geometric-mean token probability stands in for the classification
+    ``p_i`` of Park et al.; ``1 - p_i`` is TRAK's per-example weight.
+    """
+    ds, _ = setup_data_pipeline(index_cfg)
+    cfg = deepcopy(index_cfg)
+    cfg.fsdp = False
+    model, _ = setup_model_and_peft(cfg, apply_fsdp=False)
+    model.eval()
+    device = next(model.parameters()).device
+    probs = np.zeros(len(ds), dtype=np.float64)
+    with torch.no_grad():
+        for start in range(0, len(ds), batch_size):
+            batch = ds[start : start + batch_size]
+            x, y, _, _ = pad_and_tensor(
+                batch["input_ids"],
+                labels=batch.get("labels"),
+                device=device,
+                sync_max_len=False,
+            )
+            logits = model(input_ids=x).logits[:, :-1].float()
+            target = y[:, 1:]
+            token_ce = F.cross_entropy(
+                logits.flatten(0, 1),
+                target.flatten(),
+                reduction="none",
+                ignore_index=-100,
+            ).view(target.shape)
+            valid = (target != -100).float()
+            mean_ce = (token_ce * valid).sum(1) / valid.sum(1).clamp(min=1)
+            probs[start : start + len(mean_ce)] = torch.exp(-mean_ce).cpu().numpy()
+    del model
+    torch.cuda.empty_cache()
+    return probs
+
+
+def _open_scores(scores_dir: Path, mode: str) -> tuple[np.memmap, dict]:
+    info = json.loads((scores_dir / "info.json").read_text())
+    if info.get("attribute_tokens"):
+        raise ValueError("TRAK weighting supports per-sequence scores only")
+    mmap = np.memmap(
+        scores_dir / "scores.bin",
+        dtype=info["dtype"],
+        mode=mode,
+        shape=(info["num_rows"],),
+    )
+    return mmap, info
+
+
+def _weight_rows(scores_dir: Path, weights: np.ndarray) -> None:
+    """Multiply every query's score column by the per-row ``weights`` in place."""
+    mmap, info = _open_scores(scores_dir, "r+")
+    assert len(weights) == info["num_rows"], (len(weights), info["num_rows"])
+    for q in range(info["num_scores"]):
+        col = f"score_{q}"
+        mmap[col] = (mmap[col].astype(np.float64) * weights).astype(mmap[col].dtype)
+    mmap.flush()
+    np.save(scores_dir / "trak_weights.npy", weights)
+
+
+def _average_scores(member_dirs: list[Path], out_dir: Path) -> None:
+    """Write the mean of the members' score stores to ``out_dir``."""
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    shutil.copytree(member_dirs[0], out_dir)
+    out, info = _open_scores(out_dir, "r+")
+    for q in range(info["num_scores"]):
+        col = f"score_{q}"
+        acc = np.zeros(info["num_rows"], dtype=np.float64)
+        for d in member_dirs:
+            member, _ = _open_scores(d, "r")
+            acc += member[col].astype(np.float64)
+        out[col] = (acc / len(member_dirs)).astype(out[col].dtype)
+    out.flush()
+
+
+def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
+    """Gram -> preconditioned query index -> score -> (1 - p) weighting."""
+    run_path = index_cfg.run_path
+    gram_path = f"{run_path}/train_hessian"
+    query_path = f"{run_path}/query"
+    scores_path = f"{run_path}/scores"
+    resume = trak_cfg.resume
+    preprocess_cfg = deepcopy(trak_cfg.preprocess_cfg)
+    # TRAK whitens with the Gram inverse; unit normalization would turn that
+    # into the trackstar H^-1/2 split and is not part of the method.
+    preprocess_cfg.unit_normalize = False
+    preprocess_cfg.hessian_path = gram_path
+
+    def _validate(cfg: IndexConfig):
+        if resume and cfg.partial_run_path.exists():
+            return
+        validate_run_path(cfg)
+
+    print("Step 1/4: Fitting the projected-gradient Gram on the training set...")
+    if not _step_complete(gram_path, resume):
+        gram_cfg = deepcopy(index_cfg)
+        gram_cfg.run_path = gram_path
+        _limit_split_for_hess(gram_cfg, trak_cfg.stats_sample_size)
+        _validate(gram_cfg)
+        hess_cfg = HessianConfig(method="autocorrelation")
+        save_run_config(
+            Hessian(hessian_cfg=hess_cfg, index_cfg=gram_cfg),
+            gram_cfg.partial_run_path,
+        )
+        approximate_hessians(gram_cfg, hess_cfg)
+    parent_barrier(index_cfg.distributed)
+
+    print("Step 2/4: Building the Gram-whitened query index...")
+    if not _step_complete(query_path, resume):
+        query_cfg = deepcopy(index_cfg)
+        query_cfg.run_path = query_path
+        query_cfg.data = deepcopy(trak_cfg.query)
+        if preprocess_cfg.aggregation != "none" and query_cfg.attribute_tokens:
+            query_cfg.attribute_tokens = False
+        _validate(query_cfg)
+        save_run_config(Build(query_cfg, preprocess_cfg), query_cfg.partial_run_path)
+        build(query_cfg, preprocess_cfg)
+
+    print("Step 3/4: Scoring the training set...")
+    if not _step_complete(scores_path, resume):
+        score_index_cfg = deepcopy(index_cfg)
+        score_index_cfg.run_path = scores_path
+        score_cfg = deepcopy(trak_cfg.score_cfg)
+        score_cfg.query_path = query_path
+        score_cfg.higher_is_better = True
+        _validate(score_index_cfg)
+        save_run_config(
+            Score(score_cfg, score_index_cfg, preprocess_cfg),
+            score_index_cfg.partial_run_path,
+        )
+        score_dataset(score_index_cfg, score_cfg, preprocess_cfg)
+    parent_barrier(index_cfg.distributed)
+
+    print("Step 4/4: Weighting training rows by (1 - p_i)...")
+    weights_file = Path(scores_path) / "trak_weights.npy"
+    if (
+        trak_cfg.q_weighting == "one_minus_p"
+        and index_cfg.distributed._node_rank == 0
+        and not weights_file.exists()
+    ):
+        if index_cfg.attribute_tokens:
+            raise ValueError("TRAK's (1 - p) weighting needs per-sequence scores")
+        probs = _train_label_probs(index_cfg, trak_cfg.loss_batch_size)
+        _weight_rows(Path(scores_path), 1.0 - probs)
+    parent_barrier(index_cfg.distributed)
+    return Path(scores_path)
+
+
+def trak(index_cfg: IndexConfig, trak_cfg: TrakConfig):
+    """Run TRAK, averaging over ``trak_cfg.checkpoints`` when given."""
+    if index_cfg.projection_dim == 0:
+        raise ValueError(
+            "TRAK scores random-projected gradients and requires a nonzero "
+            "index_cfg.projection_dim; got 0."
+        )
+    if not trak_cfg.checkpoints:
+        _trak_single(index_cfg, trak_cfg)
+        return
+
+    members = []
+    for i, model in enumerate(trak_cfg.checkpoints):
+        print(f"[TRAK] checkpoint {i + 1}/{len(trak_cfg.checkpoints)}: {model}")
+        member_cfg = deepcopy(index_cfg)
+        member_cfg.model = model
+        member_cfg.run_path = f"{index_cfg.run_path}/checkpoint_{i}"
+        members.append(_trak_single(member_cfg, trak_cfg))
+    if index_cfg.distributed._node_rank == 0:
+        _average_scores(members, Path(index_cfg.run_path) / "scores")
+    parent_barrier(index_cfg.distributed)

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -9,11 +9,13 @@ import torch
 import torch.nn.functional as F
 
 from ..build import build
-from ..config.config import HessianConfig, IndexConfig, TrakConfig
+from ..config.config import HessianConfig, IndexConfig, InversionConfig, TrakConfig
 from ..config.config_io import save_run_config
 from ..data import pad_and_tensor
 from ..distributed import parent_barrier
+from ..gradients import GradientProcessor
 from ..hessians.hessian_approximations import approximate_hessians
+from ..hessians.inversion import invert_psd_matrix
 from ..score.score import score_dataset
 from ..utils.worker_utils import (
     setup_data_pipeline,
@@ -82,27 +84,53 @@ def _weight_rows(scores_dir: Path, weights: np.ndarray) -> None:
         col = f"score_{q}"
         mmap[col] = (mmap[col].astype(np.float64) * weights).astype(mmap[col].dtype)
     mmap.flush()
-    np.save(scores_dir / "trak_weights.npy", weights)
+
+
+def _inverse_gram_scale(gram_path: str, inversion_cfg: InversionConfig) -> float:
+    """Mean absolute entry of the inverse Gram at ``gram_path``. The reference
+    implementation divides the inverse by it so that ensemble members' scores
+    share a scale."""
+    processor = GradientProcessor.load(Path(gram_path), map_location="cpu")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    h_inv = invert_psd_matrix(
+        processor.hessians["joint"].to(device=device, dtype=torch.float32),
+        inversion=inversion_cfg.inversion,
+        damping_factor=inversion_cfg.damping_factor,
+        power=-1.0,
+    )
+    return float(h_inv.abs().mean())
 
 
 def _average_scores(member_dirs: list[Path], out_dir: Path) -> None:
-    """Write the mean of the members' score stores to ``out_dir``."""
+    """Write the ensemble score store to ``out_dir``. Each member's unweighted
+    scores divided by its ``trak_scale``, averaged over members, times the
+    members' mean ``1 - p_i`` weights."""
     if out_dir.exists():
         shutil.rmtree(out_dir)
     shutil.copytree(member_dirs[0], out_dir)
+    weights = np.mean([np.load(d / "trak_weights.npy") for d in member_dirs], axis=0)
+    scales = np.array([np.load(d / "trak_scale.npy") for d in member_dirs])
     out, info = _open_scores(out_dir, "r+")
     for q in range(info["num_scores"]):
         col = f"score_{q}"
         acc = np.zeros(info["num_rows"], dtype=np.float64)
-        for d in member_dirs:
+        for d, scale in zip(member_dirs, scales):
             member, _ = _open_scores(d, "r")
-            acc += member[col].astype(np.float64)
-        out[col] = (acc / len(member_dirs)).astype(out[col].dtype)
+            acc += member[col].astype(np.float64) / scale
+        out[col] = (acc / len(member_dirs) * weights).astype(out[col].dtype)
     out.flush()
+    np.save(out_dir / "trak_weights.npy", weights)
+    np.save(out_dir / "trak_scale.npy", scales)
 
 
-def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
-    """Gram -> preconditioned query index -> score -> (1 - p) weighting."""
+def _trak_single(
+    index_cfg: IndexConfig, trak_cfg: TrakConfig, member: bool = False
+) -> Path:
+    """Gram -> preconditioned query index -> score -> (1 - p) weighting.
+
+    An ensemble ``member`` saves its weights and scale but leaves its scores
+    unweighted for :func:`_average_scores`.
+    """
     run_path = index_cfg.run_path
     gram_path = f"{run_path}/train_hessian"
     query_path = f"{run_path}/query"
@@ -163,14 +191,19 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
     parent_barrier(index_cfg.distributed)
 
     print("Step 4/4: Weighting training rows by (1 - p_i)...")
-    weights_file = Path(scores_path) / "trak_weights.npy"
+    scores_dir = Path(scores_path)
+    weights_file = scores_dir / "trak_weights.npy"
     if index_cfg.distributed._node_rank == 0 and not weights_file.exists():
         if index_cfg.attribute_tokens:
             raise ValueError("TRAK's (1 - p) weighting needs per-sequence scores")
-        probs = _train_label_probs(index_cfg, trak_cfg.loss_batch_size)
-        _weight_rows(Path(scores_path), 1.0 - probs)
+        weights = 1.0 - _train_label_probs(index_cfg, trak_cfg.loss_batch_size)
+        scale = _inverse_gram_scale(gram_path, preprocess_cfg.inversion_cfg)
+        if not member:
+            _weight_rows(scores_dir, weights / scale)
+        np.save(scores_dir / "trak_scale.npy", scale)
+        np.save(weights_file, weights)
     parent_barrier(index_cfg.distributed)
-    return Path(scores_path)
+    return scores_dir
 
 
 def trak(index_cfg: IndexConfig, trak_cfg: TrakConfig):
@@ -202,8 +235,9 @@ def trak(index_cfg: IndexConfig, trak_cfg: TrakConfig):
         print(f"[TRAK] checkpoint {i + 1}/{len(trak_cfg.checkpoints)}: {model}")
         member_cfg = deepcopy(index_cfg)
         member_cfg.model = model
+        member_cfg.projection_seed = index_cfg.projection_seed + i
         member_cfg.run_path = f"{index_cfg.run_path}/checkpoint_{i}"
-        members.append(_trak_single(member_cfg, trak_cfg))
+        members.append(_trak_single(member_cfg, trak_cfg, member=True))
     if index_cfg.distributed._node_rank == 0:
         _average_scores(members, Path(index_cfg.run_path) / "scores")
     parent_barrier(index_cfg.distributed)

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -44,10 +44,9 @@ from .trackstar import _limit_split_for_hess, _step_complete
 
 
 def _train_label_probs(index_cfg: IndexConfig, batch_size: int) -> np.ndarray:
-    """Return ``p_i = exp(-mean token CE)`` of every training row under the model.
-
-    The geometric-mean token probability stands in for the classification
-    ``p_i`` of Park et al.; ``1 - p_i`` is TRAK's per-example weight.
+    """Return ``p_i``, the mean label-token probability of every training row
+    under the model, so ``1 - p_i`` is the row's TRAK ``Q`` term: the
+    derivative of the loss w.r.t. the margin output, averaged over tokens.
     """
     ds, _ = setup_data_pipeline(index_cfg)
     cfg = deepcopy(index_cfg)
@@ -74,8 +73,8 @@ def _train_label_probs(index_cfg: IndexConfig, batch_size: int) -> np.ndarray:
                 ignore_index=-100,
             ).view(target.shape)
             valid = (target != -100).float()
-            mean_ce = (token_ce * valid).sum(1) / valid.sum(1).clamp(min=1)
-            probs[start : start + len(mean_ce)] = torch.exp(-mean_ce).cpu().numpy()
+            mean_p = (torch.exp(-token_ce) * valid).sum(1) / valid.sum(1).clamp(min=1)
+            probs[start : start + len(mean_p)] = mean_p.cpu().numpy()
     del model
     torch.cuda.empty_cache()
     return probs
@@ -145,7 +144,10 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
         gram_cfg.run_path = gram_path
         _limit_split_for_hess(gram_cfg, trak_cfg.stats_sample_size)
         _validate(gram_cfg)
-        hess_cfg = HessianConfig(method="autocorrelation", scope="joint")
+        # The Gram is over the training examples' own margin gradients.
+        hess_cfg = HessianConfig(
+            method="autocorrelation", scope="joint", use_dataset_labels=True
+        )
         save_run_config(
             Hessian(hessian_cfg=hess_cfg, index_cfg=gram_cfg),
             gram_cfg.partial_run_path,
@@ -200,6 +202,11 @@ def trak(index_cfg: IndexConfig, trak_cfg: TrakConfig):
         raise ValueError(
             "TRAK scores random-projected gradients and requires a nonzero "
             "index_cfg.projection_dim; got 0."
+        )
+    if index_cfg.loss_fn != "margin":
+        raise ValueError(
+            "TRAK's features are gradients of the margin output function; set "
+            f"index_cfg.loss_fn='margin' (got {index_cfg.loss_fn!r})."
         )
     if index_cfg.projection_target != "global":
         raise ValueError(

--- a/bergson/cli/trak.py
+++ b/bergson/cli/trak.py
@@ -7,15 +7,14 @@ example ``z_i`` for a query ``z_q`` as
 
 where ``phi`` is a random projection of the per-example gradient, ``Phi``
 stacks the projected training gradients and ``p_i`` is the model's
-probability of ``z_i``'s labels. The sketch is Bergson's per-module
-double-sided projection (``projection_target="global"`` gives a single global
-sketch when its ``k x d`` matrices fit in memory); the kernel is the
-``autocorrelation`` Hessian with ``scope="joint"`` (one Gram over the
-concatenated sketch, inverted as one matrix) or, with ``kernel="per_module"``,
-its block-diagonal per-module form. The damped inverse is applied to the query side,
-so the pipeline is the trackstar one without Hessian mixing or unit
-normalization, plus the ``(1 - p_i)`` weighting and an optional average over
-independently trained checkpoints.
+probability of ``z_i``'s labels. ``phi`` is one random projection of the
+whole gradient (``projection_target="global"``: every module's flattened
+gradient is projected with its own block of a single ``k x d`` Rademacher
+matrix and the blocks are summed) and the Gram is the ``autocorrelation``
+Hessian with ``scope="joint"`` over that sketch. The damped inverse is applied
+to the query side, so the pipeline is the trackstar one without Hessian
+mixing or unit normalization, plus the ``(1 - p_i)`` weighting and an
+optional average over independently trained checkpoints.
 """
 
 import json
@@ -139,13 +138,13 @@ def _trak_single(index_cfg: IndexConfig, trak_cfg: TrakConfig) -> Path:
             return
         validate_run_path(cfg)
 
-    print(f"Step 1/4: Fitting the projected-gradient Gram ({trak_cfg.kernel})...")
+    print("Step 1/4: Fitting the projected-gradient Gram...")
     if not _step_complete(gram_path, resume):
         gram_cfg = deepcopy(index_cfg)
         gram_cfg.run_path = gram_path
         _limit_split_for_hess(gram_cfg, trak_cfg.stats_sample_size)
         _validate(gram_cfg)
-        hess_cfg = HessianConfig(method="autocorrelation", scope=trak_cfg.kernel)
+        hess_cfg = HessianConfig(method="autocorrelation", scope="joint")
         save_run_config(
             Hessian(hessian_cfg=hess_cfg, index_cfg=gram_cfg),
             gram_cfg.partial_run_path,
@@ -200,6 +199,14 @@ def trak(index_cfg: IndexConfig, trak_cfg: TrakConfig):
         raise ValueError(
             "TRAK scores random-projected gradients and requires a nonzero "
             "index_cfg.projection_dim; got 0."
+        )
+    if index_cfg.projection_target != "global":
+        raise ValueError(
+            "TRAK projects the whole gradient with one random matrix; set "
+            "index_cfg.projection_target='global' (got "
+            f"{index_cfg.projection_target!r}). Per-module projections "
+            "concatenated over modules are a different sketch; use "
+            "`bergson trackstar` for a per-module pipeline."
         )
     if not trak_cfg.checkpoints:
         _trak_single(index_cfg, trak_cfg)

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -925,15 +925,16 @@ def token_losses(
     loss_fn: str, logits: Tensor, labels: Tensor, label_smoothing: float = 0.0
 ) -> Tensor:
     """Per-token losses ``[batch, seq]`` for ``loss_fn`` ``ce`` or ``log_odds``;
-    padding labels (-100) give zero."""
+    padding labels (-100) give zero. ``label_smoothing`` only applies to ``ce``."""
     if loss_fn == "log_odds":
+        # follows
+        # https://github.com/MadryLab/trak/blob/main/trak/modelout_functions.py
         valid = labels != -100
-        lp = torch.log_softmax(logits.float(), dim=-1)
-        lp = lp.gather(-1, labels.clamp(min=0).unsqueeze(-1)).squeeze(-1)
-        # log(1 - p) = log(-expm1(log p)); cap log p so the log odds stays finite.
-        lp = lp.clamp(max=-1e-6)
-        log_odds = lp - torch.log(-torch.expm1(lp))
-        return (-log_odds * valid).to(logits.dtype)
+        idx = labels.clamp(min=0).unsqueeze(-1)
+        logits = logits.float()
+        z_y = logits.gather(-1, idx).squeeze(-1)
+        others = logits.scatter(-1, idx, float("-inf")).logsumexp(-1)
+        return (-(z_y - others) * valid).to(logits.dtype)
     return F.cross_entropy(
         logits.reshape(-1, logits.size(-1)),
         labels.flatten(),

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -921,14 +921,35 @@ class CollectorComputer:
         self.logger.info(f"Total processed: {total_processed.item()}")
 
 
+def token_losses(
+    loss_fn: str, logits: Tensor, labels: Tensor, label_smoothing: float = 0.0
+) -> Tensor:
+    """Per-token losses ``[batch, seq]`` for ``loss_fn`` ``ce`` or ``margin``;
+    padding labels (-100) give zero."""
+    if loss_fn == "margin":
+        valid = labels != -100
+        lp = torch.log_softmax(logits.float(), dim=-1)
+        lp = lp.gather(-1, labels.clamp(min=0).unsqueeze(-1)).squeeze(-1)
+        # log(1 - p) = log(-expm1(log p)); cap log p so the margin stays finite.
+        lp = lp.clamp(max=-1e-6)
+        margin = lp - torch.log(-torch.expm1(lp))
+        return (-margin * valid).to(logits.dtype)
+    return F.cross_entropy(
+        logits.reshape(-1, logits.size(-1)),
+        labels.flatten(),
+        reduction="none",
+        label_smoothing=label_smoothing,
+    ).reshape_as(labels)
+
+
 def fwd_bwd_factory(cfg: IndexConfig) -> Callable:
     """
     Create a forward/backward function based on the configuration.
 
     Args:
         cfg: IndexConfig that specifies:
-            - cfg.loss_fn: Either "kl" for KL divergence (requires PEFT model) or
-              any other value for cross-entropy loss.
+            - cfg.loss_fn: "kl" for KL divergence (requires PEFT model),
+              "margin" for the negative label log-odds, else cross-entropy.
             - cfg.loss_reduction: Either "mean" to average over tokens, or "sum" for
               summed loss.
 
@@ -965,12 +986,7 @@ def fwd_bwd_factory(cfg: IndexConfig) -> Callable:
                 losses *= torch.tensor(batch["advantage"], device=losses.device)
 
         else:
-            losses = F.cross_entropy(
-                logits.reshape(-1, logits.size(-1)),
-                y[:, 1:].flatten(),
-                reduction="none",
-                label_smoothing=cfg.label_smoothing,
-            ).reshape_as(y[:, 1:])
+            losses = token_losses(cfg.loss_fn, logits, y[:, 1:], cfg.label_smoothing)
             losses = losses.sum(1) / denoms
             if "advantage" in batch:
                 losses *= torch.tensor(batch["advantage"], device=losses.device)
@@ -995,11 +1011,7 @@ def fwd_bwd_hessian_factory(
             else 1.0
         )
         if hessian_cfg.use_dataset_labels:
-            losses = F.cross_entropy(
-                logits.reshape(-1, logits.size(-1)),
-                y[:, 1:].flatten(),
-                reduction="none",
-            ).reshape_as(y[:, 1:])
+            losses = token_losses(index_cfg.loss_fn, logits, y[:, 1:])
             losses = losses.sum(1) / denoms
         else:
             with torch.no_grad():

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -333,6 +333,16 @@ class HookCollectorBase(ContextDecorator, ABC):
 
         return shapes
 
+    @staticmethod
+    def projection_identifier(
+        name: str, role: Literal["left", "right", "single"], seed: int
+    ) -> str:
+        """Name (and seed) of parameter ``name``'s ``role`` projection matrix"""
+        identifier = f"{name}/{role}"
+        if seed:
+            identifier = f"{identifier}/seed{seed}"
+        return identifier
+
     def projection(
         self,
         name: str,
@@ -347,7 +357,9 @@ class HookCollectorBase(ContextDecorator, ABC):
         if key in self.processor._projection_matrices:
             return self.processor._projection_matrices[key]
 
-        identifier = f"{name}/{role}"
+        identifier = self.projection_identifier(
+            name, role, self.processor.projection_seed
+        )
 
         A = create_projection_matrix(
             identifier,
@@ -375,7 +387,7 @@ class HookCollectorBase(ContextDecorator, ABC):
 
         assert self.processor.projection_dim is not None
         projected = project_global(
-            f"{name}/single",
+            self.projection_identifier(name, "single", self.processor.projection_seed),
             P,
             self.processor.projection_dim,
             self.processor.projection_type,

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from contextlib import ContextDecorator, nullcontext
 from dataclasses import astuple, dataclass, field
 from fnmatch import fnmatchcase
-from typing import Iterator, Callable, Literal, Mapping, Optional
+from typing import Callable, Iterator, Literal, Mapping, Optional
 
 import numpy as np
 import torch
@@ -1052,7 +1052,9 @@ def global_projection_blocks(
         seed = int.from_bytes(digest, byteorder="big") % (2**63 - 1)
         prng = torch.Generator(device).manual_seed(seed)
         if projection_type == "normal":
-            block = torch.randn(m, stop - start, device=device, dtype=dtype, generator=prng)
+            block = torch.randn(
+                m, stop - start, device=device, dtype=dtype, generator=prng
+            )
         elif projection_type == "rademacher":
             block = torch.empty(m, stop - start, device=device, dtype=dtype)
             block.bernoulli_(0.5, generator=prng).mul_(2).sub_(1)

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -1036,8 +1036,9 @@ def fwd_bwd_hessian_factory(
     return fwd_bwd_hessian
 
 
-GLOBAL_BLOCK_ELEMENTS = 1 << 27
-"""Elements per generated block of a global projection matrix (512 MB in fp32)."""
+CHUNKED_PROJECTION_INSTANTIATION_NUMEL = 1 << 27
+"""Batch size of the batched global projection matrix instantiations (512 MB
+in fp32)."""
 
 
 def global_projection_blocks(
@@ -1057,7 +1058,7 @@ def global_projection_blocks(
     whenever it is regenerated. Blocks are unscaled: apply the projection
     scale to the result (see :func:`project_global`).
     """
-    cols = max(1, GLOBAL_BLOCK_ELEMENTS // m)
+    cols = max(1, CHUNKED_PROJECTION_INSTANTIATION_NUMEL // m)
     for start in range(0, n, cols):
         stop = min(n, start + cols)
         digest = hashlib.md5(f"{identifier}/{start}".encode()).digest()

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -924,16 +924,16 @@ class CollectorComputer:
 def token_losses(
     loss_fn: str, logits: Tensor, labels: Tensor, label_smoothing: float = 0.0
 ) -> Tensor:
-    """Per-token losses ``[batch, seq]`` for ``loss_fn`` ``ce`` or ``margin``;
+    """Per-token losses ``[batch, seq]`` for ``loss_fn`` ``ce`` or ``log_odds``;
     padding labels (-100) give zero."""
-    if loss_fn == "margin":
+    if loss_fn == "log_odds":
         valid = labels != -100
         lp = torch.log_softmax(logits.float(), dim=-1)
         lp = lp.gather(-1, labels.clamp(min=0).unsqueeze(-1)).squeeze(-1)
-        # log(1 - p) = log(-expm1(log p)); cap log p so the margin stays finite.
+        # log(1 - p) = log(-expm1(log p)); cap log p so the log odds stays finite.
         lp = lp.clamp(max=-1e-6)
-        margin = lp - torch.log(-torch.expm1(lp))
-        return (-margin * valid).to(logits.dtype)
+        log_odds = lp - torch.log(-torch.expm1(lp))
+        return (-log_odds * valid).to(logits.dtype)
     return F.cross_entropy(
         logits.reshape(-1, logits.size(-1)),
         labels.flatten(),
@@ -949,7 +949,7 @@ def fwd_bwd_factory(cfg: IndexConfig) -> Callable:
     Args:
         cfg: IndexConfig that specifies:
             - cfg.loss_fn: "kl" for KL divergence (requires PEFT model),
-              "margin" for the negative label log-odds, else cross-entropy.
+              "log_odds" for the negative label log-odds, else cross-entropy.
             - cfg.loss_reduction: Either "mean" to average over tokens, or "sum" for
               summed loss.
 

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -335,11 +335,11 @@ class HookCollectorBase(ContextDecorator, ABC):
 
     @staticmethod
     def projection_identifier(
-        name: str, role: Literal["left", "right", "single"], seed: int
+        name: str, role: Literal["left", "right", "single"], seed: int | None
     ) -> str:
         """Name (and seed) of parameter ``name``'s ``role`` projection matrix"""
         identifier = f"{name}/{role}"
-        if seed:
+        if seed is not None:
             identifier = f"{identifier}/seed{seed}"
         return identifier
 

--- a/bergson/collector/collector.py
+++ b/bergson/collector/collector.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from contextlib import ContextDecorator, nullcontext
 from dataclasses import astuple, dataclass, field
 from fnmatch import fnmatchcase
-from typing import Callable, Literal, Mapping, Optional
+from typing import Iterator, Callable, Literal, Mapping, Optional
 
 import numpy as np
 import torch
@@ -374,15 +374,13 @@ class HookCollectorBase(ContextDecorator, ABC):
             return False
 
         assert self.processor.projection_dim is not None
-        R = self.projection(
-            name,
+        projected = project_global(
+            f"{name}/single",
+            P,
             self.processor.projection_dim,
-            P.shape[1],
-            "single",
-            P.device,
-            P.dtype,
-        )
-        projected = P @ R.T  # [N, proj_dim]
+            self.processor.projection_type,
+            self.processor.projection_scale,
+        )  # [N, proj_dim]
         if "gradients" in self.mod_grads:
             self.mod_grads["gradients"].add_(projected)
         else:
@@ -1024,6 +1022,73 @@ def fwd_bwd_hessian_factory(
         return losses
 
     return fwd_bwd_hessian
+
+
+GLOBAL_BLOCK_ELEMENTS = 1 << 27
+"""Elements per generated block of a global projection matrix (512 MB in fp32)."""
+
+
+def global_projection_blocks(
+    identifier: str,
+    m: int,
+    n: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    projection_type: Literal["normal", "rademacher"] = "normal",
+) -> Iterator[tuple[int, int, Tensor]]:
+    """Yield the column blocks ``(start, stop, R[:, start:stop])`` of the
+    ``[m, n]`` projection matrix named ``identifier``, generated on ``device``
+    one block at a time so the whole matrix is never held in memory.
+
+    The block layout depends only on ``m``, and every block is seeded from
+    ``identifier`` and its start column, so the same matrix is reproduced
+    whenever it is regenerated. Blocks are unscaled: apply the projection
+    scale to the result (see :func:`project_global`).
+    """
+    cols = max(1, GLOBAL_BLOCK_ELEMENTS // m)
+    for start in range(0, n, cols):
+        stop = min(n, start + cols)
+        digest = hashlib.md5(f"{identifier}/{start}".encode()).digest()
+        seed = int.from_bytes(digest, byteorder="big") % (2**63 - 1)
+        prng = torch.Generator(device).manual_seed(seed)
+        if projection_type == "normal":
+            block = torch.randn(m, stop - start, device=device, dtype=dtype, generator=prng)
+        elif projection_type == "rademacher":
+            block = torch.empty(m, stop - start, device=device, dtype=dtype)
+            block.bernoulli_(0.5, generator=prng).mul_(2).sub_(1)
+        else:
+            raise ValueError(f"Unknown projection type: {projection_type}")
+        yield start, stop, block
+
+
+def project_global(
+    identifier: str,
+    P: Tensor,
+    m: int,
+    projection_type: Literal["normal", "rademacher"] = "normal",
+    projection_scale: Literal["jl", "row_norm"] = "jl",
+) -> Tensor:
+    """``P @ R.T`` for the ``[m, n]`` projection matrix named ``identifier``,
+    where ``P`` is ``[N, n]``, streaming ``R`` in column blocks.
+
+    Matches :func:`create_projection_matrix` in its scaling: ``jl`` divides by
+    ``sqrt(m)``; ``row_norm`` divides each output column by the norm of the
+    corresponding row of ``R`` (``sqrt(n)`` exactly for Rademacher entries).
+    """
+    n = P.shape[1]
+    out = P.new_zeros(P.shape[0], m)
+    row_sq = P.new_zeros(m) if projection_scale == "row_norm" else None
+    for start, stop, block in global_projection_blocks(
+        identifier, m, n, P.dtype, P.device, projection_type
+    ):
+        out.addmm_(P[:, start:stop], block.T)
+        if row_sq is not None:
+            row_sq.add_(block.pow(2).sum(dim=1))
+    if row_sq is not None:
+        out.div_(row_sq.sqrt())
+    else:
+        out.div_(math.sqrt(m))
+    return out
 
 
 def create_projection_matrix(

--- a/bergson/config/__init__.py
+++ b/bergson/config/__init__.py
@@ -19,6 +19,7 @@ from .config import (
     ScoreConfig,
     TrackstarConfig,
     TrainingConfig,
+    TrakConfig,
     ValidationConfig,
 )
 from .validation import (
@@ -52,6 +53,7 @@ __all__ = [
     "RecallDataConfig",
     "ScoreConfig",
     "TrackstarConfig",
+    "TrakConfig",
     "TrainingConfig",
     "ValidationConfig",
 ]

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -990,12 +990,6 @@ class TrakConfig:
 
     score_cfg: ScoreConfig = field(default_factory=ScoreConfig)
 
-    kernel: Literal["joint", "per_module"] = "joint"
-    """Scope of the autocorrelation Gram (``HessianConfig.scope``): ``joint``
-    (TRAK) is one Gram over the concatenation of all modules' projected
-    gradients, inverted as a single matrix; ``per_module`` is the block-diagonal
-    approximation with one Gram per module, cheaper but not TRAK's kernel."""
-
     q_weighting: Literal["one_minus_p", "none"] = "one_minus_p"
     """Multiply each training row's scores by ``1 - p_i``, with ``p_i`` the
     geometric-mean token probability of the row's labels under the model

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -966,3 +966,40 @@ class TrackstarConfig:
 
     resume: bool = False
     """Skip pipeline steps whose output directory already exists."""
+
+
+@dataclass
+class TrakConfig:
+    """Config for the TRAK pipeline (Park et al., 2023): random-projected
+    gradients whitened by the damped inverse of their Gram matrix, weighted by
+    ``1 - p_i`` on the training side, optionally averaged over independently
+    trained checkpoints."""
+
+    query: DataConfig = field(default_factory=DataConfig)
+    """Query dataset specification."""
+
+    preprocess_cfg: PreprocessConfig = field(default_factory=PreprocessConfig)
+    """``inversion_cfg`` sets the Gram damping; ``unit_normalize`` is ignored
+    (TRAK whitens with the full inverse)."""
+
+    score_cfg: ScoreConfig = field(default_factory=ScoreConfig)
+
+    q_weighting: Literal["one_minus_p", "none"] = "one_minus_p"
+    """Multiply each training row's scores by ``1 - p_i``, with ``p_i`` the
+    geometric-mean token probability of the row's labels under the model
+    (TRAK's ``Q`` term). ``none`` leaves the whitened inner products."""
+
+    checkpoints: list[str] = field(default_factory=list)
+    """Independently trained model checkpoints to ensemble. Each runs the full
+    pipeline under ``<run_path>/checkpoint_<i>``; ``<run_path>/scores`` is the
+    mean of their score stores. Empty: use ``index_cfg.model`` alone."""
+
+    stats_sample_size: int | None = None
+    """Number of training examples the Gram is fit on. ``None`` (default)
+    uses the whole training set, as TRAK does."""
+
+    loss_batch_size: int = 32
+    """Rows per forward pass when computing ``p_i``."""
+
+    resume: bool = False
+    """Skip pipeline steps whose output directory already exists."""

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -613,8 +613,11 @@ class IndexConfig(AttributionConfig, Serializable):
     Note: Untested with the AdamW eps_root in the bergson trainer -
     consider setting this to 0 when using optimizer normalization."""
 
-    loss_fn: Literal["ce", "kl"] = "ce"
-    """Loss function to use."""
+    loss_fn: Literal["ce", "kl", "margin"] = "ce"
+    """Loss function to use. ``margin`` is the negative log-odds of each label
+    token, ``-(log p - log(1 - p))``, the model output function of TRAK
+    (Park et al., 2023) whose per-token derivative w.r.t. the loss is
+    ``1 - p``."""
 
     loss_reduction: Literal["mean", "sum"] = "sum"
     """How the per-token losses of a document are reduced before the backward
@@ -984,16 +987,20 @@ class TrakConfig:
     query: DataConfig = field(default_factory=DataConfig)
     """Query dataset specification."""
 
-    preprocess_cfg: PreprocessConfig = field(default_factory=PreprocessConfig)
-    """``inversion_cfg`` sets the Gram damping; ``unit_normalize`` is ignored
-    (TRAK whitens with the full inverse)."""
+    preprocess_cfg: PreprocessConfig = field(
+        default_factory=lambda: PreprocessConfig(
+            inversion_cfg=InversionConfig(damping_factor=0.0)
+        )
+    )
+    """``inversion_cfg`` sets the Gram damping, zero by default as in the paper;
+    ``unit_normalize`` is ignored (TRAK whitens with the full inverse)."""
 
     score_cfg: ScoreConfig = field(default_factory=ScoreConfig)
 
     q_weighting: Literal["one_minus_p", "none"] = "one_minus_p"
-    """Multiply each training row's scores by ``1 - p_i``, with ``p_i`` the
-    geometric-mean token probability of the row's labels under the model
-    (TRAK's ``Q`` term). ``none`` leaves the whitened inner products."""
+    """Multiply each training row's scores by TRAK's ``Q`` term, the derivative
+    of the loss w.r.t. the margin output, ``1 - p``, averaged over the row's
+    label tokens. ``none`` leaves the whitened inner products."""
 
     checkpoints: list[str] = field(default_factory=list)
     """Independently trained model checkpoints to ensemble. Each runs the full

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -613,11 +613,8 @@ class IndexConfig(AttributionConfig, Serializable):
     Note: Untested with the AdamW eps_root in the bergson trainer -
     consider setting this to 0 when using optimizer normalization."""
 
-    loss_fn: Literal["ce", "kl", "margin"] = "ce"
-    """Loss function to use. ``margin`` is the negative log-odds of each label
-    token, ``-(log p - log(1 - p))``, the model output function of TRAK
-    (Park et al., 2023) whose per-token derivative w.r.t. the loss is
-    ``1 - p``."""
+    loss_fn: Literal["ce", "kl", "log_odds"] = "ce"
+    """Loss function to use."""
 
     loss_reduction: Literal["mean", "sum"] = "sum"
     """How the per-token losses of a document are reduced before the backward

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -876,10 +876,14 @@ class ApproxUnrollingConfig(Serializable):
 class HessianConfig(Serializable):
     """Config for reducing the gradients."""
 
-    method: Literal["kfac", "tkfac", "shampoo", "autocorrelation", "gram"]
-    """Method for approximating the Hessian. ``autocorrelation`` fits a dense
-    per-module Gram of the projected gradients; ``gram`` fits one joint Gram over
-    the concatenation of every module's projected gradient (the TRAK kernel)."""
+    method: Literal["kfac", "tkfac", "shampoo", "autocorrelation"]
+    """Method for approximating the Hessian."""
+
+    scope: Literal["per_module", "joint"] = "per_module"
+    """Which gradient the dense ``autocorrelation`` Gram is taken over: each
+    module's projected gradient separately (a block-diagonal Hessian), or the
+    concatenation of every module's projected gradient as one matrix (the TRAK
+    kernel). Ignored by the factored methods."""
 
     ev_correction: bool = False
     """Whether to additionally compute eigenvalue correction."""
@@ -987,10 +991,10 @@ class TrakConfig:
     score_cfg: ScoreConfig = field(default_factory=ScoreConfig)
 
     kernel: Literal["joint", "per_module"] = "joint"
-    """``joint`` (TRAK): one Gram over the concatenation of all modules' projected
-    gradients, inverted as a single matrix. ``per_module``: a block-diagonal
-    approximation with one Gram per module (Bergson's ``autocorrelation``
-    Hessian), cheaper but not TRAK's kernel."""
+    """Scope of the autocorrelation Gram (``HessianConfig.scope``): ``joint``
+    (TRAK) is one Gram over the concatenation of all modules' projected
+    gradients, inverted as a single matrix; ``per_module`` is the block-diagonal
+    approximation with one Gram per module, cheaper but not TRAK's kernel."""
 
     q_weighting: Literal["one_minus_p", "none"] = "one_minus_p"
     """Multiply each training row's scores by ``1 - p_i``, with ``p_i`` the

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -595,7 +595,7 @@ class IndexConfig(AttributionConfig, Serializable):
     an independent right-side matrix and sums into one vector per example."""
 
     projection_seed: int | None = None
-    """Seed of the random projection. ``trak`` gives each ensemble member its own 
+    """Seed of the random projection. ``trak`` gives each ensemble member its own
     seed."""
 
     token_batch_size: int = 2048

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -594,9 +594,9 @@ class IndexConfig(AttributionConfig, Serializable):
     each module gradient. ``global`` projects each module's flattened gradient with
     an independent right-side matrix and sums into one vector per example."""
 
-    projection_seed: int = 0
-    """Seed of the random projection. ``trak`` gives each ensemble member its
-    own seed."""
+    projection_seed: int | None = None
+    """Seed of the random projection. ``trak`` gives each ensemble member its own 
+    seed."""
 
     token_batch_size: int = 2048
     """Batch size in tokens for building the index."""
@@ -998,8 +998,8 @@ class TrakConfig:
 
     checkpoints: list[str] = field(default_factory=list)
     """Independently trained model checkpoints to ensemble; member ``i`` is
-    projected with ``projection_seed + i``. When not set ``index_cfg.model``
-    is used."""
+    projected with seed ``projection_seed + i`` (``i`` when no seed is set).
+    When not set ``index_cfg.model`` is used."""
 
     stats_sample_size: int | None = None
     """Number of training examples to fit the Gram on. ``None`` (default)

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -594,6 +594,10 @@ class IndexConfig(AttributionConfig, Serializable):
     each module gradient. ``global`` projects each module's flattened gradient with
     an independent right-side matrix and sums into one vector per example."""
 
+    projection_seed: int = 0
+    """Seed of the random projection. ``trak`` gives each ensemble member its
+    own seed."""
+
     token_batch_size: int = 2048
     """Batch size in tokens for building the index."""
 
@@ -993,8 +997,9 @@ class TrakConfig:
     score_cfg: ScoreConfig = field(default_factory=ScoreConfig)
 
     checkpoints: list[str] = field(default_factory=list)
-    """Independently trained model checkpoints to ensemble. When not set
-    ``index_cfg.model`` is used."""
+    """Independently trained model checkpoints to ensemble; member ``i`` is
+    projected with ``projection_seed + i``. When not set ``index_cfg.model``
+    is used."""
 
     stats_sample_size: int | None = None
     """Number of training examples to fit the Gram on. ``None`` (default)

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -876,8 +876,10 @@ class ApproxUnrollingConfig(Serializable):
 class HessianConfig(Serializable):
     """Config for reducing the gradients."""
 
-    method: Literal["kfac", "tkfac", "shampoo", "autocorrelation"]
-    """Method for approximating the Hessian."""
+    method: Literal["kfac", "tkfac", "shampoo", "autocorrelation", "gram"]
+    """Method for approximating the Hessian. ``autocorrelation`` fits a dense
+    per-module Gram of the projected gradients; ``gram`` fits one joint Gram over
+    the concatenation of every module's projected gradient (the TRAK kernel)."""
 
     ev_correction: bool = False
     """Whether to additionally compute eigenvalue correction."""
@@ -983,6 +985,12 @@ class TrakConfig:
     (TRAK whitens with the full inverse)."""
 
     score_cfg: ScoreConfig = field(default_factory=ScoreConfig)
+
+    kernel: Literal["joint", "per_module"] = "joint"
+    """``joint`` (TRAK): one Gram over the concatenation of all modules' projected
+    gradients, inverted as a single matrix. ``per_module``: a block-diagonal
+    approximation with one Gram per module (Bergson's ``autocorrelation``
+    Hessian), cheaper but not TRAK's kernel."""
 
     q_weighting: Literal["one_minus_p", "none"] = "one_minus_p"
     """Multiply each training row's scores by ``1 - p_i``, with ``p_i`` the

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -880,10 +880,9 @@ class HessianConfig(Serializable):
     """Method for approximating the Hessian."""
 
     structure: Literal["per_module", "joint"] = "per_module"
-    """Which gradient the dense ``autocorrelation`` Gram is taken over: each
-    module's projected gradient separately (a block-diagonal Hessian), or the
-    concatenation of every module's projected gradient as one matrix (the TRAK
-    kernel). Ignored by the factored methods."""
+    """Whether to produce a block-diagonal matrix of per-module autocorrelation
+    matrices, or the autocorrelation of full model gradients. Ignored by
+    factored methods."""
 
     ev_correction: bool = False
     """Whether to additionally compute eigenvalue correction."""
@@ -976,9 +975,9 @@ class TrackstarConfig:
 
 @dataclass
 class TrakConfig:
-    """Config for the TRAK pipeline (Park et al., 2023): random-projected
-    gradients whitened by the damped inverse of their Gram matrix, weighted by
-    ``1 - p_i`` on the training side, optionally averaged over independently
+    """Config for TRAK pipeline: random-projected
+    gradients preconditioned with an inverse Gram matrix and the negative
+    log-odds loss function. Optionally averaged over independently
     trained checkpoints."""
 
     query: DataConfig = field(default_factory=DataConfig)
@@ -989,27 +988,20 @@ class TrakConfig:
             inversion_cfg=InversionConfig(damping_factor=0.0)
         )
     )
-    """``inversion_cfg`` sets the Gram damping, zero by default as in the paper;
-    ``unit_normalize`` is ignored (TRAK whitens with the full inverse)."""
+    """Note that ``unit_normalize`` is ignored."""
 
     score_cfg: ScoreConfig = field(default_factory=ScoreConfig)
 
-    q_weighting: Literal["one_minus_p", "none"] = "one_minus_p"
-    """Multiply each training row's scores by TRAK's ``Q`` term, the derivative
-    of the loss w.r.t. the margin output, ``1 - p``, averaged over the row's
-    label tokens. ``none`` leaves the whitened inner products."""
-
     checkpoints: list[str] = field(default_factory=list)
-    """Independently trained model checkpoints to ensemble. Each runs the full
-    pipeline under ``<run_path>/checkpoint_<i>``; ``<run_path>/scores`` is the
-    mean of their score stores. Empty: use ``index_cfg.model`` alone."""
+    """Independently trained model checkpoints to ensemble. When not set
+    ``index_cfg.model`` is used."""
 
     stats_sample_size: int | None = None
-    """Number of training examples the Gram is fit on. ``None`` (default)
-    uses the whole training set, as TRAK does."""
+    """Number of training examples to fit the Gram on. ``None`` (default)
+    uses the whole training set."""
 
     loss_batch_size: int = 32
-    """Rows per forward pass when computing ``p_i``."""
+    """Batch size when computing ``p_i``."""
 
     resume: bool = False
     """Skip pipeline steps whose output directory already exists."""

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -879,7 +879,7 @@ class HessianConfig(Serializable):
     method: Literal["kfac", "tkfac", "shampoo", "autocorrelation"]
     """Method for approximating the Hessian."""
 
-    scope: Literal["per_module", "joint"] = "per_module"
+    structure: Literal["per_module", "joint"] = "per_module"
     """Which gradient the dense ``autocorrelation`` Gram is taken over: each
     module's projected gradient separately (a block-diagonal Hessian), or the
     concatenation of every module's projected gradient as one matrix (the TRAK

--- a/bergson/gradients.py
+++ b/bergson/gradients.py
@@ -128,7 +128,7 @@ class GradientProcessor:
     include_bias: bool = False
     """Whether to include bias gradients when present on a module."""
 
-    projection_seed: int = 0
+    projection_seed: int | None = None
     """Seed of the random projection."""
 
     def __post_init__(self):

--- a/bergson/gradients.py
+++ b/bergson/gradients.py
@@ -128,6 +128,9 @@ class GradientProcessor:
     include_bias: bool = False
     """Whether to include bias gradients when present on a module."""
 
+    projection_seed: int = 0
+    """Seed of the random projection."""
+
     def __post_init__(self):
         self._projection_matrices: dict[
             tuple[str, Literal["left", "right", "single"], torch.device], Tensor

--- a/bergson/hessians/autocorrelation.py
+++ b/bergson/hessians/autocorrelation.py
@@ -1,6 +1,5 @@
-import json
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import torch
@@ -65,10 +64,6 @@ class AutocorrelationCollector(HookCollectorBase):
             self.processor.save(Path(self.path))
 
 
-JOINT_LAYOUT_FILE = "joint_layout.json"
-"""Module order and sizes of the concatenated gradient a joint Gram was fit on."""
-
-
 @dataclass(kw_only=True)
 class JointAutocorrelationCollector(AutocorrelationCollector):
     """The ``structure="joint"`` autocorrelation Hessian: one Gram over the
@@ -77,16 +72,13 @@ class JointAutocorrelationCollector(AutocorrelationCollector):
 
     Per-module projected gradients are concatenated in ``shapes()`` order (the
     order the index stores them in) and the ``[D, D]`` Gram accumulates under the
-    key ``"joint"``; ``teardown`` saves it with the processor plus the layout
-    that :class:`JointDensePreconditioner` uses to split gradients back into
-    modules. With ``projection_target="global"`` there is a single key and the
-    joint Gram is just the ``[k, k]`` Gram of the global sketch.
+    key ``"joint"``. With ``projection_target="global"`` there is a single key
+    and the joint Gram is just the ``[k, k]`` Gram of the global sketch.
     """
 
-    _layout: list[tuple[str, int]] = field(default_factory=list, init=False)
-
     def setup(self) -> None:
-        self._layout = [(name, math.prod(s)) for name, s in self.shapes().items()]
+        """A joint Gram is fit over the global sketch too, so skip the
+        per-module check in the base class."""
 
     @HookCollectorBase.split_attention_heads
     def backward_hook(self, module: nn.Module, g: Float[Tensor, "N S O"]):
@@ -99,7 +91,7 @@ class JointAutocorrelationCollector(AutocorrelationCollector):
 
     def process_batch(self, indices: list[int], **kwargs):
         """Concatenate the batch's module gradients and add their Gram."""
-        G = torch.cat([self.mod_grads[name].float() for name, _ in self._layout], dim=1)
+        G = torch.cat([self.mod_grads[name].float() for name in self.shapes()], dim=1)
         if "joint" in self.processor.hessians:
             self.processor.hessians["joint"].addmm_(G.mT, G)
         else:
@@ -107,8 +99,8 @@ class JointAutocorrelationCollector(AutocorrelationCollector):
         self.mod_grads.clear()
 
     def teardown(self):
-        """Reduce/eigendecompose the joint Gram and save it with its layout."""
-        dim = sum(size for _, size in self._layout)
+        """Reduce/eigendecompose the joint Gram and save it."""
+        dim = sum(math.prod(s) for s in self.shapes().values())
         if self.processor.hessians:
             process_autocorrelation_matrices(
                 self.processor,
@@ -119,11 +111,3 @@ class JointAutocorrelationCollector(AutocorrelationCollector):
             )
         if self.rank == 0:
             self.processor.save(Path(self.path))
-            (Path(self.path) / JOINT_LAYOUT_FILE).write_text(
-                json.dumps(
-                    {
-                        "names": [n for n, _ in self._layout],
-                        "sizes": [s for _, s in self._layout],
-                    }
-                )
-            )

--- a/bergson/hessians/autocorrelation.py
+++ b/bergson/hessians/autocorrelation.py
@@ -68,10 +68,6 @@ class AutocorrelationCollector(HookCollectorBase):
 JOINT_LAYOUT_FILE = "joint_layout.json"
 """Module order and sizes of the concatenated gradient a joint Gram was fit on."""
 
-MAX_JOINT_DIM = 20_000
-"""Largest concatenated projected-gradient size the joint Gram accepts; the
-eigendecomposition is dense in fp64."""
-
 
 @dataclass(kw_only=True)
 class JointAutocorrelationCollector(AutocorrelationCollector):
@@ -91,13 +87,6 @@ class JointAutocorrelationCollector(AutocorrelationCollector):
 
     def setup(self) -> None:
         self._layout = [(name, math.prod(s)) for name, s in self.shapes().items()]
-        dim = sum(size for _, size in self._layout)
-        if dim > MAX_JOINT_DIM:
-            raise ValueError(
-                f"The joint Gram would be {dim} x {dim} (sum of projected module "
-                f"sizes); reduce projection_dim so the total is at most "
-                f"{MAX_JOINT_DIM}, or use structure='per_module'."
-            )
 
     @HookCollectorBase.split_attention_heads
     def backward_hook(self, module: nn.Module, g: Float[Tensor, "N S O"]):

--- a/bergson/hessians/autocorrelation.py
+++ b/bergson/hessians/autocorrelation.py
@@ -75,7 +75,7 @@ eigendecomposition is dense in fp64."""
 
 @dataclass(kw_only=True)
 class JointAutocorrelationCollector(AutocorrelationCollector):
-    """The ``scope="joint"`` autocorrelation Hessian: one Gram over the
+    """The ``structure="joint"`` autocorrelation Hessian: one Gram over the
     concatenation of every module's projected gradient — the TRAK kernel
     ``Phi^T Phi`` — instead of a Gram per module.
 
@@ -96,7 +96,7 @@ class JointAutocorrelationCollector(AutocorrelationCollector):
             raise ValueError(
                 f"The joint Gram would be {dim} x {dim} (sum of projected module "
                 f"sizes); reduce projection_dim so the total is at most "
-                f"{MAX_JOINT_DIM}, or use scope='per_module'."
+                f"{MAX_JOINT_DIM}, or use structure='per_module'."
             )
 
     @HookCollectorBase.split_attention_heads

--- a/bergson/hessians/autocorrelation.py
+++ b/bergson/hessians/autocorrelation.py
@@ -74,9 +74,10 @@ eigendecomposition is dense in fp64."""
 
 
 @dataclass(kw_only=True)
-class GramCollector(AutocorrelationCollector):
-    """Fit one joint Gram over the concatenation of every module's projected
-    gradient — the TRAK kernel ``Phi^T Phi`` — instead of a Gram per module.
+class JointAutocorrelationCollector(AutocorrelationCollector):
+    """The ``scope="joint"`` autocorrelation Hessian: one Gram over the
+    concatenation of every module's projected gradient — the TRAK kernel
+    ``Phi^T Phi`` — instead of a Gram per module.
 
     Per-module projected gradients are concatenated in ``shapes()`` order (the
     order the index stores them in) and the ``[D, D]`` Gram accumulates under the
@@ -95,7 +96,7 @@ class GramCollector(AutocorrelationCollector):
             raise ValueError(
                 f"The joint Gram would be {dim} x {dim} (sum of projected module "
                 f"sizes); reduce projection_dim so the total is at most "
-                f"{MAX_JOINT_DIM}, or use hessian method 'autocorrelation'."
+                f"{MAX_JOINT_DIM}, or use scope='per_module'."
             )
 
     @HookCollectorBase.split_attention_heads

--- a/bergson/hessians/autocorrelation.py
+++ b/bergson/hessians/autocorrelation.py
@@ -1,7 +1,9 @@
+import json
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
+import torch
 import torch.nn as nn
 from datasets import Dataset
 from jaxtyping import Float
@@ -61,3 +63,77 @@ class AutocorrelationCollector(HookCollectorBase):
             )
         if self.rank == 0:
             self.processor.save(Path(self.path))
+
+
+JOINT_LAYOUT_FILE = "joint_layout.json"
+"""Module order and sizes of the concatenated gradient a joint Gram was fit on."""
+
+MAX_JOINT_DIM = 20_000
+"""Largest concatenated projected-gradient size the joint Gram accepts; the
+eigendecomposition is dense in fp64."""
+
+
+@dataclass(kw_only=True)
+class GramCollector(AutocorrelationCollector):
+    """Fit one joint Gram over the concatenation of every module's projected
+    gradient — the TRAK kernel ``Phi^T Phi`` — instead of a Gram per module.
+
+    Per-module projected gradients are concatenated in ``shapes()`` order (the
+    order the index stores them in) and the ``[D, D]`` Gram accumulates under the
+    key ``"joint"``; ``teardown`` saves it with the processor plus the layout
+    that :class:`JointDensePreconditioner` uses to split gradients back into
+    modules. With ``projection_target="global"`` there is a single key and the
+    joint Gram is just the ``[k, k]`` Gram of the global sketch.
+    """
+
+    _layout: list[tuple[str, int]] = field(default_factory=list, init=False)
+
+    def setup(self) -> None:
+        self._layout = [(name, math.prod(s)) for name, s in self.shapes().items()]
+        dim = sum(size for _, size in self._layout)
+        if dim > MAX_JOINT_DIM:
+            raise ValueError(
+                f"The joint Gram would be {dim} x {dim} (sum of projected module "
+                f"sizes); reduce projection_dim so the total is at most "
+                f"{MAX_JOINT_DIM}, or use hessian method 'autocorrelation'."
+            )
+
+    @HookCollectorBase.split_attention_heads
+    def backward_hook(self, module: nn.Module, g: Float[Tensor, "N S O"]):
+        """Keep this module's projected per-example gradient until the batch ends."""
+        name: str = module._name  # type: ignore[assignment]
+        P = self._compute_gradient(module, g)
+        if self.accumulate_global_projection(name, P):
+            return
+        self.mod_grads[name] = P.float()
+
+    def process_batch(self, indices: list[int], **kwargs):
+        """Concatenate the batch's module gradients and add their Gram."""
+        G = torch.cat([self.mod_grads[name].float() for name, _ in self._layout], dim=1)
+        if "joint" in self.processor.hessians:
+            self.processor.hessians["joint"].addmm_(G.mT, G)
+        else:
+            self.processor.hessians["joint"] = G.mT @ G
+        self.mod_grads.clear()
+
+    def teardown(self):
+        """Reduce/eigendecompose the joint Gram and save it with its layout."""
+        dim = sum(size for _, size in self._layout)
+        if self.processor.hessians:
+            process_autocorrelation_matrices(
+                self.processor,
+                self.processor.hessians,
+                self.num_rows(self.data),
+                {"joint": dim},
+                self.rank,
+            )
+        if self.rank == 0:
+            self.processor.save(Path(self.path))
+            (Path(self.path) / JOINT_LAYOUT_FILE).write_text(
+                json.dumps(
+                    {
+                        "names": [n for n, _ in self._layout],
+                        "sizes": [s for _, s in self._layout],
+                    }
+                )
+            )

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -161,7 +161,7 @@ def hessian_worker(
         processor = create_processor(model, index_cfg, target_modules)
         collector_cls = (
             JointAutocorrelationCollector
-            if hessian_cfg.scope == "joint"
+            if hessian_cfg.structure == "joint"
             else AutocorrelationCollector
         )
         collector = collector_cls(

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -15,7 +15,7 @@ from bergson.config.config import AttentionConfig, HessianConfig, IndexConfig
 from bergson.data import allocate_batches
 from bergson.distributed import init_dist, launch_distributed_run
 from bergson.gradients import GradientProcessor
-from bergson.hessians.autocorrelation import AutocorrelationCollector
+from bergson.hessians.autocorrelation import AutocorrelationCollector, GramCollector
 from bergson.hessians.eigenvectors import (
     LambdaCollector,
     compute_eigendecomposition,
@@ -79,7 +79,10 @@ def approximate_hessians(
             "Set projection_dim=0."
         )
 
-    if hessian_cfg.method == "autocorrelation" and index_cfg.projection_dim == 0:
+    if (
+        hessian_cfg.method in ("autocorrelation", "gram")
+        and index_cfg.projection_dim == 0
+    ):
         warnings.warn(
             "Computing an autocorrelation (dense) Hessian with "
             "index_cfg.projection_dim=0 (uncompressed gradients); this scales "
@@ -154,9 +157,12 @@ def hessian_worker(
 
     # The autocorrelation Hessian is a dense per-module gradient Gram so
     # it computes in one pass and skips the factored eigendecomposition
-    if hessian_cfg.method == "autocorrelation":
+    if hessian_cfg.method in ("autocorrelation", "gram"):
         processor = create_processor(model, index_cfg, target_modules)
-        collector = AutocorrelationCollector(
+        collector_cls = (
+            GramCollector if hessian_cfg.method == "gram" else AutocorrelationCollector
+        )
+        collector = collector_cls(
             model=model.base_model,  # type: ignore
             data=ds,
             path=str(index_cfg.partial_run_path),
@@ -172,7 +178,9 @@ def hessian_worker(
             batches=batches,
             cfg=index_cfg,
         )
-        computer.run_with_collector_hooks(desc="Approximating autocorrelation Hessian")
+        computer.run_with_collector_hooks(
+            desc=f"Approximating {hessian_cfg.method} Hessian"
+        )
         return
 
     kwargs = {

--- a/bergson/hessians/hessian_approximations.py
+++ b/bergson/hessians/hessian_approximations.py
@@ -15,7 +15,10 @@ from bergson.config.config import AttentionConfig, HessianConfig, IndexConfig
 from bergson.data import allocate_batches
 from bergson.distributed import init_dist, launch_distributed_run
 from bergson.gradients import GradientProcessor
-from bergson.hessians.autocorrelation import AutocorrelationCollector, GramCollector
+from bergson.hessians.autocorrelation import (
+    AutocorrelationCollector,
+    JointAutocorrelationCollector,
+)
 from bergson.hessians.eigenvectors import (
     LambdaCollector,
     compute_eigendecomposition,
@@ -79,10 +82,7 @@ def approximate_hessians(
             "Set projection_dim=0."
         )
 
-    if (
-        hessian_cfg.method in ("autocorrelation", "gram")
-        and index_cfg.projection_dim == 0
-    ):
+    if hessian_cfg.method == "autocorrelation" and index_cfg.projection_dim == 0:
         warnings.warn(
             "Computing an autocorrelation (dense) Hessian with "
             "index_cfg.projection_dim=0 (uncompressed gradients); this scales "
@@ -157,10 +157,12 @@ def hessian_worker(
 
     # The autocorrelation Hessian is a dense per-module gradient Gram so
     # it computes in one pass and skips the factored eigendecomposition
-    if hessian_cfg.method in ("autocorrelation", "gram"):
+    if hessian_cfg.method == "autocorrelation":
         processor = create_processor(model, index_cfg, target_modules)
         collector_cls = (
-            GramCollector if hessian_cfg.method == "gram" else AutocorrelationCollector
+            JointAutocorrelationCollector
+            if hessian_cfg.scope == "joint"
+            else AutocorrelationCollector
         )
         collector = collector_cls(
             model=model.base_model,  # type: ignore

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -40,7 +40,7 @@ from bergson.hessians.sharded_computation import ShardedMul
 from bergson.utils.logger import get_logger
 
 JOINT_LAYOUT_FILE = "joint_layout.json"
-"""Written next to a joint Gram by ``GramCollector``; its presence selects
+"""Written next to a joint Gram by ``JointAutocorrelationCollector``; its presence selects
 :class:`JointDensePreconditioner`."""
 
 
@@ -99,7 +99,8 @@ class DensePreconditioner:
 
 class JointDensePreconditioner:
     """One dense ``H^p`` over the concatenation of every module's gradient, in
-    the module order a :class:`~bergson.hessians.autocorrelation.GramCollector`
+    the module order a
+    :class:`~bergson.hessians.autocorrelation.JointAutocorrelationCollector`
     fit it on (the TRAK kernel)."""
 
     def __init__(self, h_inv: Tensor, names: list[str], sizes: list[int]):

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -22,6 +22,7 @@ provides the rotations and in-place scaling for both. The eigenvalue math lives
 in :mod:`bergson.hessians.inversion`.
 """
 
+import json
 import os
 from glob import glob
 from pathlib import Path
@@ -37,6 +38,10 @@ from bergson.gradients import GradientProcessor
 from bergson.hessians.inversion import eigenvalue_multiplier, invert_psd_matrix
 from bergson.hessians.sharded_computation import ShardedMul
 from bergson.utils.logger import get_logger
+
+JOINT_LAYOUT_FILE = "joint_layout.json"
+"""Written next to a joint Gram by ``GramCollector``; its presence selects
+:class:`JointDensePreconditioner`."""
 
 
 @runtime_checkable
@@ -90,6 +95,57 @@ class DensePreconditioner:
             )
             for name, g in grads.items()
         }
+
+
+class JointDensePreconditioner:
+    """One dense ``H^p`` over the concatenation of every module's gradient, in
+    the module order a :class:`~bergson.hessians.autocorrelation.GramCollector`
+    fit it on (the TRAK kernel)."""
+
+    def __init__(self, h_inv: Tensor, names: list[str], sizes: list[int]):
+        self.h_inv = h_inv
+        self.names = names
+        self.sizes = sizes
+
+    @classmethod
+    def from_processor(
+        cls,
+        processor: GradientProcessor,
+        layout: dict,
+        *,
+        inversion_cfg: InversionConfig | None = None,
+        power: float = -1.0,
+        device: str | torch.device = "cpu",
+    ) -> "JointDensePreconditioner":
+        inversion_cfg = inversion_cfg or InversionConfig()
+        h_inv = invert_psd_matrix(
+            processor.hessians["joint"].to(device=device, dtype=torch.float32),
+            inversion=inversion_cfg.inversion,
+            damping_factor=inversion_cfg.damping_factor,
+            power=power,
+        )
+        return cls(h_inv, list(layout["names"]), [int(x) for x in layout["sizes"]])
+
+    def apply(self, grads: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Concatenate ``grads`` in layout order, multiply by ``H^p`` and split."""
+        missing = [n for n in self.names if n not in grads]
+        if missing:
+            raise KeyError(f"joint Hessian expects modules {missing} in the gradients")
+        device = next(iter(grads.values())).device
+        joined = torch.cat(
+            [
+                grads[n].to(device=self.h_inv.device, dtype=self.h_inv.dtype)
+                for n in self.names
+            ],
+            dim=1,
+        )
+        out = (joined @ self.h_inv).to(device)
+        result = dict(grads)
+        offset = 0
+        for name, size in zip(self.names, self.sizes):
+            result[name] = out[:, offset : offset + size].to(grads[name].dtype)
+            offset += size
+        return result
 
 
 class FactoredPreconditioner:
@@ -490,6 +546,15 @@ def load_preconditioner(
     # Dense: load the saved processor on CPU; from_processor moves each Gram to
     # device as it inverts it, so only one dense matrix is on the device at a time.
     processor = GradientProcessor.load(Path(hessian_path), map_location="cpu")
+    layout_file = Path(hessian_path) / JOINT_LAYOUT_FILE
+    if layout_file.exists():
+        return JointDensePreconditioner.from_processor(
+            processor,
+            json.loads(layout_file.read_text()),
+            inversion_cfg=inversion_cfg,
+            power=power,
+            device=device,
+        )
     return DensePreconditioner.from_processor(
         processor, inversion_cfg=inversion_cfg, power=power, device=device
     )

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -1,6 +1,6 @@
 """Preconditioners: apply a :class:`Preconditioner` (sometimes interpreted as an
-inverse Hessian) to gradients. This class exposes one method, 
-``apply(grads) -> grads``, mapping a ``{module: [n, d]}`` gradient dict to its 
+inverse Hessian) to gradients. This class exposes one method,
+``apply(grads) -> grads``, mapping a ``{module: [n, d]}`` gradient dict to its
 preconditioned counterpart. There are two implementations:
 
 - :class:`DensePreconditioner` — the autocorrelation Gram, a dense per-module
@@ -13,8 +13,8 @@ preconditioned counterpart. There are two implementations:
 
 :func:`load_preconditioner` builds either from a path.
 
-The factored ``apply`` can be distributed over ranks, see 
-:class:`~bergson.hessians.sharded_computation.ShardedMul`. 
+The factored ``apply`` can be distributed over ranks, see
+:class:`~bergson.hessians.sharded_computation.ShardedMul`.
 The eigenvalue math lives in :mod:`bergson.hessians.inversion`.
 """
 

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -40,8 +40,8 @@ from bergson.hessians.sharded_computation import ShardedMul
 from bergson.utils.logger import get_logger
 
 JOINT_LAYOUT_FILE = "joint_layout.json"
-"""Written next to a joint Gram by ``JointAutocorrelationCollector``; its presence selects
-:class:`JointDensePreconditioner`."""
+"""Written next to a joint Gram by ``JointAutocorrelationCollector``; its
+presence selects :class:`JointDensePreconditioner`."""
 
 
 @runtime_checkable

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -18,7 +18,6 @@ The factored ``apply`` can be distributed over ranks, see
 The eigenvalue math lives in :mod:`bergson.hessians.inversion`.
 """
 
-import json
 import os
 from glob import glob
 from pathlib import Path
@@ -31,7 +30,6 @@ from torch import Tensor
 
 from bergson.config import InversionConfig
 from bergson.gradients import GradientProcessor
-from bergson.hessians.autocorrelation import JOINT_LAYOUT_FILE
 from bergson.hessians.inversion import eigenvalue_multiplier, invert_psd_matrix
 from bergson.hessians.sharded_computation import ShardedMul
 from bergson.utils.logger import get_logger
@@ -91,21 +89,19 @@ class DensePreconditioner:
 
 
 class JointDensePreconditioner:
-    """One dense ``H^p`` over the concatenation of every module's gradient, in
-    the module order a
-    :class:`~bergson.hessians.autocorrelation.JointAutocorrelationCollector`
-    fit it on (the TRAK kernel)."""
+    """One dense ``H^p`` over the concatenation of every module's gradient (the
+    TRAK kernel), fit by a
+    :class:`~bergson.hessians.autocorrelation.JointAutocorrelationCollector`.
+    ``apply`` concatenates the gradients in the order the collector emits
+    them, which is the order the Gram was fit in."""
 
-    def __init__(self, h_inv: Tensor, names: list[str], sizes: list[int]):
+    def __init__(self, h_inv: Tensor):
         self.h_inv = h_inv
-        self.names = names
-        self.sizes = sizes
 
     @classmethod
     def from_processor(
         cls,
         processor: GradientProcessor,
-        layout: dict,
         *,
         inversion_cfg: InversionConfig | None = None,
         power: float = -1.0,
@@ -118,26 +114,29 @@ class JointDensePreconditioner:
             damping_factor=inversion_cfg.damping_factor,
             power=power,
         )
-        return cls(h_inv, list(layout["names"]), [int(x) for x in layout["sizes"]])
+        return cls(h_inv)
 
     def apply(self, grads: dict[str, Tensor]) -> dict[str, Tensor]:
-        """Concatenate ``grads`` in layout order, multiply by ``H^p`` and split."""
-        missing = [n for n in self.names if n not in grads]
-        if missing:
-            raise KeyError(f"joint Hessian expects modules {missing} in the gradients")
+        """Concatenate ``grads``, multiply by ``H^p`` and split them back."""
+        sizes = [g.shape[1] for g in grads.values()]
+        if sum(sizes) != self.h_inv.shape[0]:
+            raise ValueError(
+                f"joint Hessian of dim {self.h_inv.shape[0]} does not match "
+                f"gradients of total dim {sum(sizes)}"
+            )
         device = next(iter(grads.values())).device
         joined = torch.cat(
             [
-                grads[n].to(device=self.h_inv.device, dtype=self.h_inv.dtype)
-                for n in self.names
+                g.to(device=self.h_inv.device, dtype=self.h_inv.dtype)
+                for g in grads.values()
             ],
             dim=1,
         )
         out = (joined @ self.h_inv).to(device)
-        result = dict(grads)
+        result = {}
         offset = 0
-        for name, size in zip(self.names, self.sizes):
-            result[name] = out[:, offset : offset + size].to(grads[name].dtype)
+        for (name, g), size in zip(grads.items(), sizes):
+            result[name] = out[:, offset : offset + size].to(g.dtype)
             offset += size
         return result
 
@@ -540,11 +539,9 @@ def load_preconditioner(
     # Dense: load the saved processor on CPU; from_processor moves each Gram to
     # device as it inverts it, so only one dense matrix is on the device at a time.
     processor = GradientProcessor.load(Path(hessian_path), map_location="cpu")
-    layout_file = Path(hessian_path) / JOINT_LAYOUT_FILE
-    if layout_file.exists():
+    if "joint" in processor.hessians:
         return JointDensePreconditioner.from_processor(
             processor,
-            json.loads(layout_file.read_text()),
             inversion_cfg=inversion_cfg,
             power=power,
             device=device,

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -1,9 +1,7 @@
-"""Preconditioners: apply a preconditioner (sometimes interpreted as an
-inverse Hessian) to a set of gradients.
-
-A :class:`Preconditioner` exposes one method, ``apply(grads) -> grads``, mapping a
-``{module: [n, d]}`` gradient dict to its preconditioned counterpart. This class
-has two implementations:
+"""Preconditioners: apply a :class:`Preconditioner` (sometimes interpreted as an
+inverse Hessian) to gradients. This class exposes one method, 
+``apply(grads) -> grads``, mapping a ``{module: [n, d]}`` gradient dict to its 
+preconditioned counterpart. There are two implementations:
 
 - :class:`DensePreconditioner` — the autocorrelation Gram, a dense per-module
   ``[d, d]`` matrix; ``apply`` is a matmul ``g @ H^p``.
@@ -13,13 +11,11 @@ has two implementations:
   each gradient into the eigenbasis, scales by the inverse eigenvalue function,
   and rotates back, never materializing the dense ``[O·I, O·I]`` Hessian.
 
-:func:`load_preconditioner` builds one from a path, auto-detecting which
-representation lives there.
+:func:`load_preconditioner` builds either from a path.
 
-The factored ``apply`` runs both in a single process (full factors) and
-distributed (per-rank shards): :class:`~bergson.hessians.sharded_computation.ShardedMul`
-provides the rotations and in-place scaling for both. The eigenvalue math lives
-in :mod:`bergson.hessians.inversion`.
+The factored ``apply`` can be distributed over ranks, see 
+:class:`~bergson.hessians.sharded_computation.ShardedMul`. 
+The eigenvalue math lives in :mod:`bergson.hessians.inversion`.
 """
 
 import json

--- a/bergson/hessians/preconditioner.py
+++ b/bergson/hessians/preconditioner.py
@@ -31,13 +31,10 @@ from torch import Tensor
 
 from bergson.config import InversionConfig
 from bergson.gradients import GradientProcessor
+from bergson.hessians.autocorrelation import JOINT_LAYOUT_FILE
 from bergson.hessians.inversion import eigenvalue_multiplier, invert_psd_matrix
 from bergson.hessians.sharded_computation import ShardedMul
 from bergson.utils.logger import get_logger
-
-JOINT_LAYOUT_FILE = "joint_layout.json"
-"""Written next to a joint Gram by ``JointAutocorrelationCollector``; its
-presence selects :class:`JointDensePreconditioner`."""
 
 
 @runtime_checkable

--- a/bergson/utils/worker_utils.py
+++ b/bergson/utils/worker_utils.py
@@ -87,6 +87,7 @@ def create_processor(
         projection_scale=cfg.projection_scale,
         projection_target=cfg.projection_target,
         include_bias=cfg.include_bias,
+        projection_seed=cfg.projection_seed,
     )
     if rank == 0:
         processor.save(cfg.partial_run_path)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ Load the gradients:
 
    influence-functions
    trackstar
+   trak
    source
    magic
 

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -27,8 +27,7 @@ What It Produces
 A directory at ``run_path`` with the following subdirectories:
 
 - ``train_hessian/`` — the projected-gradient Gram fit on the training set
-  (``hessians.pth``, ``hessians_eigen.pth``, ``normalizers.pth``,
-  ``joint_layout.json``).
+  (``hessians.pth``, ``hessians_eigen.pth``, ``normalizers.pth``).
 - ``query/`` — the Gram-whitened query gradient index (same artifacts as ``build``).
 - ``scores/`` — scores for the training set (same artifacts as ``score``), with
   ``trak_weights.npy`` holding the ``1 - p_i`` weights and ``trak_scale.npy`` the

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -13,19 +13,18 @@ example ``z_i`` is scored for a query ``z_q`` as
 where :math:`\phi` is the projected per-example gradient, :math:`\Phi` stacks the
 projected training gradients and :math:`p_i` is the model's probability of the
 training example's labels (the geometric-mean token probability for a language
-model). :math:`\phi` is Bergson's per-module double-sided random projection,
-concatenated over modules; the Gram :math:`\Phi^\top \Phi` is fit over that
-concatenation as one matrix (the ``autocorrelation`` Hessian with
-``scope: joint``, the default ``kernel: joint``) and its damped inverse is
-applied to the query gradients. The
-damping :math:`\lambda` is ``preprocess_cfg.inversion_cfg.damping_factor`` times
-the mean eigenvalue. ``kernel: per_module`` instead uses the per-module Gram (``scope: per_module``),
-a block-diagonal approximation of the same kernel.
-``projection_target: global`` gives TRAK's single global sketch when its
-per-module ``k x d`` projection matrices fit in memory. The concatenated sketch
-must have at most 20,000 dimensions (for GPT-2's 48 modules, ``projection_dim``
-16 gives 12,288). Passing several independently trained checkpoints
-averages their score stores, as in the paper's ensembles.
+model). :math:`\phi` is one random projection of the whole gradient: the
+index must be built with ``projection_target: global``, which projects each
+module's flattened gradient with its own block of a single ``k x d``
+Rademacher matrix and sums the blocks, so ``projection_dim`` is the size of the
+sketch. ``bergson trak`` refuses other projection targets. The Gram
+:math:`\Phi^\top \Phi` is fit over that sketch (the ``autocorrelation``
+Hessian with ``scope: joint``) and its damped inverse is applied to the query
+gradients; the damping :math:`\lambda` is
+``preprocess_cfg.inversion_cfg.damping_factor`` times the mean eigenvalue. The
+``k x d`` projection matrices are held in memory, which bounds ``k`` for large
+models. Passing several independently trained checkpoints averages their
+score stores, as in the paper's ensembles.
 
 What It Produces
 ----------------
@@ -33,8 +32,8 @@ What It Produces
 A directory at ``run_path`` with the following subdirectories:
 
 - ``train_hessian/`` — the projected-gradient Gram fit on the training set
-  (``hessians.pth``, ``hessians_eigen.pth``, ``normalizers.pth``; with the joint
-  kernel also ``joint_layout.json``, the module order of the concatenation).
+  (``hessians.pth``, ``hessians_eigen.pth``, ``normalizers.pth``,
+  ``joint_layout.json``).
 - ``query/`` — the Gram-whitened query gradient index (same artifacts as ``build``).
 - ``scores/`` — scores for the training set (same artifacts as ``score``), with
   ``trak_weights.npy`` holding the ``1 - p_i`` weights that were applied.
@@ -46,10 +45,10 @@ Key Options
 
 - ``--data.dataset``: the training dataset.
 - ``--query.dataset``: the query dataset.
-- ``--projection_dim``: projected gradient size per module (default 16).
+- ``--projection_dim``: size of the global gradient sketch.
+- ``--projection_target``: must be ``global``.
 - ``--trak_cfg.preprocess_cfg.inversion_cfg.damping_factor``: Gram damping
   relative to the mean eigenvalue (default 0.1).
-- ``--trak_cfg.kernel``: ``joint`` (default, TRAK) or ``per_module`` (block-diagonal).
 - ``--trak_cfg.q_weighting``: ``one_minus_p`` (default) or ``none``.
 - ``--trak_cfg.checkpoints``: model checkpoints to ensemble.
 
@@ -65,7 +64,8 @@ Example
        --query.dataset NeelNanda/pile-10k \
        --query.truncation \
        --query.split "train[:20]" \
-       --projection_dim 16
+       --projection_target global \
+       --projection_dim 512
 
 Scores are influence-signed (``higher_is_better``): a positive score marks a
 proponent of the query. See :doc:`cli` for the full ``TrakConfig`` API reference.

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -18,6 +18,8 @@ The Gram :math:`\Phi^\top \Phi` inverse is applied to the query gradients, for c
 and is undamped by default. Pass several independently trained checkpoints to enable ensembling (score
 averaging).
 
+TRAK does not support per-token attribution.
+
 What It Produces
 ----------------
 
@@ -39,10 +41,9 @@ Key Options
 - ``--query.dataset``: the query dataset.
 - ``--projection_dim``: size of the global gradient sketch.
 - ``--projection_target``: must be ``global``.
-- ``--loss_fn``: must be ``margin``.
+- ``--loss_fn``: must be ``log_odds``.
 - ``--trak_cfg.preprocess_cfg.inversion_cfg.damping_factor``: Gram damping
   relative to the mean eigenvalue (default 0, the paper's plain inverse).
-- ``--trak_cfg.q_weighting``: ``one_minus_p`` (default) or ``none``.
 - ``--trak_cfg.checkpoints``: model checkpoints to ensemble.
 
 Example

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -10,12 +10,12 @@ A training example ``z_i`` is scored for a query ``z_q`` as
 
    \phi(z_q)^\top (\Phi^\top \Phi)^{-1} \phi(z_i) \,(1 - p_i)
 
-where :math:`\phi` is the projected per-example gradient of the output function :math:`\log p - \log(1 - p)` 
-summed over the example's label tokens, :math:`\Phi` is the matrix of projected training gradients, one row 
-per example, and :math:`1 - p_i` is the mean derivative of the loss w.r.t. the output function. 
+where :math:`\phi` is the projected per-example gradient of the output function :math:`\log p - \log(1 - p)`
+summed over the example's label tokens, :math:`\Phi` is the matrix of projected training gradients, one row
+per example, and :math:`1 - p_i` is the mean derivative of the loss w.r.t. the output function.
 
 The Gram :math:`\Phi^\top \Phi` inverse is applied to the query gradients, for computational efficiency,
-and is undamped by default. Pass several independently trained checkpoints to enable ensembling (score 
+and is undamped by default. Pass several independently trained checkpoints to enable ensembling (score
 averaging).
 
 What It Produces
@@ -61,5 +61,5 @@ Example
        --projection_dim 512 \
        --loss_fn margin
 
-Scores are ``higher_is_better``, so a positive score indicates a query proponent. 
+Scores are ``higher_is_better``, so a positive score indicates a query proponent.
 See :doc:`cli` for the full ``TrakConfig`` API reference.

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -1,0 +1,61 @@
+TRAK
+====
+
+``trak`` is a high-level pipeline implementing
+`TRAK: Attributing Model Behavior at Scale <https://arxiv.org/abs/2303.14186>`_
+(Park et al., 2023) on Bergson's random-projected gradient index. A training
+example ``z_i`` is scored for a query ``z_q`` as
+
+.. math::
+
+   \phi(z_q)^\top (\Phi^\top \Phi + \lambda I)^{-1} \phi(z_i) \,(1 - p_i)
+
+where :math:`\phi` is the projected per-example gradient, :math:`\Phi` stacks the
+projected training gradients and :math:`p_i` is the model's probability of the
+training example's labels (the geometric-mean token probability for a language
+model). The Gram :math:`\Phi^\top \Phi` is Bergson's ``autocorrelation`` Hessian,
+fit per module, and its damped inverse is applied by the dense preconditioner;
+the damping :math:`\lambda` is ``preprocess_cfg.inversion_cfg.damping_factor``
+times the mean eigenvalue. Passing several independently trained checkpoints
+averages their score stores, as in the paper's ensembles.
+
+What It Produces
+----------------
+
+A directory at ``run_path`` with the following subdirectories:
+
+- ``train_hessian/`` — the projected-gradient Gram fit on the training set
+  (``hessians.pth``, ``hessians_eigen.pth``, ``normalizers.pth``).
+- ``query/`` — the Gram-whitened query gradient index (same artifacts as ``build``).
+- ``scores/`` — scores for the training set (same artifacts as ``score``), with
+  ``trak_weights.npy`` holding the ``1 - p_i`` weights that were applied.
+- ``checkpoint_<i>/`` — the same layout per ensemble member when
+  ``checkpoints`` is set; ``scores/`` is then their mean.
+
+Key Options
+-----------
+
+- ``--data.dataset``: the training dataset.
+- ``--query.dataset``: the query dataset.
+- ``--projection_dim``: projected gradient size per module (default 16).
+- ``--trak_cfg.preprocess_cfg.inversion_cfg.damping_factor``: Gram damping
+  relative to the mean eigenvalue (default 0.1).
+- ``--trak_cfg.q_weighting``: ``one_minus_p`` (default) or ``none``.
+- ``--trak_cfg.checkpoints``: model checkpoints to ensemble.
+
+Example
+-------
+
+.. code-block:: bash
+
+   bergson trak runs/my-trak \
+       --model EleutherAI/pythia-14m \
+       --data.dataset NeelNanda/pile-10k \
+       --data.truncation \
+       --query.dataset NeelNanda/pile-10k \
+       --query.truncation \
+       --query.split "train[:20]" \
+       --projection_dim 32
+
+Scores are influence-signed (``higher_is_better``): a positive score marks a
+proponent of the query. See :doc:`cli` for the full ``TrakConfig`` API reference.

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -68,7 +68,8 @@ Example
        --query.truncation \
        --query.split "train[:20]" \
        --projection_target global \
-       --projection_dim 512
+       --projection_dim 512 \
+       --loss_fn margin
 
 Scores are influence-signed (``higher_is_better``): a positive score marks a
 proponent of the query. See :doc:`cli` for the full ``TrakConfig`` API reference.

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -12,11 +12,12 @@ A training example ``z_i`` is scored for a query ``z_q`` as
 
 where :math:`\phi` is the projected per-example gradient of the output function :math:`\log p - \log(1 - p)`
 summed over the example's label tokens, :math:`\Phi` is the matrix of projected training gradients, one row
-per example, and :math:`1 - p_i` is the mean derivative of the loss w.r.t. the output function.
+per example, and :math:`p_i` is the mean probability of the example's label tokens. This is the language
+modeling form of TRAK from `DsDm <https://arxiv.org/abs/2401.12926>`_ (`reference implementation <https://github.com/MadryLab/trak>`).
 
 The Gram :math:`\Phi^\top \Phi` inverse is applied to the query gradients, for computational efficiency,
-and is undamped by default. Pass several independently trained checkpoints to enable ensembling (score
-averaging).
+and is undamped by default. Pass several independently trained checkpoints to enable ensembling. Each
+checkpoint is projected with a different random seed.
 
 TRAK does not support per-token attribution.
 
@@ -30,9 +31,10 @@ A directory at ``run_path`` with the following subdirectories:
   ``joint_layout.json``).
 - ``query/`` — the Gram-whitened query gradient index (same artifacts as ``build``).
 - ``scores/`` — scores for the training set (same artifacts as ``score``), with
-  ``trak_weights.npy`` holding the ``1 - p_i`` weights that were applied.
+  ``trak_weights.npy`` holding the ``1 - p_i`` weights and ``trak_scale.npy`` the
+  mean absolute entry of the inverse Gram, for ensembling.
 - ``checkpoint_<i>/`` — the same layout per ensemble member when
-  ``checkpoints`` is set; ``scores/`` is then their mean.
+  ``checkpoints`` is set. ``scores/`` is their ensemble.
 
 Key Options
 -----------
@@ -60,7 +62,7 @@ Example
        --query.split "train[:20]" \
        --projection_target global \
        --projection_dim 512 \
-       --loss_fn margin
+       --loss_fn log_odds
 
 Scores are ``higher_is_better``, so a positive score indicates a query proponent.
 See :doc:`cli` for the full ``TrakConfig`` API reference.

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -1,32 +1,22 @@
 TRAK
 ====
 
-``trak`` is a high-level pipeline implementing
-`TRAK: Attributing Model Behavior at Scale <https://arxiv.org/abs/2303.14186>`_
-(Park et al., 2023) on Bergson's random-projected gradient index. A training
-example ``z_i`` is scored for a query ``z_q`` as
+``trak`` implements `TRAK: Attributing Model Behavior at Scale <https://arxiv.org/abs/2303.14186>`_
+(2023), a method which randomly projects whole-model gradients from ``model_dim`` to ``projection_dim``.
+
+A training example ``z_i`` is scored for a query ``z_q`` as
 
 .. math::
 
    \phi(z_q)^\top (\Phi^\top \Phi)^{-1} \phi(z_i) \,(1 - p_i)
 
-where :math:`\phi` is the projected per-example gradient of the margin output
-function :math:`\log p - \log(1 - p)` summed over the example's label tokens
-(``loss_fn: margin``, which ``bergson trak`` requires), :math:`\Phi` stacks the
-projected training gradients and :math:`1 - p_i` is the derivative of the loss
-w.r.t. the margin, averaged over the training example's label tokens.
-:math:`\phi` is one random projection of the whole gradient: the index must be
-built with ``projection_target: global``, which projects each module's
-flattened gradient with its own block of a single ``k x d`` Rademacher matrix
-and sums the blocks, so ``projection_dim`` is the size of the sketch; the
-blocks are generated on the fly, so ``k`` is bounded by the ``k x k`` Gram
-rather than by GPU memory. ``bergson trak`` refuses other projection targets.
-The Gram :math:`\Phi^\top \Phi` is fit over that sketch on the training
-examples' own labels (the ``autocorrelation`` Hessian with ``scope: joint``)
-and its inverse is applied to the query gradients, undamped by default;
-``preprocess_cfg.inversion_cfg.damping_factor`` adds a multiple of the mean
-eigenvalue. Passing several independently trained checkpoints averages their
-score stores, as in the paper's ensembles.
+where :math:`\phi` is the projected per-example gradient of the output function :math:`\log p - \log(1 - p)` 
+summed over the example's label tokens, :math:`\Phi` is the matrix of projected training gradients, one row 
+per example, and :math:`1 - p_i` is the mean derivative of the loss w.r.t. the output function. 
+
+The Gram :math:`\Phi^\top \Phi` inverse is applied to the query gradients, for computational efficiency,
+and is undamped by default. Pass several independently trained checkpoints to enable ensembling (score 
+averaging).
 
 What It Produces
 ----------------
@@ -71,5 +61,5 @@ Example
        --projection_dim 512 \
        --loss_fn margin
 
-Scores are influence-signed (``higher_is_better``): a positive score marks a
-proponent of the query. See :doc:`cli` for the full ``TrakConfig`` API reference.
+Scores are ``higher_is_better``, so a positive score indicates a query proponent. 
+See :doc:`cli` for the full ``TrakConfig`` API reference.

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -15,11 +15,12 @@ projected training gradients and :math:`p_i` is the model's probability of the
 training example's labels (the geometric-mean token probability for a language
 model). :math:`\phi` is Bergson's per-module double-sided random projection,
 concatenated over modules; the Gram :math:`\Phi^\top \Phi` is fit over that
-concatenation as one matrix (Hessian method ``gram``, the default
-``kernel: joint``) and its damped inverse is applied to the query gradients. The
+concatenation as one matrix (the ``autocorrelation`` Hessian with
+``scope: joint``, the default ``kernel: joint``) and its damped inverse is
+applied to the query gradients. The
 damping :math:`\lambda` is ``preprocess_cfg.inversion_cfg.damping_factor`` times
-the mean eigenvalue. ``kernel: per_module`` instead uses Bergson's per-module
-``autocorrelation`` Hessian, a block-diagonal approximation of the same kernel.
+the mean eigenvalue. ``kernel: per_module`` instead uses the per-module Gram (``scope: per_module``),
+a block-diagonal approximation of the same kernel.
 ``projection_target: global`` gives TRAK's single global sketch when its
 per-module ``k x d`` projection matrices fit in memory. The concatenated sketch
 must have at most 20,000 dimensions (for GPT-2's 48 modules, ``projection_dim``

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -13,10 +13,17 @@ example ``z_i`` is scored for a query ``z_q`` as
 where :math:`\phi` is the projected per-example gradient, :math:`\Phi` stacks the
 projected training gradients and :math:`p_i` is the model's probability of the
 training example's labels (the geometric-mean token probability for a language
-model). The Gram :math:`\Phi^\top \Phi` is Bergson's ``autocorrelation`` Hessian,
-fit per module, and its damped inverse is applied by the dense preconditioner;
-the damping :math:`\lambda` is ``preprocess_cfg.inversion_cfg.damping_factor``
-times the mean eigenvalue. Passing several independently trained checkpoints
+model). :math:`\phi` is Bergson's per-module double-sided random projection,
+concatenated over modules; the Gram :math:`\Phi^\top \Phi` is fit over that
+concatenation as one matrix (Hessian method ``gram``, the default
+``kernel: joint``) and its damped inverse is applied to the query gradients. The
+damping :math:`\lambda` is ``preprocess_cfg.inversion_cfg.damping_factor`` times
+the mean eigenvalue. ``kernel: per_module`` instead uses Bergson's per-module
+``autocorrelation`` Hessian, a block-diagonal approximation of the same kernel.
+``projection_target: global`` gives TRAK's single global sketch when its
+per-module ``k x d`` projection matrices fit in memory. The concatenated sketch
+must have at most 20,000 dimensions (for GPT-2's 48 modules, ``projection_dim``
+16 gives 12,288). Passing several independently trained checkpoints
 averages their score stores, as in the paper's ensembles.
 
 What It Produces
@@ -25,7 +32,8 @@ What It Produces
 A directory at ``run_path`` with the following subdirectories:
 
 - ``train_hessian/`` — the projected-gradient Gram fit on the training set
-  (``hessians.pth``, ``hessians_eigen.pth``, ``normalizers.pth``).
+  (``hessians.pth``, ``hessians_eigen.pth``, ``normalizers.pth``; with the joint
+  kernel also ``joint_layout.json``, the module order of the concatenation).
 - ``query/`` — the Gram-whitened query gradient index (same artifacts as ``build``).
 - ``scores/`` — scores for the training set (same artifacts as ``score``), with
   ``trak_weights.npy`` holding the ``1 - p_i`` weights that were applied.
@@ -40,6 +48,7 @@ Key Options
 - ``--projection_dim``: projected gradient size per module (default 16).
 - ``--trak_cfg.preprocess_cfg.inversion_cfg.damping_factor``: Gram damping
   relative to the mean eigenvalue (default 0.1).
+- ``--trak_cfg.kernel``: ``joint`` (default, TRAK) or ``per_module`` (block-diagonal).
 - ``--trak_cfg.q_weighting``: ``one_minus_p`` (default) or ``none``.
 - ``--trak_cfg.checkpoints``: model checkpoints to ensemble.
 
@@ -55,7 +64,7 @@ Example
        --query.dataset NeelNanda/pile-10k \
        --query.truncation \
        --query.split "train[:20]" \
-       --projection_dim 32
+       --projection_dim 16
 
 Scores are influence-signed (``higher_is_better``): a positive score marks a
 proponent of the query. See :doc:`cli` for the full ``TrakConfig`` API reference.

--- a/docs/trak.rst
+++ b/docs/trak.rst
@@ -8,22 +8,24 @@ example ``z_i`` is scored for a query ``z_q`` as
 
 .. math::
 
-   \phi(z_q)^\top (\Phi^\top \Phi + \lambda I)^{-1} \phi(z_i) \,(1 - p_i)
+   \phi(z_q)^\top (\Phi^\top \Phi)^{-1} \phi(z_i) \,(1 - p_i)
 
-where :math:`\phi` is the projected per-example gradient, :math:`\Phi` stacks the
-projected training gradients and :math:`p_i` is the model's probability of the
-training example's labels (the geometric-mean token probability for a language
-model). :math:`\phi` is one random projection of the whole gradient: the
-index must be built with ``projection_target: global``, which projects each
-module's flattened gradient with its own block of a single ``k x d``
-Rademacher matrix and sums the blocks, so ``projection_dim`` is the size of the
-sketch. ``bergson trak`` refuses other projection targets. The Gram
-:math:`\Phi^\top \Phi` is fit over that sketch (the ``autocorrelation``
-Hessian with ``scope: joint``) and its damped inverse is applied to the query
-gradients; the damping :math:`\lambda` is
-``preprocess_cfg.inversion_cfg.damping_factor`` times the mean eigenvalue. The
-``k x d`` projection matrices are held in memory, which bounds ``k`` for large
-models. Passing several independently trained checkpoints averages their
+where :math:`\phi` is the projected per-example gradient of the margin output
+function :math:`\log p - \log(1 - p)` summed over the example's label tokens
+(``loss_fn: margin``, which ``bergson trak`` requires), :math:`\Phi` stacks the
+projected training gradients and :math:`1 - p_i` is the derivative of the loss
+w.r.t. the margin, averaged over the training example's label tokens.
+:math:`\phi` is one random projection of the whole gradient: the index must be
+built with ``projection_target: global``, which projects each module's
+flattened gradient with its own block of a single ``k x d`` Rademacher matrix
+and sums the blocks, so ``projection_dim`` is the size of the sketch; the
+blocks are generated on the fly, so ``k`` is bounded by the ``k x k`` Gram
+rather than by GPU memory. ``bergson trak`` refuses other projection targets.
+The Gram :math:`\Phi^\top \Phi` is fit over that sketch on the training
+examples' own labels (the ``autocorrelation`` Hessian with ``scope: joint``)
+and its inverse is applied to the query gradients, undamped by default;
+``preprocess_cfg.inversion_cfg.damping_factor`` adds a multiple of the mean
+eigenvalue. Passing several independently trained checkpoints averages their
 score stores, as in the paper's ensembles.
 
 What It Produces
@@ -47,8 +49,9 @@ Key Options
 - ``--query.dataset``: the query dataset.
 - ``--projection_dim``: size of the global gradient sketch.
 - ``--projection_target``: must be ``global``.
+- ``--loss_fn``: must be ``margin``.
 - ``--trak_cfg.preprocess_cfg.inversion_cfg.damping_factor``: Gram damping
-  relative to the mean eigenvalue (default 0.1).
+  relative to the mean eigenvalue (default 0, the paper's plain inverse).
 - ``--trak_cfg.q_weighting``: ``one_minus_p`` (default) or ``none``.
 - ``--trak_cfg.checkpoints``: model checkpoints to ensemble.
 

--- a/tests/test_global_projection.py
+++ b/tests/test_global_projection.py
@@ -1,10 +1,9 @@
 """Tests for the LESS-style global TRAK projection mode."""
 
+import math
 from pathlib import Path
 
 import pytest
-import math
-
 import torch
 
 from bergson import GradientProcessor, collect_gradients

--- a/tests/test_global_projection.py
+++ b/tests/test_global_projection.py
@@ -3,10 +3,17 @@
 from pathlib import Path
 
 import pytest
+import math
+
 import torch
 
 from bergson import GradientProcessor, collect_gradients
-from bergson.collector.collector import CollectorComputer, create_projection_matrix
+from bergson.collector.collector import (
+    CollectorComputer,
+    create_projection_matrix,
+    global_projection_blocks,
+    project_global,
+)
 from bergson.collector.gradient_collectors import GradientCollector
 from bergson.config import IndexConfig
 from bergson.data import load_module_gradients
@@ -216,22 +223,53 @@ def test_global_project_values_cpu(tmp_path: Path, model, dataset):
         model(input_ids=tokens, labels=tokens).loss.backward()
     projected = global_collector.mod_grads["gradients"]
 
-    # Manually replicate: same identifier → same matrix → identical result
+    # Manually replicate: same identifier → same blocks → identical result
     expected: torch.Tensor | None = None
     for name, P in raw_grads.items():
-        R = create_projection_matrix(
-            f"{name}/single",
-            proj_dim,
-            P.shape[1],
-            P.dtype,
-            P.device,
-            global_processor.projection_type,
-        )
+        R = torch.cat(
+            [
+                block
+                for _, _, block in global_projection_blocks(
+                    f"{name}/single",
+                    proj_dim,
+                    P.shape[1],
+                    P.dtype,
+                    P.device,
+                    global_processor.projection_type,
+                )
+            ],
+            dim=1,
+        ) / math.sqrt(proj_dim)
         contrib = P @ R.T
         expected = contrib if expected is None else expected + contrib
 
     assert expected is not None
     torch.testing.assert_close(projected.float(), expected)
+
+
+def test_project_global_streams_in_blocks(monkeypatch):
+    """Streaming the projection matrix in column blocks computes ``P @ R.T``
+    for the block-concatenated ``R``, reproducibly, without holding ``R``."""
+    import bergson.collector.collector as collector_module
+
+    torch.manual_seed(0)
+    m, n = 8, 1000
+    P = torch.randn(3, n)
+    monkeypatch.setattr(collector_module, "GLOBAL_BLOCK_ELEMENTS", m * 64)
+    blocks = list(
+        global_projection_blocks("mod/single", m, n, P.dtype, P.device, "rademacher")
+    )
+    assert len(blocks) > 1 and blocks[-1][1] == n
+    R = torch.cat([block for _, _, block in blocks], dim=1)
+    assert R.shape == (m, n) and set(R.unique().tolist()) == {-1.0, 1.0}
+
+    streamed = project_global("mod/single", P, m, "rademacher", "jl")
+    torch.testing.assert_close(streamed, P @ R.T / math.sqrt(m))
+    torch.testing.assert_close(
+        streamed, project_global("mod/single", P, m, "rademacher", "jl")
+    )
+    row_norm = project_global("mod/single", P, m, "rademacher", "row_norm")
+    torch.testing.assert_close(row_norm, P @ R.T / math.sqrt(n))
 
 
 def test_global_projector_e2e_cpu(tmp_path: Path, model, dataset):

--- a/tests/test_global_projection.py
+++ b/tests/test_global_projection.py
@@ -254,7 +254,9 @@ def test_project_global_streams_in_blocks(monkeypatch):
     torch.manual_seed(0)
     m, n = 8, 1000
     P = torch.randn(3, n)
-    monkeypatch.setattr(collector_module, "GLOBAL_BLOCK_ELEMENTS", m * 64)
+    monkeypatch.setattr(
+        collector_module, "CHUNKED_PROJECTION_INSTANTIATION_NUMEL", m * 64
+    )
     blocks = list(
         global_projection_blocks("mod/single", m, n, P.dtype, P.device, "rademacher")
     )

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -7,7 +8,12 @@ import torch
 from datasets import Dataset
 
 from bergson.build import build
-from bergson.cli.trak import _train_label_probs, trak
+from bergson.cli.trak import (
+    _average_scores,
+    _open_scores,
+    _train_label_probs,
+    trak,
+)
 from bergson.collector.collector import token_losses
 from bergson.config import (
     DataConfig,
@@ -43,9 +49,23 @@ def data_dir(tmp_path_factory) -> Path:
     rows = [torch.randint(10, 2000, (24,)).tolist() for _ in range(15)]
     train = Dataset.from_dict({"input_ids": rows[:12], "labels": rows[:12]})
     query = Dataset.from_dict({"input_ids": rows[12:], "labels": rows[12:]})
+    both = Dataset.from_dict({"input_ids": rows, "labels": rows})
     train.save_to_disk(str(root / "train"))
     query.save_to_disk(str(root / "query"))
+    both.save_to_disk(str(root / "both"))
     return root
+
+
+@pytest.fixture(scope="module")
+def trak_run(tmp_path_factory, data_dir) -> TrackstarIndexConfig:
+    """One full (1 - p)-weighted TRAK run shared by the GPU tests. Every
+    pipeline step reloads the model (~1 s each), so the tests below check
+    the run's pieces instead of re-running TRAK per property."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    cfg = _index_cfg(tmp_path_factory.mktemp("trak_run") / "weighted", data_dir)
+    trak(cfg, TrakConfig(query=_query_cfg(data_dir)))
+    return cfg
 
 
 def _index_cfg(run_path: Path, data_dir: Path) -> TrackstarIndexConfig:
@@ -66,25 +86,15 @@ def _query_cfg(data_dir: Path) -> DataConfig:
     return DataConfig(dataset=str(data_dir / "query"), split="train")
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_trak_weights_rows_by_one_minus_p(tmp_path, data_dir):
-    """With the Q term every training row's scores are the unweighted scores
-    scaled by 1 - p_i, p_i the row's mean label-token probability."""
-    plain = _index_cfg(tmp_path / "plain", data_dir)
-    trak(plain, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
-    unweighted = _load(tmp_path / "plain" / "scores")
-    assert unweighted.shape == (12, 3)
-
-    weighted_cfg = _index_cfg(tmp_path / "weighted", data_dir)
-    trak(weighted_cfg, TrakConfig(query=_query_cfg(data_dir)))
-    weighted = _load(tmp_path / "weighted" / "scores")
-    probs = _train_label_probs(weighted_cfg, batch_size=4)
+def test_trak_weights_rows_by_one_minus_p(trak_run):
+    """The Q term scales each training row by 1 - p_i, p_i the row's mean
+    label-token probability; the pipeline saves those weights."""
+    run_path = Path(trak_run.run_path)
+    assert _load(run_path / "scores").shape == (12, 3)
+    probs = _train_label_probs(trak_run, batch_size=4)
     assert probs.shape == (12,) and (0 < probs).all() and (probs < 1).all()
-    saved = np.load(tmp_path / "weighted" / "scores" / "trak_weights.npy")
+    saved = np.load(run_path / "scores" / "trak_weights.npy")
     np.testing.assert_allclose(saved, 1 - probs)
-    np.testing.assert_allclose(
-        weighted, unweighted * (1 - probs)[:, None], rtol=1e-4, atol=1e-6
-    )
 
 
 def test_trak_rejects_cross_entropy_features(tmp_path, data_dir):
@@ -112,20 +122,18 @@ def test_trak_rejects_per_module_projection(tmp_path, data_dir):
         trak(cfg, TrakConfig(query=_query_cfg(data_dir)))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_trak_ensemble_averages_members(tmp_path, data_dir):
-    cfg = _index_cfg(tmp_path / "ens", data_dir)
-    trak(
-        cfg,
-        TrakConfig(
-            query=_query_cfg(data_dir),
-            checkpoints=[MODEL, MODEL],
-            q_weighting="none",
-        ),
-    )
-    members = [_load(tmp_path / "ens" / f"checkpoint_{i}" / "scores") for i in range(2)]
-    mean = _load(tmp_path / "ens" / "scores")
-    np.testing.assert_allclose(mean, (members[0] + members[1]) / 2, rtol=1e-6)
+def test_trak_ensemble_averages_members(tmp_path, trak_run):
+    """The ensemble score store is the mean of the members' stores."""
+    src = Path(trak_run.run_path) / "scores"
+    members = [tmp_path / "member_0", tmp_path / "member_1"]
+    for member, scale in zip(members, (1.0, 3.0)):
+        shutil.copytree(src, member)
+        mmap, info = _open_scores(member, "r+")
+        for q in range(info["num_scores"]):
+            mmap[f"score_{q}"] = mmap[f"score_{q}"] * scale
+        mmap.flush()
+    _average_scores(members, tmp_path / "scores")
+    np.testing.assert_allclose(_load(tmp_path / "scores"), 2 * _load(src), rtol=1e-6)
 
 
 def _index_matrix(run_path: Path) -> np.ndarray:
@@ -139,27 +147,25 @@ def _index_matrix(run_path: Path) -> np.ndarray:
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_trak_matches_explicit_formula(tmp_path, data_dir):
-    """Scores are phi_q^T (Phi^T Phi / N)^-1 phi_i over the global gradient
-    sketch, with no damping by default."""
-    cfg = _index_cfg(tmp_path / "joint", data_dir)
-    trak(cfg, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
-    scores = _load(tmp_path / "joint" / "scores")
+def test_trak_matches_explicit_formula(tmp_path, trak_run, data_dir):
+    """Scores are (1 - p_i) phi_q^T (Phi^T Phi / N)^-1 phi_i over the global
+    gradient sketch, with no damping by default. One index over the training
+    and query rows together gives both Phi and phi_q."""
+    run_path = Path(trak_run.run_path)
+    scores = _load(run_path / "scores")
+    weights = np.load(run_path / "scores" / "trak_weights.npy")
 
-    train_cfg = _index_cfg(tmp_path / "train_index", data_dir)
-    build(train_cfg, PreprocessConfig())
-    query_cfg = _index_cfg(tmp_path / "query_index", data_dir)
-    query_cfg.data = _query_cfg(data_dir)
-    build(query_cfg, PreprocessConfig())
-    phi = _index_matrix(tmp_path / "train_index")
-    phi_q = _index_matrix(tmp_path / "query_index")
+    both_cfg = _index_cfg(tmp_path / "both_index", data_dir)
+    both_cfg.data = DataConfig(dataset=str(data_dir / "both"), split="train")
+    build(both_cfg, PreprocessConfig())
+    grads = _index_matrix(tmp_path / "both_index")
+    phi, phi_q = grads[:12], grads[12:]
     assert phi.shape[0] == 12 and phi_q.shape[0] == 3
 
     gram = torch.from_numpy(phi.T @ phi / phi.shape[0]).float()
     h_inv = invert_psd_matrix(
         gram, inversion="damped_inverse", damping_factor=0.0, power=-1.0
     )
-    expected = phi @ h_inv.double().numpy() @ phi_q.T
+    expected = (phi @ h_inv.double().numpy() @ phi_q.T) * weights[:, None]
     # The index stores gradients in reduced precision; the Gram is fp32.
     np.testing.assert_allclose(scores, expected, rtol=2e-2, atol=1e-3)

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -7,13 +7,11 @@ import torch
 from datasets import Dataset
 
 from bergson.build import build
-from bergson.cli.trackstar import trackstar
 from bergson.cli.trak import _train_label_probs, trak
 from bergson.config import (
     DataConfig,
     DistributedConfig,
     PreprocessConfig,
-    TrackstarConfig,
     TrakConfig,
 )
 from bergson.config.config import TrackstarIndexConfig
@@ -55,7 +53,8 @@ def _index_cfg(run_path: Path, data_dir: Path) -> TrackstarIndexConfig:
         model=MODEL,
         data=DataConfig(dataset=str(data_dir / "train"), split="train"),
         distributed=DistributedConfig(nproc_per_node=1),
-        projection_dim=8,
+        projection_dim=64,
+        projection_target="global",
         token_batch_size=256,
         precision="fp32",
     )
@@ -66,30 +65,16 @@ def _query_cfg(data_dir: Path) -> DataConfig:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_trak_matches_whitened_trackstar_and_weights_rows(tmp_path, data_dir):
-    """With the per-module kernel and no Q term TRAK is trackstar with the train
-    Gram alone and no unit normalization; with the Q term every training row is
+def test_trak_weights_rows_by_one_minus_p(tmp_path, data_dir):
+    """With the Q term every training row's scores are the unweighted scores
     scaled by 1 - p_i."""
     plain = _index_cfg(tmp_path / "plain", data_dir)
-    trak(
-        plain,
-        TrakConfig(query=_query_cfg(data_dir), q_weighting="none", kernel="per_module"),
-    )
+    trak(plain, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
     unweighted = _load(tmp_path / "plain" / "scores")
-
-    ts = _index_cfg(tmp_path / "trackstar", data_dir)
-    trackstar(
-        ts,
-        TrackstarConfig(
-            query=_query_cfg(data_dir), mix_hessians=False, stats_sample_size=None
-        ),
-    )
-    reference = _load(tmp_path / "trackstar" / "scores")
-    assert unweighted.shape == reference.shape == (12, 3)
-    np.testing.assert_allclose(unweighted, reference, rtol=1e-5, atol=1e-6)
+    assert unweighted.shape == (12, 3)
 
     weighted_cfg = _index_cfg(tmp_path / "weighted", data_dir)
-    trak(weighted_cfg, TrakConfig(query=_query_cfg(data_dir), kernel="per_module"))
+    trak(weighted_cfg, TrakConfig(query=_query_cfg(data_dir)))
     weighted = _load(tmp_path / "weighted" / "scores")
     probs = _train_label_probs(weighted_cfg, batch_size=4)
     assert probs.shape == (12,) and (0 < probs).all() and (probs < 1).all()
@@ -98,6 +83,13 @@ def test_trak_matches_whitened_trackstar_and_weights_rows(tmp_path, data_dir):
     np.testing.assert_allclose(
         weighted, unweighted * (1 - probs)[:, None], rtol=1e-4, atol=1e-6
     )
+
+
+def test_trak_rejects_per_module_projection(tmp_path, data_dir):
+    cfg = _index_cfg(tmp_path / "per_module", data_dir)
+    cfg.projection_target = "per_module"
+    with pytest.raises(ValueError, match="projection_target='global'"):
+        trak(cfg, TrakConfig(query=_query_cfg(data_dir)))
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -109,7 +101,6 @@ def test_trak_ensemble_averages_members(tmp_path, data_dir):
             query=_query_cfg(data_dir),
             checkpoints=[MODEL, MODEL],
             q_weighting="none",
-            kernel="per_module",
         ),
     )
     members = [_load(tmp_path / "ens" / f"checkpoint_{i}" / "scores") for i in range(2)]
@@ -129,9 +120,9 @@ def _index_matrix(run_path: Path) -> np.ndarray:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_trak_joint_kernel_matches_explicit_formula(tmp_path, data_dir):
-    """The default kernel scores phi_q^T (Phi^T Phi / N + damping)^-1 phi_i with
-    one Gram over the concatenation of every module's projected gradient."""
+def test_trak_matches_explicit_formula(tmp_path, data_dir):
+    """Scores are phi_q^T (Phi^T Phi / N + damping)^-1 phi_i over the global
+    gradient sketch."""
     cfg = _index_cfg(tmp_path / "joint", data_dir)
     trak(cfg, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
     scores = _load(tmp_path / "joint" / "scores")

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -8,6 +8,7 @@ from datasets import Dataset
 
 from bergson.build import build
 from bergson.cli.trak import _train_label_probs, trak
+from bergson.collector.collector import token_losses
 from bergson.config import (
     DataConfig,
     DistributedConfig,
@@ -57,6 +58,7 @@ def _index_cfg(run_path: Path, data_dir: Path) -> TrackstarIndexConfig:
         projection_target="global",
         token_batch_size=256,
         precision="fp32",
+        loss_fn="margin",
     )
 
 
@@ -67,7 +69,7 @@ def _query_cfg(data_dir: Path) -> DataConfig:
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_trak_weights_rows_by_one_minus_p(tmp_path, data_dir):
     """With the Q term every training row's scores are the unweighted scores
-    scaled by 1 - p_i."""
+    scaled by 1 - p_i, p_i the row's mean label-token probability."""
     plain = _index_cfg(tmp_path / "plain", data_dir)
     trak(plain, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
     unweighted = _load(tmp_path / "plain" / "scores")
@@ -83,6 +85,24 @@ def test_trak_weights_rows_by_one_minus_p(tmp_path, data_dir):
     np.testing.assert_allclose(
         weighted, unweighted * (1 - probs)[:, None], rtol=1e-4, atol=1e-6
     )
+
+
+def test_trak_rejects_cross_entropy_features(tmp_path, data_dir):
+    cfg = _index_cfg(tmp_path / "ce", data_dir)
+    cfg.loss_fn = "ce"
+    with pytest.raises(ValueError, match="loss_fn='margin'"):
+        trak(cfg, TrakConfig(query=_query_cfg(data_dir)))
+
+
+def test_margin_token_loss_is_negative_log_odds():
+    """The margin loss is -(log p - log(1 - p)) per label token, zero on padding."""
+    torch.manual_seed(0)
+    logits = torch.randn(2, 3, 5)
+    labels = torch.tensor([[1, 4, -100], [0, 2, 3]])
+    got = token_losses("margin", logits, labels)
+    p = torch.softmax(logits, -1).gather(-1, labels.clamp(min=0).unsqueeze(-1))[..., 0]
+    expected = -(torch.log(p) - torch.log(1 - p)) * (labels != -100)
+    torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)
 
 
 def test_trak_rejects_per_module_projection(tmp_path, data_dir):
@@ -121,8 +141,8 @@ def _index_matrix(run_path: Path) -> np.ndarray:
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_trak_matches_explicit_formula(tmp_path, data_dir):
-    """Scores are phi_q^T (Phi^T Phi / N + damping)^-1 phi_i over the global
-    gradient sketch."""
+    """Scores are phi_q^T (Phi^T Phi / N)^-1 phi_i over the global gradient
+    sketch, with no damping by default."""
     cfg = _index_cfg(tmp_path / "joint", data_dir)
     trak(cfg, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
     scores = _load(tmp_path / "joint" / "scores")
@@ -138,7 +158,7 @@ def test_trak_matches_explicit_formula(tmp_path, data_dir):
 
     gram = torch.from_numpy(phi.T @ phi / phi.shape[0]).float()
     h_inv = invert_psd_matrix(
-        gram, inversion="damped_inverse", damping_factor=0.1, power=-1.0
+        gram, inversion="damped_inverse", damping_factor=0.0, power=-1.0
     )
     expected = phi @ h_inv.double().numpy() @ phi_q.T
     # The index stores gradients in reduced precision; the Gram is fp32.

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
+import yaml
 from datasets import Dataset
 from huggingface_hub import snapshot_download
 from peft import PeftConfig
@@ -200,17 +201,49 @@ def test_trak_rejects_per_module_projection(tmp_path, data_dir):
 
 
 def test_trak_ensemble_averages_members(tmp_path, trak_run):
-    """The ensemble score store is the mean of the members' stores."""
+    """The ensemble store is the mean over members of scores / trak_scale,
+    times the members' mean trak_weights."""
     src = Path(trak_run.run_path) / "scores"
+    weights = np.load(src / "trak_weights.npy")
     members = [tmp_path / "member_0", tmp_path / "member_1"]
-    for member, scale in zip(members, (1.0, 3.0)):
+    for member, factor, w in zip(members, (1.0, 3.0), (weights, 3 * weights)):
         shutil.copytree(src, member)
         mmap, info = _open_scores(member, "r+")
         for q in range(info["num_scores"]):
-            mmap[f"score_{q}"] = mmap[f"score_{q}"] * scale
+            mmap[f"score_{q}"] = mmap[f"score_{q}"] * factor
         mmap.flush()
+        np.save(member / "trak_scale.npy", 2 * factor)
+        np.save(member / "trak_weights.npy", w)
     _average_scores(members, tmp_path / "scores")
-    np.testing.assert_allclose(_load(tmp_path / "scores"), 2 * _load(src), rtol=1e-6)
+    expected = _load(src) / 2 * (2 * weights)[:, None]
+    np.testing.assert_allclose(_load(tmp_path / "scores"), expected, rtol=1e-6)
+    np.testing.assert_allclose(np.load(tmp_path / "scores" / "trak_scale.npy"), [2, 6])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_trak_ensemble_members_use_distinct_projections(tmp_path, trak_run, data_dir):
+    """Each checkpoint is projected with its own seed, and the ensemble store is
+    the members' scaled mean times their mean weights."""
+    cfg = _index_cfg(tmp_path / "ensemble", data_dir, trak_run.model)
+    trak(cfg, TrakConfig(query=_query_cfg(data_dir), checkpoints=[cfg.model] * 2))
+    members = [tmp_path / "ensemble" / f"checkpoint_{i}" for i in range(2)]
+    seeds = [
+        yaml.safe_load((m / "query" / "processor_config.yaml").read_text())[
+            "projection_seed"
+        ]
+        for m in members
+    ]
+    assert seeds == [0, 1]
+    q0, q1 = (_index_matrix(m / "query") for m in members)
+    assert not np.allclose(q0, q1)
+    scaled = [
+        _load(m / "scores") / np.load(m / "scores" / "trak_scale.npy") for m in members
+    ]
+    weights = np.mean([np.load(m / "scores" / "trak_weights.npy") for m in members], 0)
+    expected = np.mean(scaled, axis=0) * weights[:, None]
+    np.testing.assert_allclose(
+        _load(tmp_path / "ensemble" / "scores"), expected, rtol=1e-5, atol=1e-6
+    )
 
 
 def _index_matrix(run_path: Path) -> np.ndarray:
@@ -226,8 +259,9 @@ def _index_matrix(run_path: Path) -> np.ndarray:
 
 def test_trak_matches_explicit_formula(tmp_path, trak_run, data_dir):
     """Scores are (1 - p_i) phi_q^T (Phi^T Phi / N)^-1 phi_i over the global
-    gradient sketch, with no damping by default. One index over the training
-    and query rows together gives both Phi and phi_q."""
+    gradient sketch, with no damping by default, divided by the mean absolute
+    entry of the inverse as in the reference implementation. One index over the
+    training and query rows together gives both Phi and phi_q."""
     run_path = Path(trak_run.run_path)
     scores = _load(run_path / "scores")
     weights = np.load(run_path / "scores" / "trak_weights.npy")
@@ -244,5 +278,6 @@ def test_trak_matches_explicit_formula(tmp_path, trak_run, data_dir):
         gram, inversion="damped_inverse", damping_factor=0.0, power=-1.0
     )
     expected = (phi @ h_inv.double().numpy() @ phi_q.T) * weights[:, None]
+    expected /= h_inv.abs().mean().item()
     # The index stores gradients in reduced precision; the Gram is fp32.
     np.testing.assert_allclose(scores, expected, rtol=2e-2, atol=1e-3)

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -174,6 +174,24 @@ def test_log_odds_token_loss_is_negative_log_odds():
     torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)
 
 
+def test_log_odds_token_loss_stays_finite_when_p_rounds_to_one():
+    """A label logit far above the rest makes ``p`` round to 1 in fp32, where
+    ``log(1 - p)`` is ``-inf``; the loss must still equal the log odds computed
+    from the logits and its gradient w.r.t. the label logit must be -1."""
+    logits = torch.randn(1, 1, 5)
+    logits[0, 0, 2] = 60.0
+    logits.requires_grad_()
+    labels = torch.tensor([[2]])
+    got = token_losses("log_odds", logits, labels)
+    others = logits.detach().double()[0, 0, [0, 1, 3, 4]].logsumexp(0)
+    expected = -(60.0 - others)
+    assert torch.isfinite(got).all()
+    torch.testing.assert_close(got[0, 0].double(), expected, rtol=1e-5, atol=1e-6)
+    got.sum().backward()
+    assert logits.grad is not None
+    torch.testing.assert_close(logits.grad[0, 0, 2], torch.tensor(-1.0))
+
+
 def test_trak_rejects_per_module_projection(tmp_path, data_dir):
     cfg = _index_cfg(tmp_path / "per_module", data_dir)
     cfg.projection_target = "per_module"

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import shutil
 from pathlib import Path
@@ -6,6 +7,9 @@ import numpy as np
 import pytest
 import torch
 from datasets import Dataset
+from huggingface_hub import snapshot_download
+from peft import PeftConfig
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 from bergson.build import build
 from bergson.cli.trak import (
@@ -41,6 +45,49 @@ def _load(scores_dir: Path) -> np.ndarray:
     return np.stack([mmap[f"score_{q}"] for q in range(info["num_scores"])], 1)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _cached_hf_loaders():
+    """Every pipeline step reloads the tokenizer, configs and model from the
+    Hub cache (about 1 s per step for pythia-14m). Serve them from a module
+    cache: the same tokenizer and config objects, the same PEFT lookup result
+    (a ValueError for a plain model), and a fresh deep copy of a template
+    model per call so hooks and gradient flags never leak between steps."""
+    patch = pytest.MonkeyPatch()
+    cache: dict = {}
+
+    def key(name, args, kwargs):
+        return (name, args, tuple(sorted((k, repr(v)) for k, v in kwargs.items())))
+
+    def cached(name, load, copy_result=False):
+        def call(*args, **kwargs):
+            k = key(name, args, kwargs)
+            if k not in cache:
+                try:
+                    cache[k] = (load(*args, **kwargs), None)
+                except ValueError as e:
+                    cache[k] = (None, e)
+            result, error = cache[k]
+            if error is not None:
+                raise error
+            return copy.deepcopy(result) if copy_result else result
+
+        return staticmethod(call)
+
+    for cls, copy_result in (
+        (AutoTokenizer, False),
+        (AutoConfig, False),
+        (PeftConfig, False),
+        (AutoModelForCausalLM, True),
+    ):
+        patch.setattr(
+            cls,
+            "from_pretrained",
+            cached(cls.__name__, cls.from_pretrained, copy_result),
+        )
+    yield cache
+    patch.undo()
+
+
 @pytest.fixture(scope="module")
 def data_dir(tmp_path_factory) -> Path:
     """A tiny pretokenized dataset: 12 training rows, 3 queries."""
@@ -57,21 +104,33 @@ def data_dir(tmp_path_factory) -> Path:
 
 
 @pytest.fixture(scope="module")
-def trak_run(tmp_path_factory, data_dir) -> TrackstarIndexConfig:
+def trak_run(tmp_path_factory, data_dir, _cached_hf_loaders) -> TrackstarIndexConfig:
     """One full (1 - p)-weighted TRAK run shared by the GPU tests. Every
     pipeline step reloads the model (~1 s each), so the tests below check
     the run's pieces instead of re-running TRAK per property."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
-    cfg = _index_cfg(tmp_path_factory.mktemp("trak_run") / "weighted", data_dir)
+    # A local snapshot path keeps the per-step loads off the Hub, and the
+    # model is a plain causal LM: answer the PEFT adapter lookup without a
+    # Hub round trip per step.
+    model_path = snapshot_download(MODEL)
+    _cached_hf_loaders[("PeftConfig", (model_path,), ())] = (
+        None,
+        ValueError(f"{MODEL} is not a PEFT adapter"),
+    )
+    cfg = _index_cfg(
+        tmp_path_factory.mktemp("trak_run") / "weighted", data_dir, model_path
+    )
     trak(cfg, TrakConfig(query=_query_cfg(data_dir)))
     return cfg
 
 
-def _index_cfg(run_path: Path, data_dir: Path) -> TrackstarIndexConfig:
+def _index_cfg(
+    run_path: Path, data_dir: Path, model: str = MODEL
+) -> TrackstarIndexConfig:
     return TrackstarIndexConfig(
         run_path=str(run_path),
-        model=MODEL,
+        model=model,
         data=DataConfig(dataset=str(data_dir / "train"), split="train"),
         distributed=DistributedConfig(nproc_per_node=1),
         projection_dim=64,
@@ -155,7 +214,7 @@ def test_trak_matches_explicit_formula(tmp_path, trak_run, data_dir):
     scores = _load(run_path / "scores")
     weights = np.load(run_path / "scores" / "trak_weights.npy")
 
-    both_cfg = _index_cfg(tmp_path / "both_index", data_dir)
+    both_cfg = _index_cfg(tmp_path / "both_index", data_dir, trak_run.model)
     both_cfg.data = DataConfig(dataset=str(data_dir / "both"), split="train")
     build(both_cfg, PreprocessConfig())
     grads = _index_matrix(tmp_path / "both_index")

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -137,7 +137,7 @@ def _index_cfg(
         projection_target="global",
         token_batch_size=256,
         precision="fp32",
-        loss_fn="margin",
+        loss_fn="log_odds",
     )
 
 
@@ -159,16 +159,16 @@ def test_trak_weights_rows_by_one_minus_p(trak_run):
 def test_trak_rejects_cross_entropy_features(tmp_path, data_dir):
     cfg = _index_cfg(tmp_path / "ce", data_dir)
     cfg.loss_fn = "ce"
-    with pytest.raises(ValueError, match="loss_fn='margin'"):
+    with pytest.raises(ValueError, match="loss_fn='log_odds'"):
         trak(cfg, TrakConfig(query=_query_cfg(data_dir)))
 
 
-def test_margin_token_loss_is_negative_log_odds():
-    """The margin loss is -(log p - log(1 - p)) per label token, zero on padding."""
+def test_log_odds_token_loss_is_negative_log_odds():
+    """The log-odds loss is -(log p - log(1 - p)) per label token, zero on padding."""
     torch.manual_seed(0)
     logits = torch.randn(2, 3, 5)
     labels = torch.tensor([[1, 4, -100], [0, 2, 3]])
-    got = token_losses("margin", logits, labels)
+    got = token_losses("log_odds", logits, labels)
     p = torch.softmax(logits, -1).gather(-1, labels.clamp(min=0).unsqueeze(-1))[..., 0]
     expected = -(torch.log(p) - torch.log(1 - p)) * (labels != -100)
     torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from datasets import Dataset
+
+from bergson.cli.trackstar import trackstar
+from bergson.cli.trak import _train_label_probs, trak
+from bergson.config import DataConfig, DistributedConfig, TrackstarConfig, TrakConfig
+from bergson.config.config import TrackstarIndexConfig
+
+MODEL = "EleutherAI/pythia-14m"
+
+
+def _load(scores_dir: Path) -> np.ndarray:
+    info = json.loads((scores_dir / "info.json").read_text())
+    mmap = np.memmap(
+        scores_dir / "scores.bin",
+        dtype=info["dtype"],
+        mode="r",
+        shape=(info["num_rows"],),
+    )
+    for q in range(info["num_scores"]):
+        assert mmap[f"written_{q}"].all()
+    return np.stack([mmap[f"score_{q}"] for q in range(info["num_scores"])], 1)
+
+
+@pytest.fixture(scope="module")
+def data_dir(tmp_path_factory) -> Path:
+    """A tiny pretokenized dataset: 12 training rows, 3 queries."""
+    torch.manual_seed(0)
+    root = tmp_path_factory.mktemp("trak_data")
+    rows = [torch.randint(10, 2000, (24,)).tolist() for _ in range(15)]
+    train = Dataset.from_dict({"input_ids": rows[:12], "labels": rows[:12]})
+    query = Dataset.from_dict({"input_ids": rows[12:], "labels": rows[12:]})
+    train.save_to_disk(str(root / "train"))
+    query.save_to_disk(str(root / "query"))
+    return root
+
+
+def _index_cfg(run_path: Path, data_dir: Path) -> TrackstarIndexConfig:
+    return TrackstarIndexConfig(
+        run_path=str(run_path),
+        model=MODEL,
+        data=DataConfig(dataset=str(data_dir / "train"), split="train"),
+        distributed=DistributedConfig(nproc_per_node=1),
+        projection_dim=8,
+        token_batch_size=256,
+        precision="fp32",
+    )
+
+
+def _query_cfg(data_dir: Path) -> DataConfig:
+    return DataConfig(dataset=str(data_dir / "query"), split="train")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_trak_matches_whitened_trackstar_and_weights_rows(tmp_path, data_dir):
+    """Without the Q term TRAK is trackstar with the train Gram alone and no
+    unit normalization; with it every training row is scaled by 1 - p_i."""
+    plain = _index_cfg(tmp_path / "plain", data_dir)
+    trak(plain, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
+    unweighted = _load(tmp_path / "plain" / "scores")
+
+    ts = _index_cfg(tmp_path / "trackstar", data_dir)
+    trackstar(
+        ts,
+        TrackstarConfig(
+            query=_query_cfg(data_dir), mix_hessians=False, stats_sample_size=None
+        ),
+    )
+    reference = _load(tmp_path / "trackstar" / "scores")
+    assert unweighted.shape == reference.shape == (12, 3)
+    np.testing.assert_allclose(unweighted, reference, rtol=1e-5, atol=1e-6)
+
+    weighted_cfg = _index_cfg(tmp_path / "weighted", data_dir)
+    trak(weighted_cfg, TrakConfig(query=_query_cfg(data_dir)))
+    weighted = _load(tmp_path / "weighted" / "scores")
+    probs = _train_label_probs(weighted_cfg, batch_size=4)
+    assert probs.shape == (12,) and (0 < probs).all() and (probs < 1).all()
+    saved = np.load(tmp_path / "weighted" / "scores" / "trak_weights.npy")
+    np.testing.assert_allclose(saved, 1 - probs)
+    np.testing.assert_allclose(
+        weighted, unweighted * (1 - probs)[:, None], rtol=1e-4, atol=1e-6
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_trak_ensemble_averages_members(tmp_path, data_dir):
+    cfg = _index_cfg(tmp_path / "ens", data_dir)
+    trak(
+        cfg,
+        TrakConfig(
+            query=_query_cfg(data_dir), checkpoints=[MODEL, MODEL], q_weighting="none"
+        ),
+    )
+    members = [_load(tmp_path / "ens" / f"checkpoint_{i}" / "scores") for i in range(2)]
+    mean = _load(tmp_path / "ens" / "scores")
+    np.testing.assert_allclose(mean, (members[0] + members[1]) / 2, rtol=1e-6)

--- a/tests/test_trak.py
+++ b/tests/test_trak.py
@@ -6,10 +6,19 @@ import pytest
 import torch
 from datasets import Dataset
 
+from bergson.build import build
 from bergson.cli.trackstar import trackstar
 from bergson.cli.trak import _train_label_probs, trak
-from bergson.config import DataConfig, DistributedConfig, TrackstarConfig, TrakConfig
+from bergson.config import (
+    DataConfig,
+    DistributedConfig,
+    PreprocessConfig,
+    TrackstarConfig,
+    TrakConfig,
+)
 from bergson.config.config import TrackstarIndexConfig
+from bergson.data import column_offsets, load_gradients
+from bergson.hessians.inversion import invert_psd_matrix
 
 MODEL = "EleutherAI/pythia-14m"
 
@@ -58,10 +67,14 @@ def _query_cfg(data_dir: Path) -> DataConfig:
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_trak_matches_whitened_trackstar_and_weights_rows(tmp_path, data_dir):
-    """Without the Q term TRAK is trackstar with the train Gram alone and no
-    unit normalization; with it every training row is scaled by 1 - p_i."""
+    """With the per-module kernel and no Q term TRAK is trackstar with the train
+    Gram alone and no unit normalization; with the Q term every training row is
+    scaled by 1 - p_i."""
     plain = _index_cfg(tmp_path / "plain", data_dir)
-    trak(plain, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
+    trak(
+        plain,
+        TrakConfig(query=_query_cfg(data_dir), q_weighting="none", kernel="per_module"),
+    )
     unweighted = _load(tmp_path / "plain" / "scores")
 
     ts = _index_cfg(tmp_path / "trackstar", data_dir)
@@ -76,7 +89,7 @@ def test_trak_matches_whitened_trackstar_and_weights_rows(tmp_path, data_dir):
     np.testing.assert_allclose(unweighted, reference, rtol=1e-5, atol=1e-6)
 
     weighted_cfg = _index_cfg(tmp_path / "weighted", data_dir)
-    trak(weighted_cfg, TrakConfig(query=_query_cfg(data_dir)))
+    trak(weighted_cfg, TrakConfig(query=_query_cfg(data_dir), kernel="per_module"))
     weighted = _load(tmp_path / "weighted" / "scores")
     probs = _train_label_probs(weighted_cfg, batch_size=4)
     assert probs.shape == (12,) and (0 < probs).all() and (probs < 1).all()
@@ -93,9 +106,49 @@ def test_trak_ensemble_averages_members(tmp_path, data_dir):
     trak(
         cfg,
         TrakConfig(
-            query=_query_cfg(data_dir), checkpoints=[MODEL, MODEL], q_weighting="none"
+            query=_query_cfg(data_dir),
+            checkpoints=[MODEL, MODEL],
+            q_weighting="none",
+            kernel="per_module",
         ),
     )
     members = [_load(tmp_path / "ens" / f"checkpoint_{i}" / "scores") for i in range(2)]
     mean = _load(tmp_path / "ens" / "scores")
     np.testing.assert_allclose(mean, (members[0] + members[1]) / 2, rtol=1e-6)
+
+
+def _index_matrix(run_path: Path) -> np.ndarray:
+    """All projected gradients of an index concatenated in stored module order."""
+    info = json.loads((run_path / "info.json").read_text())
+    mmap = load_gradients(run_path)
+    cols = column_offsets(info["grad_sizes"])
+    return np.concatenate(
+        [np.asarray(mmap[:, lo:hi], dtype=np.float64) for _, (lo, hi) in cols.items()],
+        axis=1,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_trak_joint_kernel_matches_explicit_formula(tmp_path, data_dir):
+    """The default kernel scores phi_q^T (Phi^T Phi / N + damping)^-1 phi_i with
+    one Gram over the concatenation of every module's projected gradient."""
+    cfg = _index_cfg(tmp_path / "joint", data_dir)
+    trak(cfg, TrakConfig(query=_query_cfg(data_dir), q_weighting="none"))
+    scores = _load(tmp_path / "joint" / "scores")
+
+    train_cfg = _index_cfg(tmp_path / "train_index", data_dir)
+    build(train_cfg, PreprocessConfig())
+    query_cfg = _index_cfg(tmp_path / "query_index", data_dir)
+    query_cfg.data = _query_cfg(data_dir)
+    build(query_cfg, PreprocessConfig())
+    phi = _index_matrix(tmp_path / "train_index")
+    phi_q = _index_matrix(tmp_path / "query_index")
+    assert phi.shape[0] == 12 and phi_q.shape[0] == 3
+
+    gram = torch.from_numpy(phi.T @ phi / phi.shape[0]).float()
+    h_inv = invert_psd_matrix(
+        gram, inversion="damped_inverse", damping_factor=0.1, power=-1.0
+    )
+    expected = phi @ h_inv.double().numpy() @ phi_q.T
+    # The index stores gradients in reduced precision; the Gram is fp32.
+    np.testing.assert_allclose(scores, expected, rtol=2e-2, atol=1e-3)


### PR DESCRIPTION
- Add `bergson trak` for [TRAK (Park et al., 2023)](https://arxiv.org/abs/2303.14186).
- `trak_cfg.checkpoints` averages the scores of independently trained models. 
- Refuse incompatible projection/loss function settings
- Stream the global projection per-module to avoid OOM, because the paper uses a 4k+ projection dim. This is mathematically different from the per-module projection of TrackStar.
- New `loss_fn: margin`.
