### PR TITLE
fix: NaN with HF when padding rows fill a micro-batch

### DIFF
--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -164,6 +164,11 @@ def mean_query_loss(
             batch, n_tokens = mask_padded_rows(batch)
             tokens += n_tokens
             for micro in split_batch(batch, grad_accum_steps):
+                # A micro-batch of only padding rows has no supervised tokens;
+                # a plain HF model returns NaN for it where the trainer's loss
+                # returns 0, so skip it rather than poison the sum.
+                if not (micro["labels"][:, 1:] != -100).any():
+                    continue
                 total += model(**micro).loss * loss_denom(micro)
     if dist.is_initialized():
         dist.all_reduce(total)

--- a/bergson/validate.py
+++ b/bergson/validate.py
@@ -164,9 +164,7 @@ def mean_query_loss(
             batch, n_tokens = mask_padded_rows(batch)
             tokens += n_tokens
             for micro in split_batch(batch, grad_accum_steps):
-                # A micro-batch of only padding rows has no supervised tokens;
-                # a plain HF model returns NaN for it where the trainer's loss
-                # returns 0, so skip it rather than poison the sum.
+                # Ignore padding-only micro-batches
                 if not (micro["labels"][:, 1:] != -100).any():
                     continue
                 total += model(**micro).loss * loss_denom(micro)

--- a/tests/test_query_loss_padding.py
+++ b/tests/test_query_loss_padding.py
@@ -1,0 +1,24 @@
+import torch
+
+from bergson.magic.data_stream import DataStream, pad_dataset_to_batch_size
+from bergson.validate import mean_query_loss
+
+from .test_ddp import _make_dataset, _make_model
+
+
+def test_mean_query_loss_skips_all_padding_micro_batches():
+    """A plain model returns NaN on a micro-batch with no supervised tokens,
+    so padding rows split into their own micro-batches must not poison the
+    mean: the padded stream gives the single document's loss."""
+    model = _make_model().eval()
+    docs = _make_dataset().select(range(1))
+    padded, n, _, weight_pad = pad_dataset_to_batch_size(docs, 4, 1, "Q", 0)
+    stream = DataStream(padded, 4, device="cpu", weight_shape=(n,))
+    stream.weights.data[-weight_pad:] = 0.0
+    with torch.no_grad():
+        padded_loss = mean_query_loss(model, stream, grad_accum_steps=4)
+        ref = mean_query_loss(
+            model, DataStream(docs, 1, device="cpu", weight_shape=(1,))
+        )
+    assert torch.isfinite(padded_loss)
+    torch.testing.assert_close(padded_loss, ref, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
`mean_query_loss` splits each batch into `grad_accum_steps` micro-batches. When the query set is padded to the batch size, whole micro-batches can consist of padding rows whose labels are all -100. A HF model returns NaN for such a micro-batch (while bergson's trainer loss returns 0), so we need to skip these micro-batches. The token count already excludes them, so the mean is unchanged.