### PR TITLE
fix: safer defaults for apply_batch_size and eps_root

### DIFF
--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -104,8 +104,7 @@ class InversionConfig(Serializable):
 
     apply_batch_size: int = 2
     """Query gradients moved on-device and preconditioned at a time in the
-    inverse application. Each one costs about three times its fp32 size in
-    GPU memory, so two 1.5B-parameter gradients fill a 48 GB card."""
+    inverse application."""
 
 
 @dataclass

--- a/bergson/config/config.py
+++ b/bergson/config/config.py
@@ -102,9 +102,10 @@ class InversionConfig(Serializable):
     damping_factor: float = 0.1
     """Damping / truncation strength, relative to the mean eigenvalue."""
 
-    apply_batch_size: int = 32
+    apply_batch_size: int = 2
     """Query gradients moved on-device and preconditioned at a time in the
-    inverse application."""
+    inverse application. Each one costs about three times its fp32 size in
+    GPU memory, so two 1.5B-parameter gradients fill a 48 GB card."""
 
 
 @dataclass
@@ -350,7 +351,7 @@ class TrainingConfig(AttributionConfig, Serializable):
     adam_beta2: float = 0.975
     """Beta2 for AdamW optimizer."""
 
-    eps_root: float = 1e-8
+    eps_root: float = 1e-17
     """Epsilon root for AdamW optimizer.
 
     Note for TrackStar attribution: Adam normalization with a non-zero

--- a/bergson/hessians/apply_hessian.py
+++ b/bergson/hessians/apply_hessian.py
@@ -31,7 +31,7 @@ class EkfacConfig:
     """If True, use the corrected eigenvalues, this requires
     `hessian_method_path` to have been created with
     `HessianConfig.ev_correction=True`."""
-    apply_batch_size: int = 32
+    apply_batch_size: int = 2
     """Number of query gradients moved on-device and preconditioned at a time."""
     projection_dim: int = 0
     """When set, compress each module's IVHP output to a ``[p, p]`` Kronecker

--- a/tests/ekfac_tests/test_factored_preconditioner.py
+++ b/tests/ekfac_tests/test_factored_preconditioner.py
@@ -310,3 +310,48 @@ def test_apply_hessian_rejects_compression_with_ev_correction():
     )
     with pytest.raises(ValueError, match="EK-FAC"):
         EkfacApplicator(cfg, inversion_cfg=InversionConfig())
+
+
+def test_apply_hessian_batches_queries(tmp_path):
+    """The default ``apply_batch_size`` is small enough for large models, and
+    batching the queries through the EK-FAC inverse (ev_correction, the path
+    that also holds the corrected eigenvalue grid on-device) must give the same
+    output as applying them all at once."""
+    assert InversionConfig().apply_batch_size == 2
+
+    modules = {"a": (4, 6), "b": (5, 3)}  # (O, I)
+    hessian_path = tmp_path / "hessian"
+    _write_factored_hessian(hessian_path, modules, num_shards=1, seed=0)
+    # EK-FAC applies the corrected eigenvalue grid; derive one from the grid.
+    grid = load_file(str(hessian_path / "eigenvalue_sharded" / "shard_0.safetensors"))
+    corrected_dir = hessian_path / "eigenvalue_correction_sharded"
+    corrected_dir.mkdir()
+    save_file(
+        {k: v * 1.5 for k, v in grid.items()},
+        str(corrected_dir / "shard_0.safetensors"),
+    )
+    grad_sizes = {name: o * i for name, (o, i) in modules.items()}
+    num_grads = 5
+    query_path = str(tmp_path / "query")
+    _make_query_gradients(query_path, grad_sizes, num_grads)
+    inversion_cfg = InversionConfig(inversion="damped_inverse", damping_factor=0.1)
+
+    outs = []
+    for label, batch_size in [("default", None), ("all", num_grads)]:
+        kwargs = {} if batch_size is None else {"apply_batch_size": batch_size}
+        cfg = EkfacConfig(
+            hessian_method_path=str(hessian_path),
+            gradient_path=query_path,
+            run_path=str(tmp_path / f"out_{label}"),
+            ev_correction=True,
+            **kwargs,
+        )
+        assert cfg.apply_batch_size == (batch_size or 2)
+        EkfacApplicator(cfg, inversion_cfg=inversion_cfg).compute_ivhp_sharded()
+        outs.append(load_module_gradients(str(tmp_path / f"out_{label}")))
+
+    for name in modules:
+        batched = torch.from_numpy(np.asarray(outs[0][name][:]))
+        whole = torch.from_numpy(np.asarray(outs[1][name][:]))
+        assert batched.shape[0] == num_grads
+        assert torch.allclose(batched, whole, atol=1e-6), name


### PR DESCRIPTION
Two default changes.

- `InversionConfig.apply_batch_size` (and `ApplyHessianConfig.apply_batch_size`): 32 → 2. The inverse-Hessian step moves that many fp32 query gradients onto one GPU and holds roughly three copies while preconditioning. With a 1.5B-parameter model each gradient is 6 GB, so the old default needed about 570 GB and any query set with more than a handful of rows died with CUDA OOM on 48 GB and 80 GB cards. Two is verified on A40s with Qwen2.5-1.5B and 48-row query sets; the step is a small fraction of a scoring run, so the cost of the smaller batch is minutes.
- `TrainingConfig.eps_root`: 1e-8 → 1e-17. Every recipe in `examples/` already sets it, and the trainer comparisons in the tests pass their own torchopt optimizer, so no test depends on the old default.

Test: one new CPU test, `test_apply_hessian_batches_queries`, pins the default and checks that batching queries through the EK-FAC inverse (the ev-corrected path, which also holds the corrected eigenvalue grid on-device) gives the same output as applying them all at once. The existing `test_adam_state_loading`, `test_magic`, `test_muon`, `test_hessian` and `test_score` files also pass on 4 A40s against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyh3is739zD8bg3wdiHgEn
