### PR TITLE
draft

### DIFF
--- a/bergson/approx_unrolling/pipeline.py
+++ b/bergson/approx_unrolling/pipeline.py
@@ -28,7 +28,7 @@ import shutil
 from copy import deepcopy
 from pathlib import Path
 
-from ..build import build_contrast
+from ..build import build_query
 from ..cli.commands import Build
 from ..config import (
     ApproxUnrollingConfig,
@@ -209,7 +209,7 @@ def approx_unrolling_pipeline(
             Build(query_cfg, query_preprocess_cfg),
             query_cfg.partial_run_path,
         )
-        build_contrast(
+        build_query(
             query_cfg, approx_unrolling_cfg.query_contrast, query_preprocess_cfg
         )
 

--- a/bergson/approx_unrolling/pipeline.py
+++ b/bergson/approx_unrolling/pipeline.py
@@ -28,7 +28,7 @@ import shutil
 from copy import deepcopy
 from pathlib import Path
 
-from ..build import build
+from ..build import build_contrast
 from ..cli.commands import Build
 from ..config import (
     ApproxUnrollingConfig,
@@ -200,7 +200,6 @@ def approx_unrolling_pipeline(
         query_cfg = deepcopy(index_cfg)
         query_cfg.model = str(approx_unrolling_cfg.checkpoints[-1])
         query_cfg.data = approx_unrolling_cfg.query
-        query_cfg.contrast = approx_unrolling_cfg.query_contrast
         query_cfg.run_path = str(query_path)
         query_cfg.projection_dim = 0
         query_preprocess_cfg = PreprocessConfig(
@@ -210,7 +209,9 @@ def approx_unrolling_pipeline(
             Build(query_cfg, query_preprocess_cfg),
             query_cfg.partial_run_path,
         )
-        build(query_cfg, query_preprocess_cfg)
+        build_contrast(
+            query_cfg, approx_unrolling_cfg.query_contrast, query_preprocess_cfg
+        )
 
     # Per-segment Adam preconditioners from the checkpoints' second moments
     preconditioner_paths: list[Path] = []

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -8,7 +8,7 @@ import torch.distributed as dist
 from datasets import Dataset
 
 from bergson.collection import collect_gradients
-from bergson.config.config import IndexConfig, PreprocessConfig
+from bergson.config.config import DataConfig, IndexConfig, PreprocessConfig
 from bergson.data import allocate_batches, load_gradients
 from bergson.distributed import (
     DIST_TIMEOUT,
@@ -147,18 +147,22 @@ def build(
     if dist_cfg.world_size < index_cfg.distributed.world_size:
         parent_barrier(index_cfg.distributed)
 
-    if index_cfg.contrast is not None:
-        subtract_contrast(index_cfg, preprocess_cfg)
 
-
-def subtract_contrast(index_cfg: IndexConfig, preprocess_cfg: PreprocessConfig):
-    """Build ``index_cfg.contrast`` under ``<run_path>/contrast`` and subtract
-    its aggregated gradient from the index's row in place, normalizing the
-    difference if the index normalizes its aggregated gradient."""
+def build_contrast(
+    index_cfg: IndexConfig, control: DataConfig | None, preprocess_cfg: PreprocessConfig
+):
+    """Build the index, then build ``control`` under ``<run_path>/contrast``
+    with the same settings and subtract its aggregated gradient from the
+    index's row in place, so the index holds ``mean_grad(data) -
+    mean_grad(control)``. A ``None`` control is a plain ``build``."""
+    if control is None:
+        return build(index_cfg, preprocess_cfg)
     if preprocess_cfg.aggregation == "none":
         raise ValueError("contrast needs aggregation 'mean' or 'sum'")
+    build(index_cfg, preprocess_cfg)
+
     contrast_cfg = deepcopy(index_cfg)
-    contrast_cfg.data, contrast_cfg.contrast = index_cfg.contrast, None
+    contrast_cfg.data = control
     contrast_cfg.run_path = os.path.join(index_cfg.run_path, "contrast")
     contrast_preprocess = deepcopy(preprocess_cfg)
     contrast_preprocess.normalize_aggregated_grad = False

--- a/bergson/build.py
+++ b/bergson/build.py
@@ -148,13 +148,13 @@ def build(
         parent_barrier(index_cfg.distributed)
 
 
-def build_contrast(
+def build_query(
     index_cfg: IndexConfig, control: DataConfig | None, preprocess_cfg: PreprocessConfig
 ):
-    """Build the index, then build ``control`` under ``<run_path>/contrast``
-    with the same settings and subtract its aggregated gradient from the
-    index's row in place, so the index holds ``mean_grad(data) -
-    mean_grad(control)``. A ``None`` control is a plain ``build``."""
+    """Build the query index. With a ``control`` dataset, also build it under
+    ``<run_path>/contrast`` with the same settings and subtract its aggregated
+    gradient from the index's row in place, so the index holds
+    ``mean_grad(data) - mean_grad(control)``."""
     if control is None:
         return build(index_cfg, preprocess_cfg)
     if preprocess_cfg.aggregation == "none":

--- a/bergson/cli/trackstar.py
+++ b/bergson/cli/trackstar.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from pathlib import Path
 
-from ..build import build_contrast
+from ..build import build_query
 from ..config.config import (
     HessianConfig,
     IndexConfig,
@@ -155,7 +155,7 @@ def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
             Build(query_cfg, trackstar_cfg.preprocess_cfg),
             query_cfg.partial_run_path,
         )
-        build_contrast(
+        build_query(
             query_cfg, trackstar_cfg.query_contrast, trackstar_cfg.preprocess_cfg
         )
 

--- a/bergson/cli/trackstar.py
+++ b/bergson/cli/trackstar.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from pathlib import Path
 
-from ..build import build
+from ..build import build_contrast
 from ..config.config import (
     HessianConfig,
     IndexConfig,
@@ -134,7 +134,6 @@ def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
         query_cfg = deepcopy(index_cfg)
         query_cfg.run_path = query_path
         query_cfg.data = deepcopy(trackstar_cfg.query)
-        query_cfg.contrast = deepcopy(trackstar_cfg.query_contrast)
 
         # query-side aggregation is currently not compatible with token attribution
         # only. When aggregating the query (aggregation != "none"), per-token
@@ -156,7 +155,9 @@ def trackstar(index_cfg: IndexConfig, trackstar_cfg: TrackstarConfig):
             Build(query_cfg, trackstar_cfg.preprocess_cfg),
             query_cfg.partial_run_path,
         )
-        build(query_cfg, trackstar_cfg.preprocess_cfg)
+        build_contrast(
+            query_cfg, trackstar_cfg.query_contrast, trackstar_cfg.preprocess_cfg
+        )
 
     # Step 5: Score value dataset against query using mixed hessian
     print("Step 5/5: Scoring value dataset...")

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -574,12 +574,6 @@ class AttentionConfig:
 class IndexConfig(AttributionConfig, Serializable):
     """Config for building the index and running the model/dataset pipeline."""
 
-    contrast: DataConfig | None = field(default=None, cmd=False)
-    """Control dataset whose aggregated gradient is subtracted from ``data``'s,
-    so the index holds ``mean_grad(data) - mean_grad(contrast)``. Needs
-    ``aggregation`` mean or sum. Config file or code only, so ``--dataset``
-    stays unprefixed on the ``build`` CLI."""
-
     projection_dim: int = 0
     """Dimension of the random projection for the index, or 0 to disable it."""
 
@@ -875,8 +869,8 @@ class ApproxUnrollingConfig(Serializable):
     """Query dataset spec; gradients computed at the final checkpoint."""
 
     query_contrast: DataConfig | None = None
-    """Control dataset subtracted from the aggregated query gradient (see
-    ``IndexConfig.contrast``)."""
+    """Control dataset subtracted from the aggregated query gradient, so
+    scores measure the query loss minus the control loss."""
 
     query_aggregation: Literal["mean", "sum", "none"] = "mean"
     """How to aggregate the query gradients. "none" produces one
@@ -916,8 +910,8 @@ class HessianPipelineConfig:
     """Query dataset specification."""
 
     query_contrast: DataConfig | None = None
-    """Control dataset subtracted from the aggregated query gradient (see
-    ``IndexConfig.contrast``)."""
+    """Control dataset subtracted from the aggregated query gradient, so
+    scores measure the query loss minus the control loss."""
 
     query_aggregation: Literal["mean", "sum", "none"] = "mean"
     """How to aggregate the query gradients. "none" produces
@@ -961,8 +955,8 @@ class TrackstarConfig:
     """Query dataset specification."""
 
     query_contrast: DataConfig | None = None
-    """Control dataset subtracted from the aggregated query gradient (see
-    ``IndexConfig.contrast``)."""
+    """Control dataset subtracted from the aggregated query gradient, so
+    scores measure the query loss minus the control loss."""
 
     preprocess_cfg: PreprocessConfig = field(default_factory=PreprocessConfig)
 

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -2,7 +2,7 @@ import time
 from contextlib import contextmanager
 from copy import deepcopy
 
-from ..build import build
+from ..build import build_contrast
 from ..cli.commands import Build, Score
 from ..config.config import (
     HessianConfig,
@@ -88,7 +88,6 @@ def hessian_pipeline(
             query_cfg = deepcopy(index_cfg)
             query_cfg.run_path = query_path
             query_cfg.data = hessian_pipeline_cfg.query
-            query_cfg.contrast = hessian_pipeline_cfg.query_contrast
             query_cfg.projection_dim = 0
 
             # Query aggregation is not compatible with query-side token
@@ -110,7 +109,9 @@ def hessian_pipeline(
                 Build(query_cfg, query_preprocess_cfg),
                 query_cfg.partial_run_path,
             )
-            build(query_cfg, query_preprocess_cfg)
+            build_contrast(
+                query_cfg, hessian_pipeline_cfg.query_contrast, query_preprocess_cfg
+            )
 
     # ── Step 2: Fit Hessian factors on training data ──────────────────────
     print(f"Step 2/4: Fitting {method} factors on training data...")

--- a/bergson/hessians/pipeline.py
+++ b/bergson/hessians/pipeline.py
@@ -2,7 +2,7 @@ import time
 from contextlib import contextmanager
 from copy import deepcopy
 
-from ..build import build_contrast
+from ..build import build_query
 from ..cli.commands import Build, Score
 from ..config.config import (
     HessianConfig,
@@ -109,7 +109,7 @@ def hessian_pipeline(
                 Build(query_cfg, query_preprocess_cfg),
                 query_cfg.partial_run_path,
             )
-            build_contrast(
+            build_query(
                 query_cfg, hessian_pipeline_cfg.query_contrast, query_preprocess_cfg
             )
 

--- a/docs/building_blocks.rst
+++ b/docs/building_blocks.rst
@@ -110,9 +110,6 @@ A directory at ``run_path`` containing:
   Requires ``--aggregation none``.
 - ``--unit_normalize``: unit-normalize individual gradients, applied *before* aggregating.
 - ``--projection_dim``: random-projection size; ``0`` keeps the full gradient.
-- ``contrast`` (config file only): a control dataset whose aggregated gradient is
-  subtracted from the main dataset's, so the stored row is the gradient of the
-  difference of the two mean losses. Requires ``aggregation`` ``mean`` or ``sum``.
 
 **Example** — a per-example index
 

--- a/examples/contrastive_queries/README.md
+++ b/examples/contrastive_queries/README.md
@@ -4,7 +4,7 @@ A contrastive query scores training data by how it moves one loss relative to an
 
 - `build_eval_queries.py` writes five positive sets (sycophancy, toxicity, consciousness claims, self-awareness, power-seeking) and an MMLU control as JSONL of source rows.
 - `formats/*.yaml` are the Jinja templates (`doc_to_text`, `doc_to_target`) that render a row into a prompt and a completion; pass one as `format_template` on the query `DataConfig`.
-- `magic_contrast.yaml` scores one set with MAGIC using `query_contrast`. The same fields exist on the `build`-based pipelines (`contrast` on `build`, `query_contrast` on `trackstar`, `ekfac` and `approxunrolling`).
+- `magic_contrast.yaml` scores one set with MAGIC using `query_contrast`. The same field exists on `trackstar`, `ekfac` and `approxunrolling`.
 
 ```bash
 python -m examples.contrastive_queries.build_eval_queries --out queries/

--- a/tests/test_contrast.py
+++ b/tests/test_contrast.py
@@ -53,9 +53,7 @@ def test_build_query_contrast_is_difference_of_means(tmp_path):
 
     build(_index_cfg(tmp_path / "q", query), mean)
     build(_index_cfg(tmp_path / "c", control), mean)
-    build_query(
-        _index_cfg(tmp_path / "qc", query), DataConfig(dataset=control), mean
-    )
+    build_query(_index_cfg(tmp_path / "qc", query), DataConfig(dataset=control), mean)
 
     q = np.asarray(load_gradients(tmp_path / "q")[0], dtype=np.float64)
     c = np.asarray(load_gradients(tmp_path / "c")[0], dtype=np.float64)

--- a/tests/test_contrast.py
+++ b/tests/test_contrast.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from datasets import Dataset
 
-from bergson.build import build, build_contrast
+from bergson.build import build, build_query
 from bergson.config import DataConfig, DistributedConfig, IndexConfig, PreprocessConfig
 from bergson.data import load_gradients, load_scores_loss_signed
 from bergson.magic.cli import worker
@@ -46,14 +46,14 @@ def _index_cfg(run_path: Path, dataset: str, **kwargs) -> IndexConfig:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_build_contrast_is_difference_of_means(tmp_path):
+def test_build_query_contrast_is_difference_of_means(tmp_path):
     query = _save(tmp_path / "query", 4, 0)
     control = _save(tmp_path / "control", 6, 4)
     mean = PreprocessConfig(aggregation="mean")
 
     build(_index_cfg(tmp_path / "q", query), mean)
     build(_index_cfg(tmp_path / "c", control), mean)
-    build_contrast(
+    build_query(
         _index_cfg(tmp_path / "qc", query), DataConfig(dataset=control), mean
     )
 
@@ -66,10 +66,10 @@ def test_build_contrast_is_difference_of_means(tmp_path):
     assert np.abs(qc).max() > 0
 
 
-def test_build_contrast_needs_aggregation(tmp_path):
+def test_build_query_contrast_needs_aggregation(tmp_path):
     cfg = _index_cfg(tmp_path / "x", "unused")
     with pytest.raises(ValueError, match="aggregation"):
-        build_contrast(
+        build_query(
             cfg, DataConfig(dataset="unused"), PreprocessConfig(aggregation="none")
         )
 

--- a/tests/test_contrast.py
+++ b/tests/test_contrast.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from datasets import Dataset
 
-from bergson.build import build, subtract_contrast
+from bergson.build import build, build_contrast
 from bergson.config import DataConfig, DistributedConfig, IndexConfig, PreprocessConfig
 from bergson.data import load_gradients, load_scores_loss_signed
 from bergson.magic.cli import worker
@@ -53,8 +53,8 @@ def test_build_contrast_is_difference_of_means(tmp_path):
 
     build(_index_cfg(tmp_path / "q", query), mean)
     build(_index_cfg(tmp_path / "c", control), mean)
-    build(
-        _index_cfg(tmp_path / "qc", query, contrast=DataConfig(dataset=control)), mean
+    build_contrast(
+        _index_cfg(tmp_path / "qc", query), DataConfig(dataset=control), mean
     )
 
     q = np.asarray(load_gradients(tmp_path / "q")[0], dtype=np.float64)
@@ -67,9 +67,11 @@ def test_build_contrast_is_difference_of_means(tmp_path):
 
 
 def test_build_contrast_needs_aggregation(tmp_path):
-    cfg = _index_cfg(tmp_path / "x", "unused", contrast=DataConfig(dataset="unused"))
+    cfg = _index_cfg(tmp_path / "x", "unused")
     with pytest.raises(ValueError, match="aggregation"):
-        subtract_contrast(cfg, PreprocessConfig(aggregation="none"))
+        build_contrast(
+            cfg, DataConfig(dataset="unused"), PreprocessConfig(aggregation="none")
+        )
 
 
 def test_magic_contrast_needs_an_aggregated_query(tmp_path):


### PR DESCRIPTION
Stacked on #458. Moves the `build`-side contrast out of `IndexConfig` into a helper so the config stays unchanged.

- `build_contrast(index_cfg, control, preprocess_cfg)` in `bergson/build.py` builds the index, builds `control` under `<run_path>/contrast`, and subtracts its aggregated gradient in place. A `None` control is a plain `build`.
- `trackstar`, `ekfac` and `approxunrolling` call it with their `query_contrast`; the `IndexConfig.contrast` field and its hidden-from-CLI handling are gone.
- Standalone `bergson build` no longer takes a contrast; the pipelines and MAGIC/validate are unchanged in behaviour.

Tests: `tests/test_contrast.py`, `test_build.py`, `test_builder.py`, `test_hessian.py`, `ekfac_tests`, SOURCE trainer integration and checkpoint parsing all pass on an A40 (140 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyh3is739zD8bg3wdiHgEn
